### PR TITLE
Upgrade claude-agent-sdk, add Opus 5 + auto-mode default, fix resume config

### DIFF
--- a/apps/mobile/lib/backend/agent_catalog.dart
+++ b/apps/mobile/lib/backend/agent_catalog.dart
@@ -416,7 +416,7 @@ String sessionConfigSummary(AgentCatalog catalog, SessionConfig config) {
 /// the flag today; this comment is the rule.
 const String _agentCatalogFallbackJson = r'''
 {
-  "version": "2026-07-13-1",
+  "version": "2026-09-02-1",
   "min_cli_version": "1.20.0",
   "min_client_version": "0.42.0",
   "agents": [
@@ -425,6 +425,7 @@ const String _agentCatalogFallbackJson = r'''
       "label": "Claude Code",
       "models": [
         {"id": "claude-fable-5", "label": "Fable 5", "default_thinking_effort": "xhigh", "permission_modes": ["auto"]},
+        {"id": "claude-opus-5", "label": "Opus 5", "default_thinking_effort": "xhigh", "permission_modes": ["auto"]},
         {"id": "claude-opus-4-8", "label": "Opus 4.8", "default_thinking_effort": "xhigh", "permission_modes": ["auto"]},
         {"id": "claude-opus-4-8[1m]", "label": "Opus 4.8 1M", "default_thinking_effort": "xhigh", "permission_modes": ["auto"]},
         {"id": "claude-opus-4-7", "label": "Opus 4.7", "default_thinking_effort": "xhigh", "permission_modes": ["auto"]},
@@ -446,8 +447,8 @@ const String _agentCatalogFallbackJson = r'''
         {"id": "off", "label": "Off"}
       ],
       "permission_modes": [
-        {"id": "default", "label": "Default", "is_default": true},
-        {"id": "auto", "label": "Auto mode", "opt_in": true},
+        {"id": "default", "label": "Default"},
+        {"id": "auto", "label": "Auto mode", "opt_in": true, "is_default": true},
         {"id": "acceptEdits", "label": "Accept Edits"},
         {"id": "plan", "label": "Plan"},
         {"id": "bypassPermissions", "label": "Skip permissions (Yolo)"}

--- a/apps/mobile/lib/custom_code/actions/api_resume_session.dart
+++ b/apps/mobile/lib/custom_code/actions/api_resume_session.dart
@@ -7,6 +7,9 @@ import 'package:flutter/material.dart';
 // `RpcException` is not re-exported by the index.dart barrel; pull it from its
 // own file to read the wire error code. Same pattern as fetch_slash_commands.
 import 'ws_client.dart' show RpcException;
+// SessionConfig.toSpawnMetadata rebuilds the daemon metadata from the stored
+// config so a resume keeps its model / effort / permission mode.
+import '/backend/agent_catalog.dart';
 
 /// Relaunch a stopped session on the machine it came from.
 ///
@@ -34,11 +37,21 @@ Future<Map<String, dynamic>> apiResumeSession(
   String directory, {
   String agent = 'claude',
   String? agentSessionId,
+  Map<String, dynamic>? sessionConfig,
 }) async {
   try {
     if (machineId.isEmpty || agentInstanceId.isEmpty || directory.isEmpty) {
       return {'success': false, 'error': 'Session cannot be resumed: missing machine or folder'};
     }
+
+    // Rebuild the daemon `metadata` from the stored config so the resumed
+    // session keeps its model / thinking effort / permission mode. Without this
+    // the daemon sees no metadata and falls back to its defaults (permission
+    // mode `default`), so an `auto`-mode session came back running as
+    // `default`. Mirrors the web's resumeSpawnMetadata (session-resume.ts).
+    final metadata = (sessionConfig != null && sessionConfig.isNotEmpty)
+        ? SessionConfig.fromJson({...sessionConfig, 'agent': agent}).toSpawnMetadata()
+        : <String, dynamic>{};
 
     final result = await VicoaWsClient.instance.callRpc(
       machineId,
@@ -50,6 +63,7 @@ Future<Map<String, dynamic>> apiResumeSession(
           'agent_instance_id': agentInstanceId,
           if (agentSessionId != null && agentSessionId.isNotEmpty) 'agent_session_id': agentSessionId,
         },
+        if (metadata.isNotEmpty) 'metadata': metadata,
       },
     );
 

--- a/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
+++ b/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
@@ -2190,6 +2190,9 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
         sessionConfig: _instanceMap('session_config'),
       ),
       agentSessionId: actions.resumeAgentSessionHandle(metadata),
+      // Carry the stored model / effort / permission mode through so the
+      // resumed session isn't reset to the daemon's defaults.
+      sessionConfig: _instanceMap('session_config'),
     );
     if (!mounted) return;
     if (result['success'] != true) {

--- a/apps/web/lib/agent-catalog.ts
+++ b/apps/web/lib/agent-catalog.ts
@@ -381,7 +381,7 @@ export function savePersistedSelection(payload: Partial<PersistedSelection>): vo
 // ---------------------------------------------------------------------------
 
 export const AGENT_CATALOG_FALLBACK: AgentCatalog = {
-  version: "2026-07-18-1",
+  version: "2026-09-02-1",
   min_cli_version: "1.20.0",
   min_client_version: "0.42.0",
   agents: [
@@ -391,9 +391,10 @@ export const AGENT_CATALOG_FALLBACK: AgentCatalog = {
       models: [
         // Opus 4.7+ default to xhigh via `default_thinking_effort` (per-model
         // override of the agent-level `high` is_default).
-        // Fable 5 is natively 1M-context (no `[1m]` variant), premium-priced,
-        // thinking-always-on — offered but not the picker default.
+        // Fable 5 and Opus 5 are natively 1M-context (no `[1m]` variant); Fable 5
+        // is premium-priced and thinking-always-on — offered but not the picker default.
         { id: "claude-fable-5", label: "Fable 5", default_thinking_effort: "xhigh", permission_modes: ["auto"] },
+        { id: "claude-opus-5", label: "Opus 5", default_thinking_effort: "xhigh", permission_modes: ["auto"] },
         { id: "claude-opus-4-8", label: "Opus 4.8", default_thinking_effort: "xhigh", permission_modes: ["auto"] },
         { id: "claude-opus-4-8[1m]", label: "Opus 4.8 1M", default_thinking_effort: "xhigh", permission_modes: ["auto"] },
         { id: "claude-opus-4-7", label: "Opus 4.7", default_thinking_effort: "xhigh", permission_modes: ["auto"] },
@@ -414,9 +415,13 @@ export const AGENT_CATALOG_FALLBACK: AgentCatalog = {
         { id: "low", label: "Low" },
         { id: "off", label: "Off" },
       ],
+      // `auto` is the default for every model that opts into it (Sonnet 4.6+,
+      // Opus 4.7+, Opus 5, Fable 5), mirroring Claude Code's auto-by-default.
+      // It stays `opt_in`, so models that don't support it (Opus 4.6, Haiku 4.5)
+      // fall through to `default` via pickWithModelFilter.
       permission_modes: [
-        { id: "default", label: "Default", is_default: true },
-        { id: "auto", label: "Auto mode", opt_in: true },
+        { id: "default", label: "Default" },
+        { id: "auto", label: "Auto mode", opt_in: true, is_default: true },
         { id: "acceptEdits", label: "Accept Edits" },
         { id: "plan", label: "Plan" },
         { id: "bypassPermissions", label: "Skip permissions (Yolo)" },

--- a/apps/web/lib/session-resume.test.ts
+++ b/apps/web/lib/session-resume.test.ts
@@ -12,6 +12,7 @@ import {
   resumeAgentSlug,
   resumeBlockedMessage,
   resumeBlockedReason,
+  resumeSpawnMetadata,
   type ResumableInstance,
 } from './session-resume';
 
@@ -150,6 +151,51 @@ describe('resumeAgentSlug', () => {
     expect(
       resumeAgentSlug(inst({ agent_type_name: name, session_config: null }))
     ).toBe(expected);
+  });
+});
+
+describe('resumeSpawnMetadata', () => {
+  it('rebuilds the daemon metadata from the stored config so resume keeps model/effort/mode', () => {
+    // The bug this fixes: resume sent no metadata, so the daemon fell back to
+    // permission mode `default` — an `auto` session came back as `default`.
+    expect(
+      resumeSpawnMetadata(
+        inst({
+          session_config: {
+            agent: 'claude',
+            model: 'claude-opus-5',
+            thinking_effort: 'xhigh',
+            permission_mode: 'auto',
+          },
+        })
+      )
+    ).toEqual({
+      model: 'claude-opus-5',
+      thinking_effort: 'xhigh',
+      // Dual-written for old daemons alongside thinking_effort.
+      enable_thinking: true,
+      permission_mode: 'auto',
+    });
+  });
+
+  it('maps codex reasoning_effort', () => {
+    expect(
+      resumeSpawnMetadata(
+        inst({
+          agent_type_name: 'Codex',
+          session_config: {
+            agent: 'codex',
+            model: 'gpt-5.5',
+            reasoning_effort: 'high',
+            permission_mode: 'default',
+          },
+        })
+      )
+    ).toEqual({ model: 'gpt-5.5', reasoning_effort: 'high', permission_mode: 'default' });
+  });
+
+  it('is empty for a legacy row with no stored config (daemon keeps its fallback)', () => {
+    expect(resumeSpawnMetadata(inst({ session_config: null }))).toEqual({});
   });
 });
 

--- a/apps/web/lib/session-resume.ts
+++ b/apps/web/lib/session-resume.ts
@@ -14,6 +14,7 @@
  */
 
 import { getWsClient } from '@/lib/ws-client';
+import { toSpawnMetadata, type SessionConfig } from '@/lib/agent-catalog';
 import {
   LIVENESS_STARTUP_GRACE_MS,
   isClosedByDesign,
@@ -225,6 +226,36 @@ export function agentSessionHandle(
   return meta.codex_thread_id ?? meta.acp_session_id ?? undefined;
 }
 
+/**
+ * Rebuild the daemon spawn `metadata` from the session's stored config so a
+ * resume relaunches with the SAME model, thinking effort, and permission mode
+ * it had.
+ *
+ * Resume used to send no `metadata` at all, so the daemon saw nothing to
+ * restore and fell back to its own defaults (permission mode `default`, no
+ * model/effort flags) — an `auto`-mode session came back running as `default`.
+ * `session_config` is the source of truth persisted on the row; run it through
+ * the same `toSpawnMetadata` the new-session spawn uses so the two paths agree.
+ * Returns `{}` when the row recorded no config (legacy rows) — the caller then
+ * omits `metadata` and the daemon keeps its own fallback.
+ */
+export function resumeSpawnMetadata(
+  instance: ResumableInstance
+): Record<string, unknown> {
+  const cfg = instance.session_config ?? {};
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() ? v : undefined;
+  const config: SessionConfig = {
+    agent: resumeAgentSlug(instance),
+    model: str(cfg.model),
+    thinking_effort: str(cfg.thinking_effort),
+    reasoning_effort: str(cfg.reasoning_effort),
+    permission_mode: str(cfg.permission_mode),
+    opencode_mode: str(cfg.opencode_mode),
+  };
+  return toSpawnMetadata(config);
+}
+
 export interface ResumeResult {
   agentInstanceId?: string;
 }
@@ -243,6 +274,9 @@ export async function resumeSession(
   }
 
   const handle = agentSessionHandle(instance);
+  // Carry the stored model / effort / permission mode through the resume so the
+  // relaunched session isn't silently reset to the daemon's defaults.
+  const metadata = resumeSpawnMetadata(instance);
   const result = await getWsClient().callRpc(instance.machine_id, 'spawn-session', {
     directory: expandProjectPath(instance.project, instance.home_dir),
     agent: resumeAgentSlug(instance),
@@ -250,6 +284,7 @@ export async function resumeSession(
       agent_instance_id: instance.id,
       agent_session_id: handle,
     },
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
   });
 
   if (result.error) {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # /ws endpoint); bare uvicorn ships without one.
     "websockets>=12.0",
     "pydantic>=2.11.5",
-    "claude-agent-sdk>=0.1.80",
+    "claude-agent-sdk>=0.2.151",
     "anthropic>=0.25.0",
     "pathspec>=0.11.0",
     # Cron parsing for scheduled automations (5-field cron + IANA tz).

--- a/backend/src/backend/tests/test_agent_catalog.py
+++ b/backend/src/backend/tests/test_agent_catalog.py
@@ -55,13 +55,15 @@ class TestAgentCatalogShape:
         assert auto.get("opt_in") is True
 
     def test_modern_models_opt_into_auto(self):
-        """Sonnet 4.6+, Opus 4.7+, and Fable 5 per-model arrays opt into `auto`."""
+        """Sonnet 4.6+, Opus 4.7+, Opus 5, and Fable 5 per-model arrays opt into `auto`."""
         claude = next(a for a in AGENT_CATALOG["agents"] if a["id"] == "claude")
         for model in claude["models"]:
             model_id = model["id"]
-            is_opus_47_plus = model_id.startswith(
-                "claude-opus-4-7"
-            ) or model_id.startswith("claude-opus-4-8")
+            is_opus_47_plus = (
+                model_id.startswith("claude-opus-4-7")
+                or model_id.startswith("claude-opus-4-8")
+                or model_id.startswith("claude-opus-5")
+            )
             is_sonnet_46_plus = model_id.startswith(
                 "claude-sonnet-4-6"
             ) or model_id.startswith("claude-sonnet-5")
@@ -76,13 +78,15 @@ class TestAgentCatalogShape:
                 assert "auto" not in perm_opts, f"{model_id} must NOT opt into `auto`"
 
     def test_opus_47_plus_default_to_xhigh(self):
-        """Opus 4.7/4.8 and Fable 5 per-model `default_thinking_effort` → `xhigh`."""
+        """Opus 4.7/4.8, Opus 5, and Fable 5 per-model `default_thinking_effort` → `xhigh`."""
         claude = next(a for a in AGENT_CATALOG["agents"] if a["id"] == "claude")
         for model in claude["models"]:
             model_id = model["id"]
-            is_opus_47_plus = model_id.startswith(
-                "claude-opus-4-7"
-            ) or model_id.startswith("claude-opus-4-8")
+            is_opus_47_plus = (
+                model_id.startswith("claude-opus-4-7")
+                or model_id.startswith("claude-opus-4-8")
+                or model_id.startswith("claude-opus-5")
+            )
             # Fable 5 is the deepest-reasoning tier, so it shares the xhigh
             # baseline with Opus 4.7+.
             is_fable_5 = model_id.startswith("claude-fable-5")

--- a/backend/src/integrations/cli_wrappers/claude_code/monitoring/jsonl_monitor.py
+++ b/backend/src/integrations/cli_wrappers/claude_code/monitoring/jsonl_monitor.py
@@ -26,6 +26,7 @@ from ..format_utils import format_content_block
 # so the table is maintained in lock-step with the catalog. When upstream
 # adds a model, add it here too — existing tests guard the parsing path.
 _CLAUDE_LABEL_TO_SLUG: Dict[str, str] = {
+    "Opus 5": "claude-opus-5",
     "Opus 4.8": "claude-opus-4-8",
     "Opus 4.8 1M": "claude-opus-4-8[1m]",
     "Opus 4.7": "claude-opus-4-7",

--- a/backend/src/integrations/cli_wrappers/claude_code/utils/initial_session_config.py
+++ b/backend/src/integrations/cli_wrappers/claude_code/utils/initial_session_config.py
@@ -24,6 +24,7 @@ from .model_env_parser import parse_anthropic_model_env
 # JSONLMonitor's /effort handler overrides this whenever the user changes
 # effort mid-session, so this is just the best initial guess.
 _MODEL_DEFAULT_THINKING: dict[str, str] = {
+    "claude-opus-5": "xhigh",
     "claude-opus-4-7": "xhigh",
     "claude-opus-4-8": "xhigh",
     "claude-sonnet-4-6": "high",

--- a/backend/src/protocol/agent_catalog.py
+++ b/backend/src/protocol/agent_catalog.py
@@ -24,7 +24,7 @@ from typing import Any
 
 
 AGENT_CATALOG: dict[str, Any] = {
-    "version": "2026-07-18-1",
+    "version": "2026-09-02-1",
     "min_cli_version": "1.20.0",
     "min_client_version": "0.42.0",
     "agents": [
@@ -41,13 +41,21 @@ AGENT_CATALOG: dict[str, Any] = {
                 # with the depth-of-reasoning to justify the agent-level `high`
                 # baseline being bumped. `default_thinking_effort` overrides
                 # `is_default` when this model is selected.
-                # Fable 5 is natively 1M-context (max == default), so it has
-                # no `[1m]` variant. Premium-priced and thinking-always-on, so
-                # it is not the picker default. `xhigh` is the recommended
-                # coding/agentic effort tier.
+                # Fable 5 and Opus 5 are natively 1M-context (max == default),
+                # so they have no `[1m]` variant — see
+                # ``integrations/headless/usage.py`` (_CLAUDE_CONTEXT_WINDOWS).
+                # Fable 5 is premium-priced and thinking-always-on, so it is not
+                # the picker default. `xhigh` is the recommended coding/agentic
+                # effort tier for both.
                 {
                     "id": "claude-fable-5",
                     "label": "Fable 5",
+                    "default_thinking_effort": "xhigh",
+                    "permission_modes": ["auto"],
+                },
+                {
+                    "id": "claude-opus-5",
+                    "label": "Opus 5",
                     "default_thinking_effort": "xhigh",
                     "permission_modes": ["auto"],
                 },
@@ -113,9 +121,20 @@ AGENT_CATALOG: dict[str, Any] = {
                 {"id": "low", "label": "Low"},
                 {"id": "off", "label": "Off"},
             ],
+            # `auto` is the default for every model that opts into it (Sonnet
+            # 4.6+, Opus 4.7+, Opus 5, Fable 5), mirroring Claude Code — which
+            # now starts new sessions in auto mode by default. `auto` stays
+            # `opt_in`, so models that don't support it (Opus 4.6, Haiku 4.5)
+            # fall through to `default` via the per-model filter (see
+            # reconcileAgainst / pickWithModelFilter in the web/mobile catalogs).
             "permission_modes": [
-                {"id": "default", "label": "Default", "is_default": True},
-                {"id": "auto", "label": "Auto mode", "opt_in": True},
+                {"id": "default", "label": "Default"},
+                {
+                    "id": "auto",
+                    "label": "Auto mode",
+                    "opt_in": True,
+                    "is_default": True,
+                },
                 {"id": "acceptEdits", "label": "Accept Edits"},
                 {"id": "plan", "label": "Plan"},
                 {"id": "bypassPermissions", "label": "Skip permissions (Yolo)"},

--- a/backend/src/servers/requirements.txt
+++ b/backend/src/servers/requirements.txt
@@ -15,7 +15,7 @@ sendgrid>=6.10.0
 
 # Agent integrations (integrations/headless/claude_code.py); also declared in
 # pyproject.toml for the vicoa daemon.
-claude-agent-sdk>=0.1.80
+claude-agent-sdk>=0.2.151
 
 # Shared dependencies
 -r ../shared/requirements.txt

--- a/backend/src/servers/requirements.txt
+++ b/backend/src/servers/requirements.txt
@@ -13,9 +13,5 @@ firebase-admin>=6.2.0
 twilio>=8.0.0
 sendgrid>=6.10.0
 
-# Agent integrations (integrations/headless/claude_code.py); also declared in
-# pyproject.toml for the vicoa daemon.
-claude-agent-sdk>=0.2.151
-
 # Shared dependencies
 -r ../shared/requirements.txt


### PR DESCRIPTION
## Summary

Upgrades the Claude Agent SDK, refreshes the Claude model catalog, makes `auto` the default permission mode where supported, slims the server image, and fixes a resume bug that reset a session's config.

## Changes

### 1. `claude-agent-sdk` upgrade
- Bump the pin **0.1.80 → 0.2.151** (`pyproject.toml`).
- Verified every runner import and every `ClaudeAgentOptions` field used in `integrations/headless/claude_code.py` resolves against 0.2.151 (runtime was already on 0.2.x; this just makes the pin honest). No code changes needed in the runner.

### 2. Add **Opus 5** to the model catalog
- Add `claude-opus-5` (native 1M, `xhigh`, `auto`) to `protocol/agent_catalog.py`, mirrored into the web/mobile fallback catalogs, the JSONL label→slug map, and the TUI initial-thinking seed. Catalog version → `2026-09-02-1`.
- Modelled as a single native-1M entry (no `[1m]` variant), matching Fable 5 and the existing `usage.py` convention.
- (There is no "Fable 5.1" in Anthropic's model list — not added.)

### 3. `auto` becomes the default permission mode
- Move the agent-level `is_default` from `default` → `auto` for Claude. `auto` stays `opt_in`, so via the existing per-model filter: models that support it (Sonnet 4.6+, Opus 4.7+, Opus 5, Fable 5) default to **auto**, while Opus 4.6 / Haiku 4.5 fall back to **default**. Mirrors Claude Code, which now starts new sessions in auto mode.

### 4. Drop the SDK from the server image
- The FastAPI backend/servers never spawn Claude (only the on-machine daemon does, via `pyproject.toml`). The dep — added to `servers/requirements.txt` in #12 — only bloated the deployed image with the SDK's ~190 MB bundled CLI. Removed.

### 5. Fix: resume no longer resets model / effort / permission mode
- **Root cause:** resume rode the `spawn-session` RPC but sent **no `metadata`**, so the daemon fell back to its defaults (`--permission-mode default`, no model/effort) — an `auto` session came back as `default`.
- **Fix:** rebuild the spawn metadata from the row's persisted `session_config` (source of truth) via the same `toSpawnMetadata` the new-session path uses, on both clients (web `resumeSpawnMetadata` helper + mobile `apiResumeSession`).

## Testing
- Backend: `test_agent_catalog` + daemon/endpoint/CLI suites — **114 + 15 pass**; ruff clean.
- Web: `agent-catalog` + `session-resume` — **48 pass** (incl. 3 new resume-metadata tests); `tsc --noEmit` clean.
- Mobile: `agent_catalog_test` — **13 pass**; `flutter analyze` clean on changed files.

## Follow-ups (not in this PR)
- The CLI `vicoa <agent> --resume` (interactive TUI) path still needs config flags passed explicitly.
- A server-side WS-relay backfill could restore resume config for all clients from one place (belt-and-braces).