### PR TITLE
web: live-update onboarding checklist without a page refresh

### DIFF
--- a/apps/web/app/dashboard/automation/components/detail-panel.tsx
+++ b/apps/web/app/dashboard/automation/components/detail-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 import { cn, toAbsolutePath } from '@/lib/utils';
 import { isMachineOnline } from '@/lib/session-liveness';
+import { notifyOnboardingProgress } from '@/lib/onboarding-progress';
 import { Button } from '@/components/ui/button';
 import { MentionPromptField } from '@/components/mention-prompt-field';
 import type { AgentType } from '@/lib/constants/slash-commands';
@@ -178,6 +179,7 @@ export function DetailPanel({
         : await api.createAutomation({ ...base, enabled: true });
       setDirty(false);
       onSaved(saved);
+      if (!automation) notifyOnboardingProgress();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save automation');
     } finally {

--- a/apps/web/app/dashboard/tasks/page.tsx
+++ b/apps/web/app/dashboard/tasks/page.tsx
@@ -33,6 +33,7 @@ import {
   UpdateTaskRequest,
 } from '@/lib/backend-api';
 import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
+import { notifyOnboardingProgress } from '@/lib/onboarding-progress';
 import {
   ProjectIcon,
   inlineLabelColor,
@@ -366,6 +367,7 @@ function TasksPageInner() {
         const maxPosition = tasks.reduce((max, t) => Math.max(max, t.position), 0);
         const created = await api.createTask({ ...payload, position: maxPosition + 1 });
         setTasks((prev) => [...prev, created]);
+        notifyOnboardingProgress();
         return created;
       } catch (err) {
         console.error('Failed to save task:', err);
@@ -417,6 +419,7 @@ function TasksPageInner() {
         position: maxPosition + 1,
       });
       setTasks((prev) => [...prev, created]);
+      notifyOnboardingProgress();
     },
     [api, tasks],
   );

--- a/apps/web/components/dashboard/setup-checklist.tsx
+++ b/apps/web/components/dashboard/setup-checklist.tsx
@@ -49,6 +49,7 @@ import {
 import { cn } from '@/lib/utils';
 import { readBrowserIdentity } from '@/lib/auth/browser-token';
 import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
+import { subscribeOnboardingProgress } from '@/lib/onboarding-progress';
 
 const DISMISSED_KEY = 'vicoa_setup_checklist_dismissed';
 const COLLAPSED_KEY = 'vicoa_setup_checklist_collapsed';
@@ -142,9 +143,18 @@ export function SetupChecklist() {
   checksRef.current = checks;
 
   // Re-run the checks when the session set changes (a new session may have
-  // added the first message, etc.).
+  // added the first message, etc.). We key on `latest_message_at` as well as
+  // `chat_length` because sending a message advances the former live — the
+  // context's WS `onNewMessage` handler patches `latest_message_at`, but
+  // nothing updates `chat_length` on a sent message (the `instance-update`
+  // frame omits it). Without it, `instanceSig` never changes on a sent
+  // message, so `getActivity()` is never re-checked and the "Send your first
+  // message" step stays stale until a full page reload.
   const instanceSig = useMemo(
-    () => recentInstances.map((i) => `${i.id}:${i.chat_length}`).join(','),
+    () =>
+      recentInstances
+        .map((i) => `${i.id}:${i.chat_length}:${i.latest_message_at ?? ''}`)
+        .join(','),
     [recentInstances],
   );
 
@@ -192,6 +202,20 @@ export function SetupChecklist() {
     if (STEP_IDS.every((id) => c[id])) return;
     void refresh();
   }, [refresh, instanceSig, dismissed, hydrated, userId]);
+
+  // Creating a task or automation touches neither the instance list nor the WS
+  // stream, so `instanceSig` never changes and the effect above wouldn't
+  // re-check those steps. The create flows emit an onboarding-progress nudge —
+  // re-run the checks on it (still gated by the monotonic per-step cache in
+  // `refresh`, so satisfied steps are never re-fetched and an all-done card
+  // makes no calls).
+  useEffect(() => {
+    if (!hydrated || !userId || dismissed) return;
+    return subscribeOnboardingProgress(() => {
+      if (STEP_IDS.every((id) => checksRef.current[id])) return;
+      void refresh();
+    });
+  }, [refresh, dismissed, hydrated, userId]);
 
   // Persist completion (per user) so future loads skip the satisfied steps.
   useEffect(() => {

--- a/apps/web/lib/onboarding-progress.ts
+++ b/apps/web/lib/onboarding-progress.ts
@@ -1,0 +1,31 @@
+'use client';
+
+/**
+ * Same-document nudge that a piece of onboarding progress just happened in THIS
+ * client — e.g. the user created their first task or automation.
+ *
+ * The setup checklist ("Onboarding" card) derives each row from a live backend
+ * read, but those reads only re-run when the agent-instance list changes.
+ * Creating a task or automation touches neither the instance list nor the
+ * WebSocket instance stream, so without a nudge the card sits stale until a
+ * page reload. Emit `notifyOnboardingProgress()` right after such a create call
+ * resolves; the card listens via `subscribeOnboardingProgress` and re-checks
+ * its still-incomplete steps.
+ *
+ * (The "Send your first message" step needs no emit here — it's already covered
+ * by the WS new-message stream advancing each session's `latest_message_at`.)
+ */
+
+const ONBOARDING_PROGRESS_EVENT = 'vicoa:onboarding-progress';
+
+export function notifyOnboardingProgress(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(ONBOARDING_PROGRESS_EVENT));
+}
+
+/** Subscribe to onboarding-progress nudges; returns an unsubscribe fn. */
+export function subscribeOnboardingProgress(callback: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(ONBOARDING_PROGRESS_EVENT, callback);
+  return () => window.removeEventListener(ONBOARDING_PROGRESS_EVENT, callback);
+}


### PR DESCRIPTION
## Problem

The sidebar **Onboarding** checklist (`SetupChecklist`) only advanced its steps after a full page reload — sending the first message, or creating a task/automation, never flipped the corresponding step live.

Root cause: the checklist re-runs its backend checks only when `instanceSig` (the agent-instance list signature) changes, and that was keyed on `chat_length`, which is **never updated live over WebSocket**. And creating a task/automation touches neither the instance list nor the WS stream, so nothing re-triggered a check at all for those steps.

## Fix

- **Message step:** key `instanceSig` on `latest_message_at` as well — that field *is* advanced live by the context's WS `onNewMessage` handler, so a sent/received message now re-checks `getActivity()` within ~2s (no refresh). Confirmed the sender receives `new-message` frames for both its own message and the agent reply.
- **Task / automation steps:** add a small same-document event bus (`lib/onboarding-progress.ts`, mirroring the existing `mobile-sidebar-pref` / `desktop-notifications` pattern). The create flows emit `notifyOnboardingProgress()` after a successful create; the checklist re-checks on it. Fired after the `await`, so the follow-up `listTasks()`/`listAutomations()` always sees the new row (no race).

The checklist's monotonic per-step cache still holds: satisfied steps are never re-fetched, and an all-done / dismissed card makes zero backend calls, so post-onboarding the emit is an effective no-op.

## Notes

- Covers same-tab actions; cross-device/cross-tab still relies on the existing focus/reload refresh (acceptable for onboarding).
- No schema, dependency, or API changes. `tsc --noEmit` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)