### PR TITLE
feat(notifications): show sessions-awaiting-input count as app-icon badge

### DIFF
--- a/apps/mobile/lib/backend/push_notifications/push_notifications_handler.dart
+++ b/apps/mobile/lib/backend/push_notifications/push_notifications_handler.dart
@@ -308,6 +308,10 @@ class PushNotificationsHandler with WidgetsBindingObserver {
       // The user may have just toggled notifications on in system Settings, or
       // a previous registration attempt may have failed silently. Re-sync.
       syncPushRegistration();
+      // Reconcile the launcher badge with server truth: a push may have set it
+      // while backgrounded, but the user could have answered on another device
+      // since — recompute so a stale (or now-zero) count is corrected on open.
+      actions.refreshAppBadge();
     }
   }
 
@@ -335,10 +339,26 @@ class PushNotificationsHandler with WidgetsBindingObserver {
       print('Message notification: ${message.notification?.title}');
     }
 
+    // iOS doesn't apply aps.badge while the app is foregrounded (we intercept
+    // the notification here), so mirror the count the backend stamped onto the
+    // payload ourselves. Background/terminated badges are handled by the OS.
+    _applyBadgeFromMessage(message);
+
     // Show local notification when app is in foreground
     if (message.notification != null) {
       await _showLocalNotification(message);
     }
+  }
+
+  /// Set the launcher badge to the awaiting-input count carried in the push
+  /// data payload (added by the backend FCM service). Silently ignores a
+  /// missing/unparseable value so a malformed push never disturbs the badge.
+  void _applyBadgeFromMessage(RemoteMessage message) {
+    final raw = message.data['badge'];
+    if (raw == null) return;
+    final count = int.tryParse(raw.toString());
+    if (count == null) return;
+    actions.setAppBadge(count);
   }
 
   Future<void> _showLocalNotification(RemoteMessage message) async {

--- a/apps/mobile/lib/custom_code/actions/app_badge.dart
+++ b/apps/mobile/lib/custom_code/actions/app_badge.dart
@@ -1,0 +1,61 @@
+// Automatic FlutterFlow imports
+// Begin custom action code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+import 'package:flutter/foundation.dart';
+import 'package:app_badge_plus/app_badge_plus.dart';
+import '/custom_code/actions/vicoa_api_request.dart';
+
+/// App-icon (launcher) badge helpers.
+///
+/// The badge shows how many of the user's sessions are currently awaiting
+/// their input. In the background the OS renders it straight from the push
+/// payload (iOS `aps.badge`, Android `notification_count`); these helpers cover
+/// the cases the OS can't: mirroring the count while the app is foregrounded,
+/// and reconciling with server truth on resume (e.g. after the user answered on
+/// the web/desktop, so a badge a push had set must be cleared/decremented).
+///
+/// Every function swallows its own errors — a badge is cosmetic and must never
+/// break notification handling or app lifecycle.
+
+/// Set the launcher badge to [count] (clamped at 0; 0 clears it).
+Future<void> setAppBadge(int count) async {
+  final int value = count < 0 ? 0 : count;
+  try {
+    if (!await AppBadgePlus.isSupported()) return;
+    await AppBadgePlus.updateBadge(value);
+  } catch (e) {
+    if (kDebugMode) {
+      print('setAppBadge($value) failed: $e');
+    }
+  }
+}
+
+/// Clear the launcher badge.
+Future<void> clearAppBadge() => setAppBadge(0);
+
+/// Fetch the authoritative badge count (sessions awaiting input) from the
+/// backend. Returns null if the request fails so callers can leave the badge
+/// untouched rather than wrongly zeroing it on a transient error.
+Future<int?> apiGetBadgeCount() async {
+  try {
+    final result = await vicoaApiRequest('get', '/api/v1/push/badge-count', null);
+    final count = (result is Map) ? result['count'] : null;
+    if (count is int) return count;
+    if (count is num) return count.toInt();
+    return null;
+  } catch (e) {
+    if (kDebugMode) {
+      print('apiGetBadgeCount failed: $e');
+    }
+    return null;
+  }
+}
+
+/// Reconcile the launcher badge with the server's live awaiting-input count.
+/// No-op when the backend can't be reached (leaves the last-known badge).
+Future<void> refreshAppBadge() async {
+  final count = await apiGetBadgeCount();
+  if (count == null) return;
+  await setAppBadge(count);
+}

--- a/apps/mobile/lib/custom_code/actions/index.dart
+++ b/apps/mobile/lib/custom_code/actions/index.dart
@@ -81,6 +81,7 @@ export 'coding_minutes_per_year.dart' show codingMinutesPerYear;
 export 'revenue_cat_service.dart' show showRevenueCatPaywall, showRevenueCatPaywallFullScreen, checkRevenueCatSubscriptionStatus, syncRevenueCatSubscriptionStatus, getRevenueCatUserId, restoreRevenueCatPurchases;
 export 'supabase_get_referral_count.dart' show supabaseGetReferralCount;
 export 'api_register_fcm_token.dart' show apiRegisterFcmToken;
+export 'app_badge.dart' show setAppBadge, clearAppBadge, apiGetBadgeCount, refreshAppBadge;
 export 'api_unregister_fcm_token.dart' show apiUnregisterFcmToken;
 export 'api_update_instance_status.dart' show apiUpdateInstanceStatus;
 export 'test_push_notifications.dart' show testPushNotifications;

--- a/apps/mobile/lib/custom_code/actions/sign_out_and_clear_local_data.dart
+++ b/apps/mobile/lib/custom_code/actions/sign_out_and_clear_local_data.dart
@@ -28,4 +28,7 @@ Future<void> signOutAndClearLocalData() async {
   await FilesCache.wipeStatic();
   await ChatMessagesCache.instance.wipeAll();
   FFAppState().clearAllUserData();
+  // Drop the launcher badge — it counts the signed-out user's awaiting
+  // sessions and would otherwise linger on the icon after logout.
+  await clearAppBadge();
 }

--- a/apps/mobile/lib/pages/home/home_widget.dart
+++ b/apps/mobile/lib/pages/home/home_widget.dart
@@ -115,6 +115,12 @@ class _HomeWidgetState extends State<HomeWidget>
 
             // FCM token is automatically set up when permissions are granted
             await notificationHandler.getFCMToken();
+
+            // Reconcile the launcher badge on cold start — the resume observer
+            // only fires on later foregrounds, so without this a stale badge
+            // from a push (or one the user already cleared elsewhere) would
+            // linger through the first session.
+            await actions.refreshAppBadge();
           }(),
         );
 

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.0.1"
+  app_badge_plus:
+    dependency: "direct main"
+    description:
+      name: app_badge_plus
+      sha256: a22719127af1b80c6d5803fb80c02b600ceb14f726210c12b6198fe11b8bc025
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.4"
   app_links:
     dependency: "direct main"
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
     sdk: flutter
   aligned_dialog: 0.0.6
   aligned_tooltip: ^0.0.1
+  app_badge_plus: ^1.3.4
   app_links: 6.3.2
   app_links_platform_interface: 2.0.2
   app_settings: ^5.1.1

--- a/backend/src/backend/api/push_notifications.py
+++ b/backend/src/backend/api/push_notifications.py
@@ -2,6 +2,7 @@
 
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from pydantic import BaseModel
@@ -12,7 +13,7 @@ import logging
 from backend.auth.dependencies import get_current_user
 from shared.database.models import User
 from shared.database.session import get_db
-from shared.database import PushToken
+from shared.database import AgentInstance, AgentStatus, PushToken
 
 router = APIRouter(prefix="/push", tags=["push_notifications"])
 
@@ -27,6 +28,10 @@ class PushTokenResponse(BaseModel):
     token: str
     platform: str
     is_active: bool
+
+
+class BadgeCountResponse(BaseModel):
+    count: int
 
 
 @router.post("/register", response_model=dict)
@@ -108,6 +113,29 @@ def deactivate_token(
     except Exception as e:
         db.rollback()
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.get("/badge-count", response_model=BadgeCountResponse)
+def get_badge_count(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Current app-icon badge value: the user's sessions awaiting their input.
+
+    The mobile app calls this on resume to reconcile the launcher badge with
+    server truth — e.g. after the user answered on the web/desktop, so the
+    badge that a push had set is cleared/decremented the next time they open
+    the app. Mirrors the count the FCM service stamps onto every push.
+    """
+    count = (
+        db.query(func.count(AgentInstance.id))
+        .filter(
+            AgentInstance.user_id == current_user.id,
+            AgentInstance.status == AgentStatus.AWAITING_INPUT,
+        )
+        .scalar()
+    ) or 0
+    return BadgeCountResponse(count=count)
 
 
 @router.get("/tokens", response_model=List[PushTokenResponse])

--- a/backend/src/backend/tests/test_push_badge.py
+++ b/backend/src/backend/tests/test_push_badge.py
@@ -1,0 +1,84 @@
+"""Tests for the app-icon badge count endpoint (GET /api/v1/push/badge-count).
+
+The badge shows how many of the user's sessions are awaiting their input, i.e.
+agent instances with status AWAITING_INPUT, scoped to the requesting user.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from shared.database.models import AgentInstance, User, UserAgent
+from shared.database.enums import AgentStatus
+
+
+def _make_instance(test_db, user_agent, user, status):
+    instance = AgentInstance(
+        id=uuid4(),
+        user_agent_id=user_agent.id,
+        user_id=user.id,
+        status=status,
+        started_at=datetime.now(timezone.utc),
+    )
+    test_db.add(instance)
+    test_db.commit()
+    return instance
+
+
+class TestBadgeCount:
+    def test_zero_when_nothing_awaiting(
+        self, authenticated_client, test_db, test_user, test_user_agent
+    ):
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.ACTIVE)
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.COMPLETED)
+
+        response = authenticated_client.get("/api/v1/push/badge-count")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 0}
+
+    def test_counts_only_awaiting_input(
+        self, authenticated_client, test_db, test_user, test_user_agent
+    ):
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.AWAITING_INPUT)
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.AWAITING_INPUT)
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.ACTIVE)
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.COMPLETED)
+
+        response = authenticated_client.get("/api/v1/push/badge-count")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 2}
+
+    def test_is_user_scoped(
+        self, authenticated_client, test_db, test_user, test_user_agent
+    ):
+        # This user has one session awaiting input.
+        _make_instance(test_db, test_user_agent, test_user, AgentStatus.AWAITING_INPUT)
+
+        # Another user's awaiting-input session must not leak into the count.
+        other_user = User(
+            id=uuid4(),
+            email="other@example.com",
+            display_name="Other User",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        test_db.add(other_user)
+        test_db.commit()
+        other_agent = UserAgent(
+            id=uuid4(),
+            user_id=other_user.id,
+            name="claude code",
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        test_db.add(other_agent)
+        test_db.commit()
+        _make_instance(test_db, other_agent, other_user, AgentStatus.AWAITING_INPUT)
+        _make_instance(test_db, other_agent, other_user, AgentStatus.AWAITING_INPUT)
+
+        response = authenticated_client.get("/api/v1/push/badge-count")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 1}

--- a/backend/src/servers/shared/fcm_service.py
+++ b/backend/src/servers/shared/fcm_service.py
@@ -6,6 +6,7 @@ import random
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 from uuid import UUID
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 import json
 
@@ -13,7 +14,7 @@ from firebase_admin import credentials, messaging, initialize_app
 from firebase_admin.exceptions import FirebaseError
 import firebase_admin
 
-from shared.database import PushToken, User
+from shared.database import AgentInstance, AgentStatus, PushToken, User
 from shared.config import settings
 from .notification_base import NotificationServiceBase
 
@@ -84,6 +85,24 @@ class FCMNotificationService(NotificationServiceBase):
         pattern = r"^[A-Za-z0-9_:-]+$"
         return bool(re.match(pattern, token))
 
+    def _awaiting_input_count(self, db: Session, user_id: UUID) -> int:
+        """Number of the user's sessions currently waiting on their input.
+
+        This is the value surfaced as the app-icon badge: agent instances the
+        user owns whose status is AWAITING_INPUT (the agent asked a question
+        that hasn't been answered yet). Recomputed on every push so the badge
+        self-corrects — including clearing to 0 — no matter which device the
+        user answered on. Backed by the (user_id, status) composite index.
+        """
+        return (
+            db.query(func.count(AgentInstance.id))
+            .filter(
+                AgentInstance.user_id == user_id,
+                AgentInstance.status == AgentStatus.AWAITING_INPUT,
+            )
+            .scalar()
+        ) or 0
+
     async def send_notification(
         self,
         db: Session,
@@ -137,6 +156,12 @@ class FCMNotificationService(NotificationServiceBase):
                 logger.warning("No valid FCM tokens to send to")
                 return False
 
+            # App-icon badge = the user's sessions currently awaiting input.
+            # Sent on every push so the OS renders/updates it in the background
+            # (iOS applies aps.badge automatically) and the Flutter foreground
+            # handler can mirror it from the data payload.
+            badge_count = self._awaiting_input_count(db, user_id)
+
             # Prepare FCM message
             notification = messaging.Notification(title=title, body=body)
 
@@ -151,6 +176,7 @@ class FCMNotificationService(NotificationServiceBase):
                 {
                     "click_action": "FLUTTER_NOTIFICATION_CLICK",
                     "sound": "default",
+                    "badge": str(badge_count),
                 }
             )
 
@@ -161,6 +187,7 @@ class FCMNotificationService(NotificationServiceBase):
                     priority="high",
                     default_sound=True,
                     default_vibrate_timings=True,
+                    notification_count=badge_count,
                 ),
                 priority="high",
             )
@@ -171,6 +198,7 @@ class FCMNotificationService(NotificationServiceBase):
                     aps=messaging.Aps(
                         alert=messaging.ApsAlert(title=title, body=body),
                         sound="default",
+                        badge=badge_count,
                         content_available=True,
                     )
                 )


### PR DESCRIPTION
## Summary

The mobile app never showed a numeric badge on the launcher icon — the feature was never implemented on either side:

- **Backend** never put a count in the push payload (`aps` had only `alert`/`sound`/`content_available`; Android had no `notification_count`).
- **Mobile** had no badge package installed and set `presentBadge: true` with no `badgeNumber`.

This implements it end-to-end as a **server-computed count of the user's sessions awaiting their input** (`AgentInstance.status == AWAITING_INPUT`), per product decision.

## Backend
- `servers/shared/fcm_service.py` — `_awaiting_input_count()` (uses the existing `(user_id, status)` index) stamped onto **every** push three ways: `aps.badge` (iOS), `AndroidNotification.notification_count` (Android), and `data["badge"]` (so the Flutter foreground handler can mirror it).
- `backend/api/push_notifications.py` — new `GET /push/badge-count` → `{"count": N}` for reconciliation. Read-only (no `db.commit`), so no WebSocket-freeze baseline bump.
- `backend/tests/test_push_badge.py` — counts only `AWAITING_INPUT`, zero case, and user-scoping. ✅ 3 passing.

## Mobile
- Added `app_badge_plus: ^1.3.4` (`flutter_app_badger` is discontinued).
- New `custom_code/actions/app_badge.dart` — `setAppBadge` / `clearAppBadge` / `apiGetBadgeCount` / `refreshAppBadge` (all error-swallowing; a cosmetic badge never breaks notification handling).
- `push_notifications_handler.dart` — mirrors the payload count in foreground; **every resume** re-fetches the live count and corrects the badge.
- `home_widget.dart` — reconciles on **cold start** (the resume observer doesn't fire on first launch).
- `sign_out_and_clear_local_data.dart` — clears the badge on logout.

## Behavior
- **Background/terminated:** OS renders the count straight from the payload — no app code runs.
- **Foreground:** app sets it from the payload.
- **Self-correcting:** answering on web/desktop clears/decrements the badge the next time the phone app opens or resumes.

## Testing
- Backend: `ruff` ✅, `pyright` on changed files ✅ (0 errors), 3 new tests ✅, WebSocket-freeze check ✅.
- Mobile: `flutter pub get` resolved, `flutter analyze` clean on all new/changed files.
- ⚠️ Not yet validated on a physical device — a native plugin was added, so it needs `pod install` / a rebuild. On-device confirmation is worth doing before release.

## Notes / caveats
- **Android numeric badges are launcher-dependent** — Samsung/others show the number; many stock launchers show only a dot. iOS shows the exact count.
- Counts the user's **own** sessions (matches the existing `waiting_instance_count` pattern); sessions *shared with* the user are not included. Easy to fold in as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)