### PR TITLE
fix(mobile): tick onboarding "send a message" step instantly

### DIFF
--- a/apps/mobile/lib/pages/new_session/new_session_widget.dart
+++ b/apps/mobile/lib/pages/new_session/new_session_widget.dart
@@ -844,6 +844,16 @@ class _NewSessionWidgetState extends State<NewSessionWidget>
         return;
       }
 
+      // The user typed a first message (bundled into the spawn command). Mark
+      // the getting-started checklist's "Send a message" step done instantly —
+      // otherwise its server-derived total_user_messages check races the
+      // daemon's cold-start prompt POST, reads 0, latches, and the checkmark
+      // lags ~10–20s (until the card is next recreated). Mirrors the in-chat
+      // send path (agent_chat_model).
+      if (hasInitialPrompt) {
+        FFAppState().gettingStartedActivated = true;
+      }
+
       await posthogCapture('session_created', properties: {
         'agent_type': _model.selectedAgentType ?? 'claude',
         'source': 'mobile',


### PR DESCRIPTION
## Problem

In the mobile "Get started" checklist, the 3rd step (**Send a message**) got its checkmark ticked off well after the user actually sent their first message — often ~10–20s later, or not until the card was next recreated.

## Root cause

Step 3 is derived from the server's `total_user_messages > 0` (`getting_started_checklist.dart`), seeded optimistically by the local `gettingStartedActivated` flag. That flag was only set by the in-chat send path (`agent_chat_model.dart`), but the **onboarding first message rides inside the `spawn-session` RPC metadata** — it never calls `apiChatWithAgent`, so the flag was never set.

Falling back to the pure server fetch races badly:
1. Session created → `sessionCount` 0→1 triggers `_refreshStatus()` → `apiGetActivity()`.
2. At that instant the daemon is still cold-starting the agent and hasn't POSTed the prompt yet, so `total_user_messages` is still `0`.
3. `_refreshStatus` latches `_checkedStatus = true` and won't re-fetch, so the checkmark only appears once the card is recreated (app reopen / returning to home).

## Fix

Set `FFAppState().gettingStartedActivated = true` on a successful new-session spawn when the user typed a first prompt, mirroring the existing in-chat send path. Step 3 then shows done instantly and `_refreshStatus` skips the racing activity fetch entirely. The server count stays the cross-device source of truth; the flag resets on logout.

Gated on `hasInitialPrompt` only — the onboarding first message is always typed text. An attachment-only, empty-prompt first message (rare for a brand-new user) isn't covered and simply falls back to the server fetch as before.

## Testing

- `flutter analyze` on the changed file: no new issues (pre-existing `info`-level lints only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)