### PR TITLE
web: don't steal focus when a new session opens after you navigate away

### DIFF
--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -70,6 +70,7 @@ import {
   type WorktreeMode,
 } from '@/lib/worktree-selection';
 import { loadPromptDraft, savePromptDraft, clearPromptDraft } from '@/lib/new-session-draft';
+import { currentPathname, openCreatedSession } from '@/lib/new-session-navigation';
 import { getDesktopConfig } from '@/lib/runtime-config';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
 import { DesktopCollapsedLead, DesktopWindowControlsSpacer } from '@/components/desktop/window-chrome';
@@ -1150,6 +1151,11 @@ function NewSessionContent() {
   const handleSubmit = useCallback(async () => {
     if (!api || !selectedMachineId || !directory.trim() || isSubmitting) return;
 
+    // Where the user launched from. Spawning is async (RPC + waitForEntity), and
+    // if they navigate away before it finishes we must not yank them to the new
+    // session — see openCreatedSession below.
+    const startPath = currentPathname();
+
     try {
       setIsSubmitting(true);
       setErrorMessage(null);
@@ -1291,7 +1297,10 @@ function NewSessionContent() {
       }
 
       refreshData();
-      router.push(`/dashboard/agents/${newInstanceId}`);
+      // Only open the session if the user is still on the page they launched
+      // from; if they moved on during the spawn, leave them where they are (the
+      // session is already in the sidebar via refreshData).
+      openCreatedSession(router, startPath, `/dashboard/agents/${newInstanceId}`);
     } catch (error) {
       let message = 'Failed to start session. Please verify the daemon is running.';
       if (error instanceof RpcError) {

--- a/apps/web/components/dashboard/start-remote-session-dialog.tsx
+++ b/apps/web/components/dashboard/start-remote-session-dialog.tsx
@@ -19,6 +19,7 @@ import type BackendAPI from '@/lib/backend-api';
 import type { MachineSummary, RemoteAgentType } from '@/lib/backend-api';
 import { StartEllipsisText } from '@/components/ui/start-ellipsis-text';
 import { isMachineOnline as isMachineOnlineShared } from '@/lib/session-liveness';
+import { currentPathname, openCreatedSession } from '@/lib/new-session-navigation';
 
 const LAST_REMOTE_SESSION_SELECTION_KEY = 'vicoa:last-remote-session-selection';
 const REMOTE_AGENT_OPTIONS: Array<{ value: RemoteAgentType; label: string }> = [
@@ -180,6 +181,10 @@ export function StartRemoteSessionDialog({
       return;
     }
 
+    // Where the user launched from — if they navigate away during the spawn we
+    // leave them there instead of opening the new session (see openCreatedSession).
+    const startPath = currentPathname();
+
     try {
       setIsSubmitting(true);
       setStatusMessage(null);
@@ -230,7 +235,10 @@ export function StartRemoteSessionDialog({
       onSessionRequested();
       onOpenChange(false);
       setStatusMessage(null);
-      router.push(`/dashboard/agents/${newInstanceId}`);
+      // Only open the session if the user hasn't navigated away while it spawned;
+      // otherwise leave them on their current page (it's already in the sidebar
+      // via onSessionRequested).
+      openCreatedSession(router, startPath, `/dashboard/agents/${newInstanceId}`);
     } catch (error) {
       console.error('Failed to spawn remote session', error);
       setStatusVariant('error');

--- a/apps/web/lib/new-session-navigation.test.ts
+++ b/apps/web/lib/new-session-navigation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { openCreatedSession, shouldOpenCreatedSession } from './new-session-navigation';
+
+describe('shouldOpenCreatedSession', () => {
+  it('opens when the user is still on the page they launched from', () => {
+    expect(shouldOpenCreatedSession('/dashboard/agents/new-session', '/dashboard/agents/new-session')).toBe(true);
+  });
+
+  it('stays put when the user has navigated to another page', () => {
+    expect(shouldOpenCreatedSession('/dashboard/agents/new-session', '/dashboard/agents/other-id')).toBe(false);
+    expect(shouldOpenCreatedSession('/dashboard', '/dashboard/settings')).toBe(false);
+  });
+});
+
+describe('openCreatedSession', () => {
+  it('pushes to the target when the pathname is unchanged', () => {
+    const router = { push: vi.fn() };
+    vi.stubGlobal('window', { location: { pathname: '/dashboard/agents/new-session' } });
+
+    openCreatedSession(router, '/dashboard/agents/new-session', '/dashboard/agents/new-id');
+
+    expect(router.push).toHaveBeenCalledWith('/dashboard/agents/new-id');
+    vi.unstubAllGlobals();
+  });
+
+  it('does not push when the user navigated away during the spawn', () => {
+    const router = { push: vi.fn() };
+    vi.stubGlobal('window', { location: { pathname: '/dashboard/agents/some-other-session' } });
+
+    openCreatedSession(router, '/dashboard/agents/new-session', '/dashboard/agents/new-id');
+
+    expect(router.push).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/lib/new-session-navigation.ts
+++ b/apps/web/lib/new-session-navigation.ts
@@ -1,0 +1,45 @@
+import type { useRouter } from 'next/navigation';
+
+type AppRouter = ReturnType<typeof useRouter>;
+
+/**
+ * Whether opening a just-created session should take over the user's view.
+ *
+ * Creating a session is async — the `spawn-session` RPC plus the `waitForEntity`
+ * that follows can take several seconds. If the user navigates elsewhere while it
+ * runs (clicks another session in the sidebar, opens settings, …), yanking them
+ * to the freshly-created session on completion is jarring: they deliberately
+ * moved on. So we only open it when the user is still on the page they launched
+ * from.
+ *
+ * Pathname-only comparison: a query-string change on the same page (e.g. the
+ * new-session form swapping its `?directory=`/`?worktreeBranch=` params) is not
+ * "navigating away", so it must not suppress the open.
+ */
+export function shouldOpenCreatedSession(startPath: string, currentPath: string): boolean {
+  return startPath === currentPath;
+}
+
+/**
+ * Push to `target` only if the user hasn't navigated away from `startPath` since
+ * the create began. Reads the live `window.location`, so it stays correct across
+ * the `await`s that precede it (a value captured before them would be stale).
+ * See {@link shouldOpenCreatedSession}.
+ *
+ * `startPath` should be captured with `currentPathname()` at the very top of the
+ * submit handler, before the first `await`.
+ */
+export function openCreatedSession(
+  router: Pick<AppRouter, 'push'>,
+  startPath: string,
+  target: string,
+): void {
+  if (shouldOpenCreatedSession(startPath, currentPathname())) {
+    router.push(target);
+  }
+}
+
+/** The live pathname (no query/hash), or `''` when running on the server. */
+export function currentPathname(): string {
+  return typeof window === 'undefined' ? '' : window.location.pathname;
+}


### PR DESCRIPTION
## Problem

Starting a session is asynchronous — the `spawn-session` RPC plus the `waitForEntity` that follows can take several seconds. Both session-create paths then did an **unconditional** `router.push(/dashboard/agents/<newId>)`. So if you kicked off a new session and switched to another page while it spun up, the app yanked you back to the freshly-created session the moment it was ready.

## Fix

A new session should only take over your view if you're **still on the page you launched it from**. If you've moved on, the session is still created and shows up in the sidebar (via the existing data refresh) — you just aren't pulled away from wherever you are now.

- **`apps/web/lib/new-session-navigation.ts`** (new) — a small, documented helper:
  - `currentPathname()` — the live `window.location.pathname` (SSR-safe).
  - `shouldOpenCreatedSession(startPath, currentPath)` — pure predicate; pathname-only, so a query-string change on the same page doesn't count as "navigating away".
  - `openCreatedSession(router, startPath, target)` — reads the *live* location and pushes only if you haven't moved. Reading live (not a value captured before the `await`s) is what makes it correct.
- Both create handlers now capture `startPath = currentPathname()` synchronously at the top of submit (before any `await`) and replace the bare `router.push(...)` with `openCreatedSession(...)`:
  - `app/dashboard/agents/new-session/page.tsx` — the full New Session page (the main flow).
  - `components/dashboard/start-remote-session-dialog.tsx` — the Start Remote Session dialog (also guarded, so it's correct if the dialog is dismissed mid-spawn).

`refreshData()` / `onSessionRequested()` still run unconditionally, so the new session lands in the sidebar either way.

## Testing

- Added `lib/new-session-navigation.test.ts` (4 tests) — all pass (`pnpm test lib/new-session-navigation.test.ts`).
- `tsc --noEmit` is clean for all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)