### PR TITLE
ci: run backend & web CI on pushes to main

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,6 +1,12 @@
 name: Backend CI
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
     paths:
       - 'backend/**'

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,6 +1,12 @@
 name: Web CI
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/web/**'
+      - '.github/workflows/web-ci.yml'
   pull_request:
     paths:
       - 'apps/web/**'

--- a/backend/src/servers/shared/twilio_service.py
+++ b/backend/src/servers/shared/twilio_service.py
@@ -25,6 +25,7 @@ def _dashboard_base() -> str:
     urls = settings.frontend_urls
     return urls[0].rstrip("/") if urls else ""
 
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## What

Add a `push` trigger scoped to `main` to both `backend-ci.yml` and `web-ci.yml`, keeping the existing path filters.

## Why

Both CI workflows triggered **only on `pull_request`**. Merging a PR records a push to `main`, which does **not** re-fire `pull_request`-triggered workflows — so nothing validated `main` after a merge (the "CI stopped on main" symptom). This was a reasonable cost-saving setup while the repo was private.

Now that `vicoa-ai/vicoa` is **public**, GitHub Actions runs free (unlimited standard-runner minutes), so we can validate every merge to `main`.

## Changes

- `backend/**` → lint + pytest now also run on merges to `main`
- `apps/web/**` → Vitest now also runs on merges to `main`

Path filters are preserved, so a merge only triggers the workflow whose files actually changed. `permissions: contents: read` is left intact — post-merge CI only needs read access, same as PR CI. Release/build workflows are unchanged (already tag/dispatch-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)