### PR TITLE
feat(cli): `vicoa session start` — spawn sessions from the terminal

### DIFF
--- a/apps/web/content/docs/cli-commands.mdx
+++ b/apps/web/content/docs/cli-commands.mdx
@@ -100,6 +100,8 @@ Start a background agent with no local terminal UI, driven entirely from the web
 vicoa headless --agent codex --prompt "Run the test suite and summarize failures"
 ```
 
+> **`vicoa headless` vs `vicoa session start`:** `headless` starts a background agent **on this machine**, right here. [`vicoa session start`](#vicoa-session-start) asks the backend to spawn one on **any** of your registered machines (including this one) — the terminal equivalent of the dashboard's "New Session". Reach for `session start` to launch a session on a different box, or when you want the same machine/agent/model picker the apps use.
+
 ## vicoa ls
 
 List the active agent instances on the current machine, grouped by kind. This reads local OS processes — it only sees agents running on *this* box.
@@ -141,7 +143,74 @@ Works on macOS, Linux, and Windows.
 
 ## vicoa session
 
-The `session` commands read from the backend, so they cover every session you own regardless of which machine started it. They are read-only and safe to run anytime.
+The `session` commands talk to the backend, so they cover every session you own regardless of which machine started it. The read verbs (`ls`, `get`) are safe to run anytime; `start`, `update`, `message`, and `continue` change state or start real work.
+
+### vicoa session start
+
+Start a **new** session on one of your machines — the terminal equivalent of the desktop/web **"New Session"** composer. It picks a machine, directory, agent, and model/config, then hands the target machine's daemon a spawn request over REST (the same spawn path the apps drive). The session runs **headless** on that machine and streams to the mobile app and web dashboard, just like a remote session started from the UI.
+
+```bash
+# Start Claude Code on this host's daemon, in a directory
+vicoa session start --dir ~/projects/my-app
+
+# Pick a machine by name/hostname substring; name it and kick off with a prompt
+vicoa session start --machine laptop --dir ~/projects/api \
+  --name "Fix CI" --prompt "Run the test suite and fix the failures"
+
+# Codex with a model + reasoning effort, and block until it's actually running
+vicoa session start --dir ~/projects/api \
+  --agent codex --model gpt-5.5 --effort medium --wait
+```
+
+> **`vicoa session start` needs the target machine's daemon running.** The request is only picked up once that machine's `vicoa daemon` is connected. If the daemon looks offline, `start` refuses by default — pass `--allow-offline` to queue the request until the machine next reconnects.
+
+**Where it runs**
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--machine <ID\|NAME>` | this host's daemon | Target machine: full id, id prefix, or a display-name/hostname substring (`--list-machines` to see them) |
+| `--dir <PATH>` | — (**required**) | Directory on the target machine to start the session in |
+| `--allow-offline` | off | Queue the request even if the daemon looks offline (it runs when the daemon next reconnects) |
+
+**What to run**
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--agent <name>` | `claude` | Agent to run: `claude`, `codex`, `opencode`, `cursor`, `gemini`, `copilot`, `kimi`, or `hermes` (not `amp`) |
+| `--model <slug>` | agent default | Model slug (`--list-models` to see options per agent) |
+| `--effort <level>` | agent default | Reasoning/thinking effort — **claude & codex only** |
+| `--permission-mode <mode>` | agent default | Permission mode (claude/codex/ACP agents) |
+| `--opencode-mode <build\|plan>` | — | OpenCode agent mode (opencode only) |
+| `--name <text>` | — | Name for the new session |
+| `--prompt <text>` | — | Optional first user message; omit to start the session blank |
+| `--task <TASK_UUID>` | — | Link the new session to a task (full UUID, from `vicoa task ls`) |
+
+**Kick-off & discovery**
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--wait` | off | Poll until the session leaves `STARTING` (needs the daemon online) |
+| `--wait-timeout <SECS>` | 60 | How long to wait with `--wait` |
+| `--list-machines` | off | List your registered machines (id, name, hostname, online status) and exit |
+| `--list-models` | off | List agents/models/efforts/modes (optionally filtered by `--agent`) and exit |
+| `--json` | | Emit the spawn result as JSON, including `agent_instance_id` and `machine_id` |
+
+Discover what's available before you start:
+
+```bash
+vicoa session start --list-machines               # which machines can run a session
+vicoa session start --list-models                 # every agent's models/efforts/modes
+vicoa session start --list-models --agent codex    # just Codex's options
+```
+
+`session start` returns immediately with the new session id (the daemon launches it out of band), then points you at follow-ups:
+
+```
+Started claude session on Laptop in ~/projects/api — session inst-123.
+Track it with `vicoa session get inst-123` or send input with `vicoa session message inst-123 '...'`.
+```
+
+Add `--wait` when you want the command to block until the session is actually `ACTIVE` (or surfaces the error the daemon reported) instead of returning as soon as the request is accepted.
 
 ### vicoa session ls
 
@@ -150,12 +219,14 @@ List your sessions, newest first.
 ```bash
 vicoa session ls                      # newest 50
 vicoa session ls --active --limit 20  # only still-running, cap at 20
+vicoa session ls --rate-limited       # only sessions currently blocked by a rate limit
 vicoa session ls --json
 ```
 
 | Flag | Default | Meaning |
 |---|---|---|
 | `--active` | off | Only sessions still running |
+| `--rate-limited` | off | Only sessions a rate-limit window is currently blocking (adds a `RESET` column showing when each unblocks) |
 | `--limit N` | 50 | Max sessions to return (1–100) |
 | `--json` | | Raw JSON `{items, total, ...}` |
 
@@ -206,6 +277,24 @@ vicoa session update 3f9c1a2b --unlink-task
 | `--unlink-task` | Clear the task link (mutually exclusive with `--task`) |
 
 Linking drives the task's status from the session's status: a running linked session flips its task to `in_progress`.
+
+### vicoa session message
+
+Send a message into a running session — it's delivered to the agent as user input and flips the session `ACTIVE`, the same as typing in the app. Pairs naturally with `session start`: start a session blank, then drive it with `message`. The id accepts a full UUID or an 8-character prefix.
+
+```bash
+vicoa session message 3f9c1a2b "run the tests and fix any failures"
+```
+
+If the target machine is offline the message can't be delivered — retry once its daemon is back.
+
+### vicoa session continue
+
+Shorthand that sends the literal text `continue` into a session — handy after a rate-limit window resets (see `vicoa session ls --rate-limited`).
+
+```bash
+vicoa session continue 3f9c1a2b
+```
 
 ## vicoa stop
 
@@ -430,7 +519,9 @@ vicoa session ls --active --json | jq '.items[].id'
 | `Authentication failed … run vicoa --reauth` (HTTP 401) | Your key is invalid or expired — run `vicoa --reauth`. |
 | `No Vicoa API key found` | Sign in with `vicoa --auth`, set `VICOA_API_KEY`, or pass `--api-key`. |
 | `No machine to run on` (automation create) | Run `vicoa daemon` on the target machine first, or pass `--machine-id`. |
-| `'<ref>' is ambiguous` / `No session found matching` | The 8-char prefix collided or aged out — use more characters or the full UUID. |
+| `Daemon on <machine> looks offline` (session start) | Start `vicoa daemon` on that machine, or pass `--allow-offline` to queue the request until it reconnects. |
+| `--dir is required to start a session` | `vicoa session start` needs `--dir <PATH>`; run it with `--list-machines` / `--list-models` first to see your options. |
+| `'<ref>' is ambiguous` / `No session found matching` | The 8-char prefix (or `--machine` name) collided or aged out — use more characters or the full UUID/id. |
 | `404` on `task get/update/delete` | Tasks and automations need the **full UUID**; only `session` commands and `vicoa stop` accept an 8-char prefix. |
 | `Nothing to update — pass at least one field` | `update` is a PATCH; pass at least one flag, e.g. `--status done`. |
 | `Aborted (pass --yes to delete non-interactively)` | Re-run `delete` with `-y`. |

--- a/apps/web/content/docs/start-remote-session.mdx
+++ b/apps/web/content/docs/start-remote-session.mdx
@@ -60,6 +60,21 @@ Once the daemon connects, the machine shows up with its hostname in both the mob
 6. Confirm with **Start Session**
 
 
+## 4. Start a session from the terminal
+
+You don't have to open an app — `vicoa session start` spawns a remote session on any registered machine over the same path the dashboard uses. Point it at a machine, a directory, and an agent, and the target machine's daemon launches it headless:
+
+```bash
+# On this machine's daemon, running Claude Code
+vicoa session start --dir ~/projects/my-app
+
+# On another machine (matched by name), running Codex with a first prompt
+vicoa session start --machine laptop --dir ~/projects/api \
+  --agent codex --prompt "Run the test suite and fix the failures"
+```
+
+The target machine's `vicoa daemon` must be connected; if it looks offline, `start` refuses unless you pass `--allow-offline` to queue the request until it reconnects. Discover your options with `vicoa session start --list-machines` and `vicoa session start --list-models`. See the [CLI Commands reference](/docs/cli-commands#vicoa-session-start) for the full flag list.
+
 ## Troubleshooting
 
 - **Machine not appearing:** Ensure `vicoa daemon` is still running and that the machine is connected to the internet.

--- a/backend/src/servers/requirements.txt
+++ b/backend/src/servers/requirements.txt
@@ -13,5 +13,9 @@ firebase-admin>=6.2.0
 twilio>=8.0.0
 sendgrid>=6.10.0
 
+# Agent integrations (integrations/headless/claude_code.py); also declared in
+# pyproject.toml for the vicoa daemon.
+claude-agent-sdk>=0.1.80
+
 # Shared dependencies
 -r ../shared/requirements.txt

--- a/backend/src/vicoa/cli.py
+++ b/backend/src/vicoa/cli.py
@@ -1781,6 +1781,92 @@ Examples:
         help="Output raw JSON instead of a table",
     )
 
+    # Agents that can be spawned map to catalog ids (excludes 'amp', which the
+    # spawn endpoint's catalog doesn't cover). Generic ACP agents are included.
+    spawn_agent_choices = ["claude", "codex", "opencode", *GENERIC_ACP_AGENT_CHOICES]
+    session_start = session_sub.add_parser(
+        "start",
+        parents=[session_common],
+        help="Start a new session on a machine (like the desktop 'New Session')",
+    )
+    session_start.add_argument(
+        "--machine",
+        metavar="ID|NAME",
+        help="Target machine: id, or a display-name/hostname substring "
+        "(`--list-machines` to see them). Defaults to this host's daemon.",
+    )
+    session_start.add_argument(
+        "--dir",
+        metavar="PATH",
+        help="Directory on the target machine to start the session in",
+    )
+    session_start.add_argument(
+        "--allow-offline",
+        action="store_true",
+        dest="allow_offline",
+        help="Queue the request even if the target daemon looks offline "
+        "(it runs when the daemon next reconnects)",
+    )
+    session_start.add_argument(
+        "--agent",
+        choices=spawn_agent_choices,
+        default=None,
+        help="Agent to run (default: claude); also filters --list-models",
+    )
+    session_start.add_argument(
+        "--model",
+        help="Model slug (`--list-models` to see options per agent)",
+    )
+    session_start.add_argument(
+        "--effort",
+        help="Reasoning effort — claude thinking_effort / codex reasoning_effort",
+    )
+    session_start.add_argument(
+        "--permission-mode",
+        dest="permission_mode",
+        help="Permission mode (claude/codex/ACP agents)",
+    )
+    session_start.add_argument(
+        "--opencode-mode",
+        dest="opencode_mode",
+        help="OpenCode agent mode (build|plan)",
+    )
+    session_start.add_argument(
+        "--prompt",
+        help="Optional first user message; omit to start the session blank",
+    )
+    session_start.add_argument("--name", help="Name for the new session")
+    session_start.add_argument(
+        "--task",
+        metavar="TASK_ID",
+        help="Link the new session to this task (full UUID from `vicoa task ls`)",
+    )
+    session_start.add_argument(
+        "--wait",
+        action="store_true",
+        help="Poll until the session leaves STARTING (needs the daemon online)",
+    )
+    session_start.add_argument(
+        "--wait-timeout",
+        dest="wait_timeout",
+        type=float,
+        default=60.0,
+        metavar="SECS",
+        help="Seconds to wait with --wait (default 60)",
+    )
+    session_start.add_argument(
+        "--list-machines",
+        action="store_true",
+        dest="list_machines",
+        help="List your registered machines and exit",
+    )
+    session_start.add_argument(
+        "--list-models",
+        action="store_true",
+        dest="list_models",
+        help="List agents/models/efforts/modes (optionally filtered by --agent) and exit",
+    )
+
     session_ls = session_sub.add_parser(
         "ls", parents=[session_common], help="List your agent sessions"
     )

--- a/backend/src/vicoa/commands/instance.py
+++ b/backend/src/vicoa/commands/instance.py
@@ -1,14 +1,21 @@
-"""``vicoa session`` — list and inspect your agent sessions (agent instances).
+"""``vicoa session`` — start, list, and inspect your agent sessions.
 
 Unlike ``vicoa ls`` (which enumerates agent processes *running on this
 machine*), these commands read the backend, so they cover every session the
 user owns — across machines, cloud/mobile-started, and finished ones — and can
 print a session's full message transcript.
 
+``vicoa session start`` is the terminal equivalent of the desktop/web "New
+Session" composer: it picks a machine, directory, agent and model/config, then
+POSTs a spawn-request that the target machine's daemon claims and launches —
+the exact same spawn path the apps drive, just triggered over REST instead of
+the WebSocket ``spawn-session`` RPC. The machine's ``vicoa daemon`` must be
+running/connected for the request to be picked up.
+
 Talks to the agent-facing server with the same Bearer API key as every other
-``vicoa`` command, hitting the read-only ``/api/v1/agent-instances`` endpoints
-mirrored in ``servers/api/instances.py``. Human-readable output by default;
-``--json`` on every subcommand for agents (or scripts) that want to parse it.
+``vicoa`` command, hitting the ``/api/v1/agent-instances`` and
+``/api/v1/machines`` endpoints. Human-readable output by default; ``--json`` on
+every subcommand for agents (or scripts) that want to parse it.
 """
 
 from __future__ import annotations
@@ -522,7 +529,491 @@ def _cmd_continue(args, api_key: str) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# session start — spawn a new session (mirrors the desktop "New Session")
+# ---------------------------------------------------------------------------
+
+
+def _load_agent_catalog():
+    """Deferred import of the static catalog + its validation sets.
+
+    Kept out of module load (``cli.py`` imports this module eagerly) since it's
+    only needed when actually spawning. ``protocol`` is on the path in both the
+    source tree and the frozen daemon — ``machine_daemon`` imports it the same
+    way — so this resolves in a packaged CLI too.
+    """
+    from protocol.agent_catalog import (
+        AGENT_CATALOG,
+        PERMISSION_MODES,
+        REASONING_EFFORTS,
+        THINKING_EFFORTS,
+    )
+
+    return AGENT_CATALOG, PERMISSION_MODES, THINKING_EFFORTS, REASONING_EFFORTS
+
+
+def _agent_entry(catalog: dict, agent_id: str) -> Optional[dict]:
+    for agent in catalog.get("agents", []):
+        if agent.get("id") == agent_id:
+            return agent
+    return None
+
+
+def _fetch_machines(args, api_key: str) -> list[dict]:
+    data = request(args, api_key, "GET", "/api/v1/machines")
+    return data.get("machines", []) if isinstance(data, dict) else []
+
+
+def _machine_label(m: dict) -> str:
+    return m.get("display_name") or m.get("hostname") or _short(m.get("machine_id"))
+
+
+# Mirrors ``settings.liveness_online_threshold_seconds`` (90) and the web's
+# ``LIVENESS_ONLINE_THRESHOLD_MS`` in apps/web/lib/session-liveness.ts: daemons
+# beat every 30s, so ~3 missed beats means offline. Kept as a local constant
+# rather than importing ``shared.database.liveness`` — that pulls in the DB/env
+# settings module, which the lightweight REST-only CLI shouldn't need to load.
+_MACHINE_ONLINE_THRESHOLD_SECONDS = 90
+
+
+def _machine_online(m: dict) -> bool:
+    """Whether a machine's daemon heartbeat is fresh enough to accept work."""
+    from datetime import datetime, timezone
+
+    ts = m.get("last_heartbeat_at")
+    if not ts:
+        return False
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return False
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - dt).total_seconds()
+    return age < _MACHINE_ONLINE_THRESHOLD_SECONDS
+
+
+def _local_machine_id(args) -> Optional[str]:
+    """The ``machine_id`` the local daemon persisted for this base URL, if any.
+
+    The daemon writes it to ``~/.vicoa/daemon_state.json`` at registration, so
+    this is how the CLI defaults ``--machine`` to "this host" — the same id the
+    backend knows this machine by, not a recomputed fingerprint (which is only
+    the create-time seed and can differ from the registered row).
+    """
+    try:
+        from vicoa.constants import DEFAULT_API_URL
+        from vicoa.machine_state import read_daemon_entry
+
+        base_url = getattr(args, "base_url", None) or DEFAULT_API_URL
+        entry = read_daemon_entry(base_url)
+        mid = entry.get("machine_id") if isinstance(entry, dict) else None
+        return str(mid) if mid else None
+    except Exception:  # noqa: BLE001 - best-effort; missing state just means "no default"
+        return None
+
+
+def _print_machines(machines: list[dict]) -> None:
+    if not machines:
+        print(
+            "No machines registered. Start the Vicoa daemon on a machine first "
+            "(`vicoa daemon`)."
+        )
+        return
+    header = (
+        f"{'ID':<10}  {'NAME':<20} {'HOSTNAME':<20} {'PLATFORM':<10} "
+        f"{'STATUS':<8} {'LAST SEEN':<16}"
+    )
+    print(header)
+    print("-" * len(header))
+    for m in machines:
+        status = "online" if _machine_online(m) else "offline"
+        print(
+            f"{_short(m.get('machine_id'), 10):<10}  "
+            f"{_fit(m.get('display_name') or '—', 20):<20} "
+            f"{_fit(m.get('hostname') or '—', 20):<20} "
+            f"{_fit(str(m.get('platform') or '—'), 10):<10} "
+            f"{status:<8} "
+            f"{_local_time(m.get('last_heartbeat_at')):<16}"
+        )
+    print(f"\n{len(machines)} machine(s).")
+
+
+def _match_machine(machines: list[dict], ref: str) -> dict:
+    """Resolve an explicit ref by id (exact/prefix) or name/hostname substring."""
+    for m in machines:
+        if str(m.get("machine_id")) == ref:
+            return m
+
+    low = ref.lower()
+    matches = [
+        m
+        for m in machines
+        if str(m.get("machine_id", "")).startswith(ref)
+        or low in (m.get("display_name") or "").lower()
+        or low in (m.get("hostname") or "").lower()
+    ]
+    if not matches:
+        print(
+            f"No machine matching '{ref}'. "
+            "Run `vicoa session start --list-machines` to see them.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if len(matches) > 1:
+        shown = ", ".join(
+            f"{_machine_label(m)} ({_short(m.get('machine_id'))})" for m in matches
+        )
+        print(
+            f"'{ref}' is ambiguous — matches {shown}. Pass the full machine id.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return matches[0]
+
+
+def _select_machine(args, api_key: str, ref: Optional[str]) -> dict:
+    """Pick the target machine — an explicit ``--machine`` or this local host.
+
+    With no ref we default to the machine this host's daemon registered (read
+    from local daemon state), matching the desktop's "runs on this computer"
+    default. If there's no local daemon we can't guess a remote one, so we fail
+    with guidance rather than silently picking someone else's machine.
+    """
+    machines = _fetch_machines(args, api_key)
+    if not machines:
+        print(
+            "No machines registered. Start the Vicoa daemon on a machine first "
+            "(`vicoa daemon`).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if ref:
+        return _match_machine(machines, ref)
+
+    local_id = _local_machine_id(args)
+    if not local_id:
+        print(
+            "No --machine given and no local daemon found on this host.\n"
+            "Pass --machine (see `vicoa session start --list-machines`) or run "
+            "`vicoa daemon` here first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    for m in machines:
+        if str(m.get("machine_id")) == local_id:
+            return m
+    print(
+        f"This host's daemon ({_short(local_id)}) isn't registered on this server. "
+        "Run `vicoa daemon` here, or pass --machine.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _print_models(catalog: dict, agent_filter: Optional[str]) -> int:
+    agents = catalog.get("agents", [])
+    if agent_filter:
+        agents = [a for a in agents if a.get("id") == agent_filter]
+        if not agents:
+            known = ", ".join(a["id"] for a in catalog.get("agents", []))
+            print(
+                f"Unknown agent '{agent_filter}'. Known agents: {known}.",
+                file=sys.stderr,
+            )
+            return 2
+
+    def _ids(entries: Optional[list]) -> str:
+        out = []
+        for e in entries or []:
+            out.append(f"{e['id']}*" if e.get("is_default") else e["id"])
+        return ", ".join(out) if out else "—"
+
+    for agent in agents:
+        print(f"\n{agent.get('label', agent['id'])}  ({agent['id']})")
+        print(f"  models:           {_ids(agent.get('models'))}")
+        if agent.get("thinking_efforts"):
+            print(f"  thinking efforts: {_ids(agent.get('thinking_efforts'))}")
+        if agent.get("reasoning_efforts"):
+            print(f"  reasoning efforts:{_ids(agent.get('reasoning_efforts'))}")
+        if agent.get("permission_modes"):
+            print(f"  permission modes: {_ids(agent.get('permission_modes'))}")
+        if agent.get("modes"):
+            print(f"  modes:            {_ids(agent.get('modes'))}")
+    print("\n(* = default)")
+    return 0
+
+
+def _validate_and_build_metadata(args, agent: str) -> dict:
+    """Validate the picked config against the catalog and build spawn metadata.
+
+    Mirrors the web's ``toSpawnMetadata`` (apps/web/lib/agent-catalog.ts): the
+    daemon's ``_extract_*`` helpers read these exact keys when building the
+    headless command. Unknown effort/permission/mode values are hard errors;
+    an unrecognised model is a soft warning (per-install ACP/opencode models
+    aren't in the static catalog), so the daemon still applies it best-effort.
+    """
+    catalog, permission_modes, thinking_efforts, reasoning_efforts = (
+        _load_agent_catalog()
+    )
+    entry = _agent_entry(catalog, agent)
+    if entry is None:
+        known = ", ".join(a["id"] for a in catalog.get("agents", []))
+        print(f"Unknown agent '{agent}'. Known agents: {known}.", file=sys.stderr)
+        sys.exit(2)
+
+    model = getattr(args, "model", None)
+    effort = getattr(args, "effort", None)
+    permission_mode = getattr(args, "permission_mode", None)
+    opencode_mode = getattr(args, "opencode_mode", None)
+
+    # Soft-validate the model against the static catalog.
+    if model:
+        known_models = {m["id"] for m in entry.get("models") or []}
+        if known_models and model not in known_models:
+            print(
+                f"Warning: '{model}' isn't a catalog model for {agent} "
+                f"({', '.join(sorted(known_models))}); passing it through anyway.",
+                file=sys.stderr,
+            )
+
+    # Effort routes to a per-agent key; reject when the agent has no such axis.
+    if effort:
+        if agent == "claude" and effort not in thinking_efforts:
+            print(
+                f"Invalid effort '{effort}' for claude. "
+                f"Valid: {', '.join(sorted(thinking_efforts))}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if agent == "codex" and effort not in reasoning_efforts:
+            print(
+                f"Invalid effort '{effort}' for codex. "
+                f"Valid: {', '.join(sorted(reasoning_efforts))}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if agent not in ("claude", "codex"):
+            print(
+                f"Warning: --effort is only used by claude/codex; ignored for {agent}.",
+                file=sys.stderr,
+            )
+            effort = None
+
+    if permission_mode:
+        valid = permission_modes.get(agent)
+        # Only hard-fail when the agent declares a permission-mode set; ACP
+        # agents validate against their live session, so pass through otherwise.
+        if valid and permission_mode not in valid:
+            print(
+                f"Invalid --permission-mode '{permission_mode}' for {agent}. "
+                f"Valid: {', '.join(sorted(valid))}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+    if opencode_mode:
+        if agent != "opencode":
+            print(
+                "Warning: --opencode-mode only applies to opencode; ignored.",
+                file=sys.stderr,
+            )
+            opencode_mode = None
+        else:
+            valid_modes = {e["id"] for e in entry.get("modes") or []}
+            if valid_modes and opencode_mode not in valid_modes:
+                print(
+                    f"Invalid --opencode-mode '{opencode_mode}'. "
+                    f"Valid: {', '.join(sorted(valid_modes))}.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+
+    meta: dict[str, Any] = {}
+    name = getattr(args, "name", None)
+    if name:
+        meta["name"] = name
+
+    if agent == "claude":
+        if model:
+            meta["model"] = model
+        if effort:
+            meta["thinking_effort"] = effort
+            # Dual-write for old daemons, exactly as the web does.
+            meta["enable_thinking"] = effort != "off"
+        if permission_mode:
+            meta["permission_mode"] = permission_mode
+    elif agent == "codex":
+        if model:
+            meta["model"] = model
+        if effort:
+            meta["reasoning_effort"] = effort
+        if permission_mode:
+            meta["permission_mode"] = permission_mode
+    elif agent == "opencode":
+        if opencode_mode:
+            meta["agent_mode"] = opencode_mode
+        # `default`/`auto` keep OpenCode's own configured model.
+        if model and model not in ("default", "auto"):
+            meta["model"] = model
+    else:  # generic ACP agents (cursor/gemini/copilot/kimi/hermes)
+        if model:
+            meta["model"] = model
+        if permission_mode:
+            meta["permission_mode"] = permission_mode
+
+    return meta
+
+
+def _wait_for_status(
+    args, api_key: str, instance_id: str, timeout: float
+) -> Optional[str]:
+    """Poll the instance until it leaves STARTING, or the timeout elapses.
+
+    Returns the last-seen status. The spawn is asynchronous — the daemon claims
+    the request and launches out of band — so this gives ``--wait`` callers a
+    concrete "it's running" (or the error the daemon reported) instead of just
+    a freshly-minted id.
+    """
+    import time
+
+    endpoint = f"/api/v1/agent-instances/{instance_id}"
+    deadline = time.monotonic() + timeout
+    last: Optional[str] = None
+    while True:
+        header = request(args, api_key, "GET", endpoint)
+        last = str(header.get("status") or "") if isinstance(header, dict) else last
+        if last and last.upper() != "STARTING":
+            return last
+        if time.monotonic() >= deadline:
+            return last
+        time.sleep(2.0)
+
+
+def _cmd_start(args, api_key: str) -> int:
+    """Spawn a new session on a chosen machine (the desktop "New Session")."""
+    as_json = getattr(args, "json", False)
+
+    # Discovery short-circuits: list machines or the model/agent catalog.
+    if getattr(args, "list_machines", False):
+        machines = _fetch_machines(args, api_key)
+        if as_json:
+            print(_json.dumps({"machines": machines}, indent=2))
+        else:
+            _print_machines(machines)
+        return 0
+    if getattr(args, "list_models", False):
+        catalog, *_ = _load_agent_catalog()
+        agent_filter = getattr(args, "agent", None)
+        if as_json:
+            agents = catalog.get("agents", [])
+            if agent_filter:
+                agents = [a for a in agents if a.get("id") == agent_filter]
+            print(_json.dumps({"agents": agents}, indent=2))
+            return 0
+        return _print_models(catalog, agent_filter)
+
+    machine_ref = getattr(args, "machine", None)
+    directory = getattr(args, "dir", None)
+    if not directory:
+        print(
+            "--dir is required to start a session.\n"
+            "See machines with `vicoa session start --list-machines` and models "
+            "with `vicoa session start --list-models`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    agent = (getattr(args, "agent", None) or "claude").strip().lower()
+    metadata = _validate_and_build_metadata(args, agent)
+
+    machine = _select_machine(args, api_key, machine_ref)
+    machine_id = str(machine["machine_id"])
+
+    # A spawn-request only runs when the machine's daemon claims it. If the
+    # daemon looks offline the request would silently queue forever, so refuse
+    # by default — unless the caller explicitly wants it queued for whenever the
+    # host next reconnects (a legit "start this when my laptop wakes" flow).
+    online = _machine_online(machine)
+    if not online:
+        last_seen = _local_time(machine.get("last_heartbeat_at"))
+        if getattr(args, "allow_offline", False):
+            print(
+                f"Warning: daemon on {_machine_label(machine)} looks offline "
+                f"(last seen {last_seen}); queuing the request until it reconnects.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"Daemon on {_machine_label(machine)} looks offline "
+                f"(last seen {last_seen}). Start it with `vicoa daemon` on that "
+                "machine, or pass --allow-offline to queue the request until it "
+                "reconnects.",
+                file=sys.stderr,
+            )
+            return 1
+
+    body: dict[str, Any] = {"directory": directory, "agent": agent}
+    prompt = getattr(args, "prompt", None)
+    if prompt and prompt.strip():
+        body["prompt"] = prompt
+    if metadata:
+        body["metadata"] = metadata
+
+    result = request(
+        args,
+        api_key,
+        "POST",
+        f"/api/v1/machines/{machine_id}/spawn-requests",
+        json=body,
+    )
+    instance_id = (
+        str(result.get("agent_instance_id")) if isinstance(result, dict) else ""
+    )
+
+    # Link a task if asked — mirrors `session update --task`, which drives the
+    # task's status from the session server-side.
+    task_id = getattr(args, "task", None)
+    if task_id and instance_id:
+        request(
+            args,
+            api_key,
+            "PATCH",
+            f"/api/v1/agent-instances/{instance_id}",
+            json={"task_id": task_id},
+        )
+
+    final_status: Optional[str] = None
+    if getattr(args, "wait", False) and instance_id:
+        final_status = _wait_for_status(
+            args, api_key, instance_id, timeout=getattr(args, "wait_timeout", 60.0)
+        )
+
+    if as_json:
+        out = dict(result) if isinstance(result, dict) else {}
+        out["machine_id"] = machine_id
+        if final_status is not None:
+            out["status"] = final_status
+        print(_json.dumps(out, indent=2))
+        return 0
+
+    verb = "Started" if online else "Queued"
+    print(
+        f"{verb} {agent} session on {_machine_label(machine)} in {directory} "
+        f"— session {_short(instance_id)}."
+    )
+    if final_status is not None:
+        print(f"Status: {final_status}.")
+    print(
+        f"Track it with `vicoa session get {_short(instance_id)}` "
+        f"or send input with `vicoa session message {_short(instance_id)} '...'`."
+    )
+    return 0
+
+
 _HANDLERS = {
+    "start": _cmd_start,
     "ls": _cmd_ls,
     "get": _cmd_get,
     "update": _cmd_update,
@@ -537,7 +1028,7 @@ def run_session_command(args) -> int:
     handler = _HANDLERS.get(sub) if sub else None
     if handler is None:
         print(
-            "usage: vicoa session {ls,get,update,message,continue} ...\n"
+            "usage: vicoa session {start,ls,get,update,message,continue} ...\n"
             "Run `vicoa session --help` for details.",
             file=sys.stderr,
         )

--- a/backend/tests/test_session_cli_format.py
+++ b/backend/tests/test_session_cli_format.py
@@ -9,6 +9,7 @@ on what counts as a control message or a tool use.
 import json
 import re
 import types
+from datetime import datetime, timedelta, timezone
 
 from vicoa.commands import instance as I
 
@@ -16,6 +17,11 @@ from vicoa.commands import instance as I
 # the assertion is independent of the machine's local timezone (the raw UTC is
 # converted to local time before display).
 _TIMESTAMP_RE = re.compile(r"\[\d{4}-\d\d-\d\d \d\d:\d\d\]")
+
+
+def _iso_ago(seconds: float) -> str:
+    """ISO-8601 UTC timestamp ``seconds`` in the past — for heartbeat freshness."""
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds)).isoformat()
 
 
 class TestControlEnvelope:
@@ -308,6 +314,262 @@ class TestGetRoleFilter:
         self._patch_request(monkeypatch)
         I._cmd_get(self._args(role="user", all_messages=True), "key")
         assert "--limit counts all senders" not in capsys.readouterr().out
+
+
+class TestBuildSpawnMetadata:
+    """`session start` metadata mirrors the web's toSpawnMetadata per agent."""
+
+    def _args(self, **over):
+        base = {
+            "model": None,
+            "effort": None,
+            "permission_mode": None,
+            "opencode_mode": None,
+            "name": None,
+        }
+        base.update(over)
+        return types.SimpleNamespace(**base)
+
+    def test_claude_effort_dual_writes_enable_thinking(self):
+        meta = I._validate_and_build_metadata(
+            self._args(
+                model="claude-sonnet-5",
+                effort="high",
+                permission_mode="default",
+                name="demo",
+            ),
+            "claude",
+        )
+        assert meta == {
+            "name": "demo",
+            "model": "claude-sonnet-5",
+            "thinking_effort": "high",
+            "enable_thinking": True,
+            "permission_mode": "default",
+        }
+
+    def test_claude_effort_off_sets_enable_thinking_false(self):
+        meta = I._validate_and_build_metadata(self._args(effort="off"), "claude")
+        assert meta["thinking_effort"] == "off"
+        assert meta["enable_thinking"] is False
+
+    def test_codex_uses_reasoning_effort_key(self):
+        meta = I._validate_and_build_metadata(
+            self._args(model="gpt-5.5", effort="medium", permission_mode="default"),
+            "codex",
+        )
+        assert meta == {
+            "model": "gpt-5.5",
+            "reasoning_effort": "medium",
+            "permission_mode": "default",
+        }
+
+    def test_opencode_default_model_dropped_mode_mapped(self):
+        meta = I._validate_and_build_metadata(
+            self._args(model="default", opencode_mode="plan"), "opencode"
+        )
+        assert meta == {"agent_mode": "plan"}
+
+    def test_opencode_explicit_model_kept(self):
+        meta = I._validate_and_build_metadata(
+            self._args(model="opencode/big-pickle"), "opencode"
+        )
+        assert meta == {"model": "opencode/big-pickle"}
+
+    def test_generic_acp_passes_model_and_permission(self):
+        meta = I._validate_and_build_metadata(
+            self._args(model="composer-2.5", permission_mode="plan"), "cursor"
+        )
+        assert meta == {"model": "composer-2.5", "permission_mode": "plan"}
+
+    def test_invalid_effort_exits(self):
+        import pytest
+
+        with pytest.raises(SystemExit) as exc:
+            I._validate_and_build_metadata(self._args(effort="bogus"), "claude")
+        assert exc.value.code == 2
+
+    def test_invalid_permission_mode_exits(self):
+        import pytest
+
+        with pytest.raises(SystemExit) as exc:
+            I._validate_and_build_metadata(
+                self._args(permission_mode="acceptEdits"), "codex"
+            )
+        assert exc.value.code == 2
+
+
+class TestSessionStart:
+    def _args(self, **over):
+        base = {
+            "json": True,
+            "list_machines": False,
+            "list_models": False,
+            "machine": "Laptop",
+            "dir": "/tmp/proj",
+            "agent": "claude",
+            "model": "claude-sonnet-5",
+            "effort": "high",
+            "permission_mode": "default",
+            "opencode_mode": None,
+            "name": "demo",
+            "prompt": "do it",
+            "task": None,
+            "wait": False,
+            "wait_timeout": 60.0,
+            "allow_offline": False,
+        }
+        base.update(over)
+        return types.SimpleNamespace(**base)
+
+    def _fake_request(self, calls, *, machines=None):
+        machines = machines or [
+            {
+                "machine_id": "mach-1234",
+                "display_name": "Laptop",
+                "hostname": "host",
+                "last_heartbeat_at": _iso_ago(5),  # fresh -> online
+            }
+        ]
+
+        def fake_request(args, api_key, method, endpoint, *, params=None, json=None):
+            calls.append((method, endpoint, json))
+            if method == "GET" and endpoint == "/api/v1/machines":
+                return {"machines": machines}
+            if method == "POST" and endpoint.endswith("/spawn-requests"):
+                return {"request_id": "req-1", "agent_instance_id": "inst-1"}
+            if method == "GET" and endpoint.startswith("/api/v1/agent-instances/"):
+                return {"status": "ACTIVE"}
+            return None
+
+        return fake_request
+
+    def test_posts_spawn_request_with_metadata(self, monkeypatch, capsys):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        rc = I._cmd_start(self._args(), "key")
+        assert rc == 0
+        post = [c for c in calls if c[0] == "POST"][0]
+        assert post[1] == "/api/v1/machines/mach-1234/spawn-requests"
+        assert post[2]["directory"] == "/tmp/proj"
+        assert post[2]["agent"] == "claude"
+        assert post[2]["prompt"] == "do it"
+        assert post[2]["metadata"]["model"] == "claude-sonnet-5"
+        assert post[2]["metadata"]["thinking_effort"] == "high"
+        assert post[2]["metadata"]["name"] == "demo"
+        out = json.loads(capsys.readouterr().out)
+        assert out["agent_instance_id"] == "inst-1"
+        assert out["machine_id"] == "mach-1234"
+
+    def test_blank_prompt_omitted(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        I._cmd_start(self._args(prompt="   "), "key")
+        post = [c for c in calls if c[0] == "POST"][0]
+        assert "prompt" not in post[2]
+
+    def test_task_link_patches_instance(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        I._cmd_start(self._args(task="task-uuid"), "key")
+        patch = [c for c in calls if c[0] == "PATCH"][0]
+        assert patch[1] == "/api/v1/agent-instances/inst-1"
+        assert patch[2] == {"task_id": "task-uuid"}
+
+    def test_missing_dir_returns_2(self, monkeypatch):
+        def boom(*a, **k):
+            raise AssertionError("request() must not run without --dir")
+
+        monkeypatch.setattr(I, "request", boom)
+        assert I._cmd_start(self._args(dir=None), "key") == 2
+
+    def test_no_machine_and_no_local_daemon_exits(self, monkeypatch):
+        import pytest
+
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        monkeypatch.setattr(I, "_local_machine_id", lambda args: None)
+        with pytest.raises(SystemExit) as exc:
+            I._cmd_start(self._args(machine=None), "key")
+        assert exc.value.code == 1
+
+    def test_defaults_to_local_machine(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        monkeypatch.setattr(I, "_local_machine_id", lambda args: "mach-1234")
+        rc = I._cmd_start(self._args(machine=None), "key")
+        assert rc == 0
+        post = [c for c in calls if c[0] == "POST"][0]
+        assert post[1] == "/api/v1/machines/mach-1234/spawn-requests"
+
+    def test_offline_machine_refused_by_default(self, monkeypatch, capsys):
+        calls = []
+        machines = [
+            {
+                "machine_id": "mach-1234",
+                "display_name": "Laptop",
+                "hostname": "host",
+                "last_heartbeat_at": _iso_ago(600),  # stale -> offline
+            }
+        ]
+        monkeypatch.setattr(I, "request", self._fake_request(calls, machines=machines))
+        rc = I._cmd_start(self._args(), "key")
+        assert rc == 1
+        assert not any(c[0] == "POST" for c in calls)
+        assert "offline" in capsys.readouterr().err
+
+    def test_offline_machine_allow_offline_queues(self, monkeypatch, capsys):
+        calls = []
+        machines = [
+            {
+                "machine_id": "mach-1234",
+                "display_name": "Laptop",
+                "hostname": "host",
+                "last_heartbeat_at": _iso_ago(600),  # stale -> offline
+            }
+        ]
+        monkeypatch.setattr(I, "request", self._fake_request(calls, machines=machines))
+        rc = I._cmd_start(self._args(json=False, allow_offline=True), "key")
+        assert rc == 0
+        assert any(c[0] == "POST" for c in calls)
+        assert "Queued" in capsys.readouterr().out
+
+    def test_machine_resolved_by_name_substring(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        I._cmd_start(self._args(machine="lap"), "key")
+        post = [c for c in calls if c[0] == "POST"][0]
+        assert post[1] == "/api/v1/machines/mach-1234/spawn-requests"
+
+    def test_ambiguous_machine_exits(self, monkeypatch):
+        import pytest
+
+        calls = []
+        machines = [
+            {"machine_id": "m-1", "display_name": "Laptop A", "hostname": "a"},
+            {"machine_id": "m-2", "display_name": "Laptop B", "hostname": "b"},
+        ]
+        monkeypatch.setattr(I, "request", self._fake_request(calls, machines=machines))
+        with pytest.raises(SystemExit) as exc:
+            I._cmd_start(self._args(machine="laptop"), "key")
+        assert exc.value.code == 1
+
+    def test_list_machines_short_circuits(self, monkeypatch, capsys):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        rc = I._cmd_start(self._args(list_machines=True), "key")
+        assert rc == 0
+        # Only the machines GET runs — no spawn.
+        assert all(c[0] == "GET" for c in calls)
+        assert not any("spawn-requests" in c[1] for c in calls)
+
+    def test_wait_polls_until_not_starting(self, monkeypatch, capsys):
+        calls = []
+        monkeypatch.setattr(I, "request", self._fake_request(calls))
+        monkeypatch.setattr(I, "_wait_for_status", lambda *a, **k: "ACTIVE")
+        out_rc = I._cmd_start(self._args(wait=True), "key")
+        assert out_rc == 0
+        assert json.loads(capsys.readouterr().out)["status"] == "ACTIVE"
 
 
 class TestRateLimitedLsParams:


### PR DESCRIPTION
## Summary

Adds **`vicoa session start`**, the terminal equivalent of the desktop/web **"New Session"** composer. It picks a machine, directory, agent, and model/config, then POSTs a spawn-request that the target machine's daemon claims and launches **headless** — the exact same spawn path the apps drive, just over REST instead of the WebSocket `spawn-session` RPC. The session then streams to the mobile app and web dashboard like any remote session.

```bash
vicoa session start --dir ~/projects/my-app                 # Claude Code on this host's daemon
vicoa session start --machine laptop --dir ~/projects/api \
  --agent codex --model gpt-5.5 --effort medium --wait      # Codex on another box, block until running
vicoa session start --list-machines                         # discovery
vicoa session start --list-models --agent codex
```

### Behavior
- **Machine selection** by id / id-prefix / display-name-or-hostname substring, defaulting to this host's registered daemon. Refuses an offline daemon by default; `--allow-offline` queues the request until it reconnects.
- **Per-agent config** validated against `protocol.agent_catalog` and mapped to spawn metadata exactly like the web's `toSpawnMetadata` (claude `thinking_effort` + `enable_thinking` dual-write, codex `reasoning_effort`, opencode `agent_mode`, generic ACP `model`/`permission`). Unknown efforts/permission/modes hard-fail; an unrecognized model is a soft warning passed through.
- `--prompt`, `--name`, `--task` (link to a task), `--wait` / `--wait-timeout` (poll until the session leaves `STARTING`), and `--json` output.
- `amp` is intentionally excluded from `--agent` (the spawn catalog doesn't cover it).

## Docs
- Full `vicoa session start` reference in `cli-commands.mdx` (flag tables, examples, offline + discovery notes) and a "start from the terminal" section in `start-remote-session.mdx` cross-linked to it.
- Filled adjacent gaps so every referenced command/flag is documented: `session message` / `continue`, and `session ls --rate-limited`.
- Fixed the stale "session commands are read-only" note; extended the errors table (offline daemon, missing `--dir`).

## Also included
- `chore(servers): declare claude-agent-sdk dependency` — an unrelated one-line dependency sync in `servers/requirements.txt` that was in the working tree; kept as its own commit. Drop it if you'd rather it land separately.

## Testing
- `pytest tests/test_session_cli_format.py` — **46 passed** (metadata building per agent + the full start-command flow: machine resolution, offline refusal/queue, task link, `--wait`, discovery short-circuits).
- `ruff check` / `ruff format --check` clean on the changed Python.

> Note: `.source/index.ts` (Fumadocs-generated) will regenerate on the next `pnpm build` from the `content/` changes and should be committed then per the web repo's house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)