### PR TITLE
feat(agents): collapsed "Thinking" cards + tidy ACP tool output

### DIFF
--- a/apps/mobile/lib/custom_code/widgets/index.dart
+++ b/apps/mobile/lib/custom_code/widgets/index.dart
@@ -15,5 +15,7 @@ export 'subagent_group.dart'
         subagentToolUseIdOf,
         subagentTypeOf,
         subagentDescriptionOf;
+export 'thinking_group.dart'
+    show ThinkingGroup, isThinkingMessage, thinkingDisplayBody;
 export 'custom_date_range_sheet.dart' show CustomDateRangeSheet;
 export 'chat_options_menu.dart' show ChatOptionsMenu;

--- a/apps/mobile/lib/custom_code/widgets/thinking_group.dart
+++ b/apps/mobile/lib/custom_code/widgets/thinking_group.dart
@@ -1,0 +1,125 @@
+// Collapsed model-reasoning ("thinking") card for the agent chat. A reasoning
+// message carries `message_metadata.thinking = { source }` (see
+// `src/integrations/headless/thinking.py`); the reasoning text rides in the
+// message content. This renders it behind a "Thinking" collapsible header
+// mirroring `buildToolGroupHeader` (like `SubagentGroup`), so reasoning is
+// available without flooding the transcript. Collapsed by default.
+
+import 'package:flutter/material.dart';
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/custom_code/widgets/markdown_text_builder.dart'
+    show buildMarkdownText, buildToolGroupHeader;
+
+/// Whether [message] is tagged as model reasoning
+/// (`message_metadata.thinking`). Sub-agent-tagged reasoning is intentionally
+/// NOT surfaced as a standalone thinking card — it renders inside its
+/// `SubagentGroup` — so callers pair this with a `!isSubagentMessage` guard.
+bool isThinkingMessage(dynamic message) {
+  if (message is! Map) return false;
+  final metadata = message['message_metadata'];
+  if (metadata is! Map) return false;
+  return metadata['thinking'] is Map;
+}
+
+/// Strips Codex's leading "Reasoning:" label (kept in the message content so
+/// pre-card clients still show it inline) — the card header already reads
+/// "Thinking", so the prefix is redundant here. The optional "🧠 " covers
+/// older daemons that still emit the emoji label.
+String thinkingDisplayBody(String content) {
+  final stripped = content
+      .replaceFirst(RegExp(r'^\s*(?:🧠\s*)?Reasoning:\s*\n?'), '')
+      .trim();
+  return stripped.isEmpty ? content.trim() : stripped;
+}
+
+/// One model-reasoning message, collapsed behind a "Thinking" header that
+/// mirrors [buildToolGroupHeader]'s bordered style (same chrome as
+/// [SubagentGroup]). Expanded, the reasoning renders as a lightweight bubble.
+class ThinkingGroup extends StatefulWidget {
+  const ThinkingGroup({
+    super.key,
+    required this.content,
+    required this.expanded,
+    required this.onToggle,
+    this.onBeforeToggle,
+    this.agentTypeName,
+    this.filterProjectRoot,
+  });
+
+  /// The reasoning text (raw message content, prefix stripped for display).
+  final String content;
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  /// Called immediately before expand/collapse, mirroring
+  /// [SubagentGroup.onBeforeToggle] — lets the host pin scroll position so the
+  /// tapped line doesn't shift as content grows.
+  final VoidCallback? onBeforeToggle;
+  final String? agentTypeName;
+  final String Function(String content)? filterProjectRoot;
+
+  @override
+  State<ThinkingGroup> createState() => _ThinkingGroupState();
+}
+
+class _ThinkingGroupState extends State<ThinkingGroup> {
+  void _toggle() {
+    widget.onBeforeToggle?.call();
+    widget.onToggle();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final body = thinkingDisplayBody(widget.content);
+    if (body.isEmpty) return const SizedBox.shrink();
+
+    if (!widget.expanded) {
+      return buildToolGroupHeader(
+        context,
+        'Thinking',
+        isLast: true,
+        expanded: false,
+        onToggle: _toggle,
+        iconToolName: 'Thinking',
+        agentTypeName: widget.agentTypeName,
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        buildToolGroupHeader(
+          context,
+          'Thinking',
+          isLast: true,
+          expanded: true,
+          onToggle: _toggle,
+          iconToolName: 'Thinking',
+          agentTypeName: widget.agentTypeName,
+        ),
+        const SizedBox(height: 8.0),
+        _buildBody(context, body),
+      ],
+    );
+  }
+
+  Widget _buildBody(BuildContext context, String content) {
+    final markdown = buildMarkdownText(
+      context,
+      content,
+      false,
+      onSendMessage: (_) {},
+      agentTypeName: widget.agentTypeName,
+      filterProjectRoot: widget.filterProjectRoot,
+    );
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 10.0),
+      decoration: BoxDecoration(
+        color: FlutterFlowTheme.of(context).secondaryBackground,
+        borderRadius: const BorderRadius.all(Radius.circular(16.0)),
+      ),
+      child: markdown,
+    );
+  }
+}

--- a/apps/mobile/lib/custom_code/widgets/tool_icon.dart
+++ b/apps/mobile/lib/custom_code/widgets/tool_icon.dart
@@ -39,6 +39,7 @@ IconData iconForToolName(String toolName) {
   }
   if (key == 'read') return Icons.remove_red_eye_outlined; // Eye
   if (key == 'askuserquestion') return Icons.help_outline; // MessageCircleQuestion
+  if (key == 'thinking') return Icons.lightbulb_outline; // Lightbulb (reasoning)
   if (isAgentToolName(toolName)) return Icons.smart_toy_outlined; // Bot
   if (key == 'search' || key == 'grep' || key == 'glob') return Icons.search; // Search
   if (key == 'list') return Icons.list; // List

--- a/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
+++ b/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
@@ -148,6 +148,11 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
   // group, unlike a first-message id.
   final Set<String> _expandedSubagentGroups = {};
 
+  // Model-reasoning ("thinking") cards expanded by the user. Keyed by message
+  // id — each reasoning message is its own standalone card (not grouped), so
+  // the message id is a stable, unique key that survives row recycling.
+  final Set<String> _expandedThinkingCards = {};
+
   // Anchor-at-first-occurrence bucketing of sub-agent messages by tool_use_id,
   // recomputed alongside the other message metadata caches (see
   // _rebuildMessageMetadataCache). Unlike collapse-tool-use's consecutive-run
@@ -1273,6 +1278,50 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
       );
     }
 
+    // Model reasoning (Claude ThinkingBlock / Codex reasoning) renders as its
+    // own standalone collapsed "Thinking" card — its own bordered box, spaced
+    // like a collapsed tool run. Checked here, ahead of the empty-content
+    // early return, for symmetry with the sub-agent branch (a reasoning
+    // message always has content, so this ordering is belt-and-braces).
+    if (_isThinkingMessage(messageIndex)) {
+      final groupKey = messageId.isNotEmpty ? messageId : 'idx_$messageIndex';
+      final agentType = _model.instanceData?['agent_type_name'] ??
+          widget.instanceData?['agent_type_name'];
+
+      return RepaintBoundary(
+        child: Container(
+          // A thinking card is always its own bordered box; own its gap on both
+          // sides like the collapsed tool-run and sub-agent branches.
+          margin: chatBlockMargin(
+            followsBorderedBlock: followsBorderedBlock,
+            precedesSubagentGroup: precedesSubagentGroup,
+            precedesBorderedBlock: precedesBorderedBlock,
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: custom_widgets.ThinkingGroup(
+                  content: content,
+                  expanded: _expandedThinkingCards.contains(groupKey),
+                  onBeforeToggle: () => _pinListItemPosition(messageIndex),
+                  onToggle: () {
+                    safeSetState(() {
+                      if (!_expandedThinkingCards.remove(groupKey)) {
+                        _expandedThinkingCards.add(groupKey);
+                      }
+                    });
+                  },
+                  agentTypeName: agentType,
+                  filterProjectRoot: _model.filterProjectRootFromContent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     // Only skip the message entirely when content is empty AND there is
     // neither an AskUserQuestion panel nor an image attachment to render.
     // Both live in message_metadata, so they can be present even when the
@@ -1569,6 +1618,17 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
   /// precomputed [_subagentGrouping] (see _rebuildMessageMetadataCache).
   bool _isSubagentMessage(int index) => _subagentGrouping.isSubagentMessage(index);
 
+  /// Whether message[index] is model reasoning tagged with
+  /// `message_metadata.thinking` — rendered as a standalone collapsed
+  /// "Thinking" card. Sub-agent-tagged reasoning is excluded (owned by the
+  /// sub-agent group, which renders its own children), so this stays a clean
+  /// "top-level thinking card" predicate everywhere it's used.
+  bool _isThinkingMessage(int index) {
+    if (index < 0 || index >= _model.messages.length) return false;
+    if (_isSubagentMessage(index)) return false;
+    return custom_widgets.isThinkingMessage(_model.messages[index]);
+  }
+
   /// Whether the block VISIBLE above [index] is a bordered block — a tool-use
   /// row, a collapsed tool-use run, or a sub-agent group. Those blocks own the
   /// [kChatBlockGap] beneath them, so the block below adds no top margin and
@@ -1584,6 +1644,9 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
   bool _followsBorderedBlock(int index) {
     for (int i = index; i >= 0; i--) {
       if (_isSubagentMessage(i)) return true;
+      // A thinking card is a bordered block too — it draws its box right at its
+      // own index, so the visible neighbour above is that box.
+      if (_isThinkingMessage(i)) return true;
       if (_rendersNothing(i)) continue;
       final m = _model.messages[i];
       final sender = m['sender_type']?.toString().toLowerCase() ?? '';
@@ -1642,6 +1705,8 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
     final next = _nextVisibleIndex(index);
     if (next == null) return false;
     if (_isSubagentRunStart(next)) return true;
+    // A thinking card below is bordered too (wide bordered-to-bordered gap).
+    if (_isThinkingMessage(next)) return true;
     final m = _model.messages[next];
     final sender = m['sender_type']?.toString().toLowerCase() ?? '';
     if (sender == 'user' || sender == 'human') return false;

--- a/apps/mobile/test/custom_code/widgets/thinking_group_test.dart
+++ b/apps/mobile/test/custom_code/widgets/thinking_group_test.dart
@@ -1,0 +1,61 @@
+// Spec for the model-reasoning ("thinking") card helpers
+// (`lib/custom_code/widgets/thinking_group.dart`). Covers the metadata reader
+// `isThinkingMessage` and the display-body normalizer `thinkingDisplayBody`.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vicoa/custom_code/widgets/thinking_group.dart';
+
+Map<String, dynamic> _thinkingMsg(String source, {String content = 'weighing options'}) => {
+      'sender_type': 'AGENT',
+      'content': content,
+      'message_metadata': {
+        'thinking': {'source': source},
+      },
+    };
+
+void main() {
+  group('isThinkingMessage', () {
+    test('true for a thinking-tagged message', () {
+      expect(isThinkingMessage(_thinkingMsg('claude')), isTrue);
+      expect(isThinkingMessage(_thinkingMsg('codex')), isTrue);
+    });
+
+    test('false without thinking metadata', () {
+      expect(isThinkingMessage({'content': 'hi', 'message_metadata': null}), isFalse);
+      expect(
+        isThinkingMessage({
+          'content': 'hi',
+          'message_metadata': {
+            'subagent': {'tool_use_id': 't'},
+          },
+        }),
+        isFalse,
+      );
+      expect(isThinkingMessage('not a map'), isFalse);
+      expect(
+        isThinkingMessage({
+          'message_metadata': {'thinking': 'not-a-map'},
+        }),
+        isFalse,
+      );
+    });
+  });
+
+  group('thinkingDisplayBody', () {
+    test('strips a leading Codex reasoning label', () {
+      expect(thinkingDisplayBody('Reasoning:\nconsidered A and B'), 'considered A and B');
+    });
+
+    test('strips a legacy emoji reasoning label', () {
+      expect(thinkingDisplayBody('🧠 Reasoning:\nconsidered A and B'), 'considered A and B');
+    });
+
+    test('leaves Claude-style plain reasoning untouched', () {
+      expect(thinkingDisplayBody('let me think about this'), 'let me think about this');
+    });
+
+    test('falls back to trimmed content when stripping empties it', () {
+      expect(thinkingDisplayBody('Reasoning:'), 'Reasoning:');
+    });
+  });
+}

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -26,6 +26,7 @@ import { MessageItem, resolveAgentType, DateSeparator, ThinkingIndicator, vibing
 import { ChatFindBar } from '@/components/dashboard/chat-find-bar';
 import { FindHighlightProvider } from '@/components/dashboard/chat-find-context';
 import { groupSubagents } from '@/components/dashboard/subagent-grouping';
+import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
 import { FilesGitPanel, FilesGitPanelToggle, usePanelState, type PanelPendingAction } from '@/components/files-git-panel';
 import { ChatInput, PermissionModeValue, OpencodeAgentModeValue, type ChatUploadedAttachment, type ChatInputHandle } from '@/components/chat-input';
 import { collectComposerDrop } from '@/lib/chat-drop';
@@ -1292,8 +1293,13 @@ function AgentInstanceContent() {
         // Interactive messages (AskUserQuestion, permission prompts) look like
         // tool uses but must render through MessageItem so their panels /
         // option buttons show — never fold them into a tool group.
+        // Reasoning rows render as their own collapsed "Thinking" card via
+        // MessageItem — never fold them into a tool-group (which would bypass
+        // that card and render them as a tool line).
         const isInteractive =
-          msg.requires_user_input || parseAskUserQuestionPayload(msg) !== null;
+          msg.requires_user_input ||
+          parseAskUserQuestionPayload(msg) !== null ||
+          parseThinkingPayload(msg) !== null;
         const isToolUse =
           !isInteractive &&
           !USER_SENDER_TYPES.has(msg.sender_type) &&

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -8,6 +8,7 @@ import { hasAnsiCodes, parseAnsiToHtml } from '@/components/ui/ansi-render';
 import { ToolUseLine, isToolUseContent } from '@/components/dashboard/tool-use-display';
 import { AskUserQuestionPanel, type AskUserQuestionSubmitPayload, parseAskUserQuestionPayload } from '@/components/dashboard/ask-user-question-panel';
 import { ChatAttachments, extractChatAttachments } from '@/components/chat-attachments';
+import { StandaloneThinkingCard, parseThinkingPayload } from '@/components/dashboard/thinking-card';
 import { CollapsibleUserMessage } from '@/components/dashboard/collapsible-user-message';
 import { stripPermissionModeCommandTokens } from '@/lib/session-control-messages';
 import { CONTROL_COMMAND_JSON_REGEX, isControlEnvelope } from '@/lib/control-messages';
@@ -105,6 +106,21 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
 
   const hasAnsi = isUser && hasAnsiCodes(userVisibleContent);
   const shouldUseMonospace = hasAnsi;
+
+  // Model reasoning (Claude ThinkingBlock / Codex reasoning) renders as a
+  // collapsed "Thinking" card instead of a plain agent bubble — same wrapper
+  // chrome as a tool-group line, works both top-level and (compact) nested in
+  // a SubagentGroup. Detected via message_metadata.thinking; agent-only.
+  const thinking = !isUser ? parseThinkingPayload(message) : null;
+  if (thinking) {
+    return (
+      <div className={compact ? 'flex justify-start' : 'flex justify-start mb-1'}>
+        <div className="rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono">
+          <StandaloneThinkingCard content={userVisibleContent} agentType={agentType} />
+        </div>
+      </div>
+    );
+  }
 
   // Shared bubble chrome, now applied to the image bubble and the text bubble
   // independently (they used to be one element).

--- a/apps/web/components/dashboard/thinking-card.test.ts
+++ b/apps/web/components/dashboard/thinking-card.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageResponse } from '@/lib/backend-api';
+import { parseThinkingPayload } from './thinking-card';
+
+const base: MessageResponse = {
+  id: 'x',
+  content: 'reasoning text',
+  sender_type: 'agent',
+  created_at: '2026-01-01T00:00:00.000Z',
+  requires_user_input: false,
+  message_metadata: null,
+};
+
+const withMetadata = (metadata: MessageResponse['message_metadata']): MessageResponse => ({
+  ...base,
+  message_metadata: metadata,
+});
+
+describe('parseThinkingPayload', () => {
+  it('reads a well-formed thinking payload', () => {
+    expect(parseThinkingPayload(withMetadata({ thinking: { source: 'claude' } }))).toEqual({
+      source: 'claude',
+    });
+    expect(parseThinkingPayload(withMetadata({ thinking: { source: 'codex' } }))).toEqual({
+      source: 'codex',
+    });
+  });
+
+  it('defaults source to empty string when missing/non-string', () => {
+    expect(parseThinkingPayload(withMetadata({ thinking: {} }))).toEqual({ source: '' });
+    expect(parseThinkingPayload(withMetadata({ thinking: { source: 42 } }))).toEqual({ source: '' });
+  });
+
+  it('returns null when there is no thinking metadata', () => {
+    expect(parseThinkingPayload(base)).toBeNull();
+    expect(parseThinkingPayload(withMetadata({ subagent: { tool_use_id: 't' } }))).toBeNull();
+    expect(parseThinkingPayload(withMetadata({ thinking: null } as never))).toBeNull();
+  });
+});

--- a/apps/web/components/dashboard/thinking-card.tsx
+++ b/apps/web/components/dashboard/thinking-card.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+import { Brain, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { MessageMarkdown } from '@/components/ui/message-markdown';
+import type { MessageResponse } from '@/lib/backend-api';
+
+/**
+ * A collapsed "Thinking" card for a model-reasoning message.
+ *
+ * The backend tags a reasoning row with
+ * `message_metadata.thinking = { source }` (see
+ * `integrations/headless/thinking.py`) — Claude `ThinkingBlock`s and Codex
+ * `reasoning` items both land here. The reasoning text rides in the row
+ * `content`; this card wraps it in a collapse (mirroring `SubagentGroup`'s
+ * chrome) so reasoning is available but never floods the transcript.
+ */
+
+// Kept structural (not imported from chat-message-item) to avoid a circular
+// import — chat-message-item imports this module.
+type UiAgentType = 'claude' | 'codex' | 'opencode';
+
+export interface ThinkingPayload {
+  source: string;
+}
+
+/** Read a message's `message_metadata.thinking` payload, or null when absent /
+    malformed. Mirrors `parseSubagentPayload` (subagent-grouping.ts). */
+export function parseThinkingPayload(message: MessageResponse): ThinkingPayload | null {
+  const metadata = message.message_metadata as Record<string, unknown> | null | undefined;
+  const raw = metadata?.thinking as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const source = typeof raw.source === 'string' ? raw.source : '';
+  return { source };
+}
+
+// Codex prefixes reasoning with a "Reasoning:" label (kept in `content` so
+// pre-card clients still show it inline). Inside the card the header already
+// says "Thinking", so strip the redundant prefix for display. The optional
+// "🧠 " covers older daemons that still emit the emoji label.
+function displayBody(content: string): string {
+  return content.replace(/^\s*(?:🧠\s*)?Reasoning:\s*\n?/, '').trim() || content;
+}
+
+/** Controlled collapse — expansion state owned by the caller. */
+export function ThinkingCard({
+  content,
+  agentType,
+  expanded,
+  onToggle,
+}: {
+  content: string;
+  agentType: UiAgentType;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const body = displayBody(content);
+  const preview = body.split('\n').find((line) => line.trim())?.trim() ?? '';
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="flex w-full min-w-0 items-center gap-1.5 rounded -mx-0.5 px-0.5 py-0.5 text-left cursor-pointer hover:bg-muted/40"
+      >
+        <Brain className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" aria-hidden="true" />
+        <span className="min-w-0 shrink-0 text-muted-foreground">Thinking</span>
+        {!expanded && preview && (
+          <span className="min-w-0 truncate italic text-muted-foreground/70" title={preview}>
+            {preview}
+          </span>
+        )}
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform',
+            expanded && 'rotate-90',
+          )}
+        />
+      </button>
+      {expanded && (
+        <div className="ml-1.5 mt-1.5 border-l border-border/40 pl-2.5 italic text-muted-foreground">
+          <div className="markdown-content">
+            <MessageMarkdown agentType={agentType}>{body}</MessageMarkdown>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Self-contained variant with local expansion state — for use in `MessageItem`,
+    which owns no page-level expansion set. Collapsed by default; a Virtuoso
+    recycle re-collapses (acceptable for secondary reasoning content, matching
+    `StandaloneToolUse`). */
+export function StandaloneThinkingCard({
+  content,
+  agentType,
+}: {
+  content: string;
+  agentType: UiAgentType;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <ThinkingCard
+      content={content}
+      agentType={agentType}
+      expanded={expanded}
+      onToggle={() => setExpanded((current) => !current)}
+    />
+  );
+}

--- a/backend/src/integrations/headless/acp_base.py
+++ b/backend/src/integrations/headless/acp_base.py
@@ -33,6 +33,7 @@ from integrations.headless.acp_client import (
     ACPMethodNotFound,
     ACPResponse,
 )
+from integrations.headless.thinking import build_thinking_metadata
 from integrations.headless.session_lifecycle import (
     WRAPPER_STOP_STATUSES,
     instance_update_requests_stop,
@@ -265,6 +266,11 @@ class ACPWrapperBase(ABC):
         # real cause to stderr (e.g. auth errors) then reach the user verbatim.
         self._turn_stderr: deque[str] = deque(maxlen=20)
         self._assistant_chunk_buffer: str = ""
+        # Model reasoning streamed on the ACP ``agent_thought_chunk`` channel.
+        # Accumulated separately from narration and flushed as its own collapsed
+        # "thinking" card (metadata-tagged) ahead of the answer — see
+        # ``_flush_thought_buffer``.
+        self._thought_chunk_buffer: str = ""
         self._assistant_chunk_first_update_at: float = 0.0
         self._assistant_chunk_last_update_at: float = 0.0
         self._assistant_chunk_flush_after_seconds: float = 1.0
@@ -1544,6 +1550,7 @@ class ACPWrapperBase(ABC):
         # status back to ACTIVE.
         self._awaiting_after_next_agent_output = False
         self._assistant_chunk_buffer = ""
+        self._thought_chunk_buffer = ""
         self._drop_stream_output_until_next_prompt = True
 
         try:
@@ -2124,7 +2131,13 @@ class ACPWrapperBase(ABC):
             self._turn_produced_output = True
 
         if update_type == "agent_thought_chunk":
-            # Hide internal model reasoning from user-facing UI.
+            # Model reasoning: accumulate and surface as a collapsed "thinking"
+            # card (flushed ahead of the answer), rather than hiding it or
+            # letting it flood the transcript as flat text.
+            content = update.get("content")
+            for text in self._extract_text_fragments_from_content_payload(content):
+                if text:
+                    self._thought_chunk_buffer += text
             return
 
         if update_type == "current_mode_update":
@@ -2213,7 +2226,7 @@ class ACPWrapperBase(ABC):
                 rendered = "\n\n".join(part for part in rendered_parts if part.strip())
                 signature = rendered.strip()
                 if signature and signature != self._last_tool_change_signature:
-                    self._append_assistant_chunk_block(rendered)
+                    self._emit_acp_tool_card(update, rendered)
                     self._last_tool_change_signature = signature
                 return
 
@@ -2240,9 +2253,8 @@ class ACPWrapperBase(ABC):
             ):
                 extracted_chunks.append(change_preview)
 
-            for chunk in extracted_chunks:
-                if chunk:
-                    self._append_assistant_chunk_block(chunk)
+            body = "\n\n".join(chunk for chunk in extracted_chunks if chunk)
+            self._emit_acp_tool_card(update, body)
 
             return
 
@@ -2377,8 +2389,14 @@ class ACPWrapperBase(ABC):
                 return str(value)
         return str(value)
 
-    def _forward_agent_text(self, text: str) -> None:
-        """Send assistant text output to Vicoa."""
+    def _forward_agent_text(
+        self, text: str, message_metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send assistant text output to Vicoa.
+
+        ``message_metadata`` rides through unchanged — used to tag a reasoning
+        message with ``thinking`` so clients render it as a collapsed card.
+        """
         if not text or not self.vicoa_client:
             return
         text = self._sanitize_agent_text(text)
@@ -2391,6 +2409,7 @@ class ACPWrapperBase(ABC):
                 agent_type=self.config.agent_type,
                 agent_instance_id=self.config.agent_instance_id,
                 requires_user_input=False,
+                message_metadata=message_metadata,
             )
 
             if response and hasattr(response, "message_id"):
@@ -2407,6 +2426,71 @@ class ACPWrapperBase(ABC):
             raise
         except Exception as e:
             self.log(f"[ERROR] Failed to send message to Vicoa: {e}")
+
+    #: ACP ``kind`` enum → a clean, hyphen-free tool name for the card header.
+    #: The name MUST stay hyphen-free: the clients' tool-name parser splits the
+    #: header on the first " - " (``tool-use-parsing.ts`` / ``_isToolUseMessage``),
+    #: so a hyphenated name (e.g. a path like ``pricing-cards.tsx``) would be
+    #: severed mid-filename. The (possibly hyphenated) title/path rides in the
+    #: arg slot after " - ", which the parser captures whole.
+    _ACP_KIND_TO_TOOL = {
+        "read": "Read",
+        "edit": "Edit",
+        "delete": "Delete",
+        "move": "Move",
+        "search": "Search",
+        "execute": "Execute",
+        "fetch": "Fetch",
+        "think": "Think",
+        "switch_mode": "Mode",
+    }
+
+    def _acp_tool_header(self, update: Dict[str, Any]) -> str:
+        """A "🔧 Using tool: <name>[ - `<detail>`]" header for a tool_call_update.
+
+        The web/mobile clients collapse any message whose content starts with
+        this prefix into a tool card, exactly as Claude/Codex tool calls render.
+        Crucially the NAME (before the first " - ") must not contain a hyphen,
+        or the client splits a filename mid-way — ACP agents put the file path
+        in ``title`` (e.g. ``apps/web/…/pricing-cards.tsx``), which is why the
+        name comes from the clean ``kind`` enum and the title/path goes in the
+        arg slot.
+        """
+        kind = str(update.get("kind") or "").strip().lower()
+        title = str(update.get("title") or "").strip()
+        name = self._ACP_KIND_TO_TOOL.get(kind)
+        detail = ""
+        if name:
+            detail = title or self._extract_tool_target_file(update)
+        elif title and "-" not in title and "*" not in title:
+            # Unknown kind, but a hyphen/asterisk-free title is safe as the name.
+            name = title
+        else:
+            # Unknown kind + a path-like/hyphenated title: keep the name generic
+            # so the client never severs a filename; show the title as the arg.
+            name = "Tool"
+            detail = title or self._extract_tool_target_file(update)
+        if detail:
+            return f"🔧 Using tool: {name} - `{detail}`"
+        return f"🔧 Using tool: {name}"
+
+    def _emit_acp_tool_card(self, update: Dict[str, Any], body: str) -> None:
+        """Send a tool_call_update's output as its own collapsed tool card.
+
+        Previously tool output was appended into the shared assistant-narration
+        buffer (``_append_assistant_chunk_block``), so raw results — file reads,
+        grep hits, "File not found", diffs — landed inline as flat text and
+        flooded the transcript. Instead we flush any pending reasoning + narration
+        (so this card is its own message and its content leads with the tool
+        prefix the clients detect), then forward a "Using tool:" card. The model's
+        own narration still streams as normal text; only tool *output* is carded.
+        """
+        body = (body or "").strip()
+        if not body:
+            return
+        self._flush_assistant_chunk_buffer()
+        header = self._acp_tool_header(update)
+        self._forward_agent_text(f"{header}\n{body}")
 
     def _set_agent_status(self, status: str) -> None:
         """Best-effort status update for current agent instance."""
@@ -2454,8 +2538,28 @@ class ACPWrapperBase(ABC):
             except Exception as e:
                 self.log(f"[ERROR] Failed to request user input: {e}")
 
+    def _flush_thought_buffer(self) -> None:
+        """Flush buffered model reasoning as a collapsed "thinking" card.
+
+        Sent ahead of the narration/answer (it's flushed at the top of
+        ``_flush_assistant_chunk_buffer`` and before every tool card), tagged
+        with ``message_metadata.thinking`` so clients render it collapsed. Runs
+        even when there is no narration this turn, so a reasoning-only turn still
+        surfaces its card.
+        """
+        text = self._thought_chunk_buffer.strip()
+        self._thought_chunk_buffer = ""
+        if not text:
+            return
+        self._forward_agent_text(
+            text, message_metadata=build_thinking_metadata(self.config.agent_type)
+        )
+
     def _flush_assistant_chunk_buffer(self) -> None:
         """Flush buffered assistant chunks as one user-visible message."""
+        # Any pending reasoning goes out first, so the thinking card precedes
+        # the answer it reasoned toward.
+        self._flush_thought_buffer()
         if not self._assistant_chunk_buffer:
             return
 

--- a/backend/src/integrations/headless/claude_code.py
+++ b/backend/src/integrations/headless/claude_code.py
@@ -60,6 +60,7 @@ from integrations.headless.permission import (
     format_dict_as_markdown as _format_dict_as_markdown,  # re-exported for tests
 )
 from integrations.headless.subagent import SubAgentTracker, build_metadata
+from integrations.headless.thinking import build_thinking_metadata
 
 try:
     from claude_agent_sdk import (
@@ -70,6 +71,7 @@ try:
         SystemMessage,
         ResultMessage,
         TextBlock,
+        ThinkingBlock,
         ToolUseBlock,
         ToolResultBlock,
         CLINotFoundError,
@@ -1269,6 +1271,27 @@ class HeadlessClaudeRunner:
         )
         return ""
 
+    @staticmethod
+    def _thinking_text(message) -> str:
+        """Concatenated text of every ``ThinkingBlock`` in an AssistantMessage.
+
+        ``format_message_content`` deliberately ignores ``ThinkingBlock`` (it
+        renders only text + tool-use), so the model's reasoning is surfaced
+        separately as its own metadata-tagged "thinking" card — see
+        ``integrations.headless.thinking``. Returns ``""`` when there is no
+        thinking to show, which is the common case on models that emit
+        ``display="omitted"`` thinking (Opus 4.7+ / Fable 5) where the block
+        carries a signature but no text.
+        """
+        if not isinstance(message, AssistantMessage):
+            return ""
+        parts = [
+            block.thinking
+            for block in message.content
+            if isinstance(block, ThinkingBlock) and getattr(block, "thinking", "")
+        ]
+        return "\n\n".join(p.strip() for p in parts if p and p.strip())
+
     def _remember_tasks_in_message(self, message) -> None:
         """Cache Task/Agent launch inputs so child messages can be labelled.
 
@@ -1768,6 +1791,27 @@ class HeadlessClaudeRunner:
                 )
             return
 
+        # Surface the model's reasoning as its own collapsed "thinking" card
+        # (metadata-tagged) BEFORE the turn's text/tool-use, matching the
+        # order the blocks arrive in. ``_thinking_text`` returns "" when
+        # there's nothing to show, so non-thinking turns POST nothing extra.
+        thinking_text = self._thinking_text(message)
+        if thinking_text:
+            self.logger.info("thinking card: emitting %d chars", len(thinking_text))
+            await self.send_to_vicoa(thinking_text, build_thinking_metadata("claude"))
+        elif isinstance(message, AssistantMessage) and any(
+            isinstance(b, ThinkingBlock) for b in message.content
+        ):
+            # Diagnostic: the model emitted a ThinkingBlock but its text is empty
+            # (display="omitted" on Opus 4.7+ / Fable 5), so there's no card to
+            # show. Distinguishes "model omitted thinking" from "no thinking at
+            # all" (thinking disabled / model didn't reason) when debugging why a
+            # session shows no Thinking card.
+            self.logger.info(
+                "thinking card: ThinkingBlock present but text empty "
+                "(model display=omitted); nothing to show"
+            )
+
         formatted_content = self.format_message_content(message)
         if formatted_content:
             await self.send_to_vicoa(formatted_content)
@@ -1832,11 +1876,25 @@ class HeadlessClaudeRunner:
         if isinstance(message, UserMessage):
             return True
 
+        subagent_type, description = self._subagent_tracker.label_for(parent_id)
+
+        # A sub-agent reasons too. Surface its thinking as a collapsed card
+        # that stays grouped under the sub-agent (both metadata keys present),
+        # emitted before the sub-agent's own text/tool-use for correct order.
+        thinking_text = self._thinking_text(message)
+        if thinking_text:
+            await self.send_to_vicoa(
+                thinking_text,
+                {
+                    **build_metadata(parent_id, subagent_type, description),
+                    **build_thinking_metadata("claude"),
+                },
+            )
+
         formatted = self.format_message_content(message)
         if not formatted:
             return True
 
-        subagent_type, description = self._subagent_tracker.label_for(parent_id)
         await self.send_to_vicoa(
             formatted, build_metadata(parent_id, subagent_type, description)
         )

--- a/backend/src/integrations/headless/codex/item_renderer.py
+++ b/backend/src/integrations/headless/codex/item_renderer.py
@@ -42,7 +42,12 @@ def _render_reasoning(item: Dict[str, Any]) -> Optional[str]:
     Prefer ``summary`` for the dashboard surface — it's the model's
     short-form rationale. Fall back to ``content`` if no summary is present.
     Return ``None`` (skip) when both are empty so we don't write empty
-    "🧠 Reasoning:\\n" rows.
+    "Reasoning:\\n" rows.
+
+    The row is tagged ``message_metadata.thinking`` upstream (see
+    ``codex_app_server._handle_item``) so clients render it as a collapsed
+    "Thinking" card with a lightbulb icon. The plain-text ``Reasoning:`` label
+    (no emoji) is only the pre-card fallback for older clients.
     """
     summary_parts = item.get("summary") or []
     content_parts = item.get("content") or []
@@ -52,7 +57,7 @@ def _render_reasoning(item: Dict[str, Any]) -> Optional[str]:
     body = "\n".join(p for p in parts if p)
     if not body:
         return None
-    return "🧠 Reasoning:\n" + body
+    return "Reasoning:\n" + body
 
 
 def _render_command_execution(item: Dict[str, Any]) -> str:

--- a/backend/src/integrations/headless/codex_app_server.py
+++ b/backend/src/integrations/headless/codex_app_server.py
@@ -36,6 +36,7 @@ from integrations.headless.codex.transport import (
     CodexTransportClosed,
 )
 from integrations.headless.permission import PermissionReplyRegistry
+from integrations.headless.thinking import build_thinking_metadata
 from integrations.headless.session_lifecycle import (
     WRAPPER_STOP_STATUSES as _WRAPPER_STOP_STATUSES,
 )
@@ -1061,11 +1062,18 @@ class CodexAppServerSession:
             item_type,
             len(content),
         )
+        # Reasoning items become a collapsed "thinking" card (metadata-tagged)
+        # instead of an inline reasoning bubble; the rendered text still rides
+        # in ``content`` so pre-card clients degrade to inline text.
+        message_metadata = (
+            build_thinking_metadata("codex") if item_type == "reasoning" else None
+        )
         try:
             await self.vicoa_client.send_message(
                 content=content,
                 agent_type=self.agent_type,
                 agent_instance_id=self.instance_id,
+                message_metadata=message_metadata,
             )
         except Exception:
             logger.exception(

--- a/backend/src/integrations/headless/tests/test_acp_base_protocol.py
+++ b/backend/src/integrations/headless/tests/test_acp_base_protocol.py
@@ -118,10 +118,15 @@ def _build_wrapper(
     wrapper._turn_stderr = deque(maxlen=20)
     wrapper._drop_stream_output_until_next_prompt = False
     wrapper._assistant_chunk_buffer = ""
+    wrapper._thought_chunk_buffer = ""
     wrapper._assistant_chunk_first_update_at = 0.0
     wrapper._assistant_chunk_last_update_at = 0.0
     wrapper._show_tool_updates = False
     wrapper._last_tool_change_signature = None
+    wrapper._tool_output_max_lines = 80
+    wrapper._tool_output_max_chars = 4000
+    wrapper._tool_output_preview_lines = 24
+    wrapper._tool_output_preview_chars = 1400
     return wrapper
 
 
@@ -882,6 +887,152 @@ def test_available_commands_update_is_retained() -> None:
     )
 
     assert wrapper.available_commands == [{"name": "plan", "description": "Plan"}]
+
+
+def test_tool_call_update_renders_as_collapsed_tool_card() -> None:
+    """A completed tool_call_update surfaces as its own "Using tool:" card
+    message (which web/mobile collapse), not glued inline into the narration
+    buffer — so raw tool output stops flooding the transcript as flat text."""
+    vc = MagicMock()
+    wrapper = _build_wrapper(vicoa_client=vc)
+    wrapper.session_id = _SESSION_ID
+    wrapper._show_tool_updates = False
+
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "status": "completed",
+                "kind": "read",
+                "title": "Read",
+                "content": [{"type": "text", "text": "Found 3 matches"}],
+            },
+        }
+    )
+
+    contents = [c for c in _feedback_texts(vc) if c]
+    cards = [c for c in contents if c.startswith("🔧 Using tool:")]
+    assert len(cards) == 1
+    assert "Read" in cards[0].splitlines()[0]
+    assert "Found 3 matches" in cards[0]
+    # Nothing was left glued into the narration buffer.
+    assert wrapper._assistant_chunk_buffer == ""
+
+
+def test_tool_card_flushes_pending_narration_first() -> None:
+    """Narration buffered before a tool result flushes as its own message so
+    the tool card leads with the "Using tool:" prefix the clients detect."""
+    vc = MagicMock()
+    wrapper = _build_wrapper(vicoa_client=vc)
+    wrapper.session_id = _SESSION_ID
+    wrapper._show_tool_updates = False
+
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Let me read the file."},
+            },
+        }
+    )
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "status": "completed",
+                "kind": "read",
+                "title": "Read",
+                "content": [{"type": "text", "text": "line 1"}],
+            },
+        }
+    )
+
+    contents = [c for c in _feedback_texts(vc) if c]
+    # Narration first (plain), then the tool card — two separate messages.
+    assert contents[0] == "Let me read the file."
+    assert contents[1].startswith("🔧 Using tool:")
+    assert "line 1" in contents[1]
+
+
+def test_tool_card_name_is_hyphen_safe_for_paths() -> None:
+    """ACP agents put the file path in ``title``; the card NAME must come from
+    the clean ``kind`` enum so a hyphenated filename (``pricing-cards.tsx``)
+    isn't severed by the clients' "<name> - <arg>" split."""
+    vc = MagicMock()
+    wrapper = _build_wrapper(vicoa_client=vc)
+    wrapper.session_id = _SESSION_ID
+    wrapper._show_tool_updates = False
+
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "status": "completed",
+                "kind": "read",
+                "title": "apps/web/components/billing/pricing-cards.tsx",
+                "content": [{"type": "text", "text": "file body"}],
+            },
+        }
+    )
+
+    card = next(c for c in _feedback_texts(vc) if c.startswith("🔧 Using tool:"))
+    first_line = card.splitlines()[0]
+    # The name segment (before the first " - ") is the clean kind — no hyphen,
+    # so the client can't sever the filename.
+    name_seg = first_line.split(" - ", 1)[0]
+    assert name_seg == "🔧 Using tool: Read"
+    # The full hyphenated path survives intact in the arg slot.
+    assert "pricing-cards.tsx" in first_line
+
+
+def _sent_calls(vc: MagicMock) -> list[tuple[str, object]]:
+    return [
+        (call.kwargs.get("content", ""), call.kwargs.get("message_metadata"))
+        for call in vc.send_message.call_args_list
+    ]
+
+
+def test_agent_thought_chunk_becomes_thinking_card() -> None:
+    """Model reasoning on the thought channel is surfaced as a metadata-tagged
+    thinking card, emitted BEFORE the answer it reasoned toward."""
+    vc = MagicMock()
+    wrapper = _build_wrapper(vicoa_client=vc)
+    wrapper.session_id = _SESSION_ID
+
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "weighing the options"},
+            },
+        }
+    )
+    wrapper._handle_session_update(
+        {
+            "sessionId": _SESSION_ID,
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Here is the answer."},
+            },
+        }
+    )
+    wrapper._flush_assistant_chunk_buffer()
+
+    calls = _sent_calls(vc)
+    tagged = [
+        content for content, md in calls if isinstance(md, dict) and "thinking" in md
+    ]
+    assert tagged == ["weighing the options"]
+    # The thinking card precedes the plain answer.
+    contents = [content for content, _ in calls]
+    assert contents.index("weighing the options") < contents.index(
+        "Here is the answer."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/integrations/headless/tests/test_codex_app_server.py
+++ b/backend/src/integrations/headless/tests/test_codex_app_server.py
@@ -1513,3 +1513,55 @@ async def test_interrupt_without_active_turn_settles_awaiting_input():
     assert vicoa_client.status_calls[-1]["status"] == "AWAITING_INPUT"
     # No turn to interrupt, so nothing should have gone out on the wire.
     assert not session_to_codex.requests_by_method["turn/interrupt"]
+
+
+# ---------------------------------------------------------------------------
+# Reasoning items surface as a collapsed "thinking" card: the rendered text
+# still rides in ``content`` (so pre-card clients degrade to inline text) but
+# ``message_metadata.thinking`` marks the row so clients wrap it collapsed.
+# ---------------------------------------------------------------------------
+
+
+def _idle_session() -> tuple[CodexAppServerSession, FakeAsyncVicoaClient]:
+    """A session wired to a fake vicoa client, with no turn started — enough
+    to exercise ``_handle_item`` directly."""
+    session_to_codex = FakeCodexPipe()
+    codex_to_session = FakeCodexPipe()
+    transport = CodexTransport(reader=codex_to_session, writer=session_to_codex)
+    vicoa_client = FakeAsyncVicoaClient()
+    session = CodexAppServerSession(
+        vicoa_client=vicoa_client,
+        instance_id="inst-thinking",
+        cwd="/tmp/codex-thinking-cwd",
+        transport=transport,
+    )
+    return session, vicoa_client
+
+
+async def test_reasoning_item_is_tagged_as_thinking():
+    session, vicoa_client = _idle_session()
+
+    await session._handle_item({"type": "reasoning", "summary": ["considered A and B"]})
+
+    assert len(vicoa_client.sent_messages) == 1
+    sent = vicoa_client.sent_messages[0]
+    assert sent["message_metadata"] == {"thinking": {"source": "codex"}}
+    # Rendered text still rides in content for pre-card clients.
+    assert "considered A and B" in sent["content"]
+
+
+async def test_agent_message_item_is_not_tagged_as_thinking():
+    session, vicoa_client = _idle_session()
+
+    await session._handle_item({"type": "agentMessage", "text": "hello there"})
+
+    assert len(vicoa_client.sent_messages) == 1
+    assert vicoa_client.sent_messages[0]["message_metadata"] is None
+
+
+async def test_empty_reasoning_item_is_dropped():
+    session, vicoa_client = _idle_session()
+
+    await session._handle_item({"type": "reasoning", "summary": [], "content": []})
+
+    assert vicoa_client.sent_messages == []

--- a/backend/src/integrations/headless/tests/test_codex_item_renderer.py
+++ b/backend/src/integrations/headless/tests/test_codex_item_renderer.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 from integrations.headless.codex.item_renderer import render_item
 
 
-def test_reasoning_item_uses_brain_prefix_with_summary():
+def test_reasoning_item_uses_reasoning_prefix_with_summary():
     # Per Codex 0.131.0 schema, reasoning carries `summary` and `content`
     # as string arrays — NOT a single `text` field (the plan was wrong).
-    # Renderer prefers summary as the short-form rationale.
+    # Renderer prefers summary as the short-form rationale. The row is tagged
+    # message_metadata.thinking upstream and rendered as a collapsed card; the
+    # plain-text "Reasoning:" label (no emoji) is only the pre-card fallback.
     out = render_item(
         {
             "type": "reasoning",
@@ -24,7 +26,8 @@ def test_reasoning_item_uses_brain_prefix_with_summary():
         }
     )
     assert out is not None
-    assert out.startswith("🧠 Reasoning:\n")
+    assert out.startswith("Reasoning:\n")
+    assert "🧠" not in out
     assert "considered options A and B" in out
     # Content not surfaced when summary is present (avoids spammy long
     # reasoning blobs in the chat surface).
@@ -41,7 +44,7 @@ def test_reasoning_item_falls_back_to_content_when_no_summary():
 
 
 def test_reasoning_item_with_no_summary_or_content_is_dropped():
-    # Empty reasoning items would render to bare "🧠 Reasoning:\n" — useless
+    # Empty reasoning items would render to bare "Reasoning:\n" — useless
     # noise in the chat surface. Drop them instead.
     assert render_item({"type": "reasoning"}) is None
     assert render_item({"type": "reasoning", "summary": [], "content": []}) is None

--- a/backend/src/integrations/headless/tests/test_thinking.py
+++ b/backend/src/integrations/headless/tests/test_thinking.py
@@ -1,0 +1,157 @@
+"""Tests for surfacing model reasoning as a collapsed "thinking" card.
+
+Covers the Claude headless path: ``_thinking_text`` extraction plus the
+main-stream and sub-agent emit paths that POST the reasoning as a
+metadata-tagged row (``message_metadata.thinking``) ahead of the turn's
+text/tool-use. The Codex reasoning path is covered in
+``test_codex_app_server.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from claude_agent_sdk import (
+    AssistantMessage,
+    TextBlock,
+    ThinkingBlock,
+)
+
+from integrations.headless.claude_code import HeadlessClaudeRunner
+from integrations.headless.thinking import build_thinking_metadata
+
+
+def _thinking(text: str) -> ThinkingBlock:
+    return ThinkingBlock(thinking=text, signature="sig")
+
+
+def _assistant(content, parent_tool_use_id=None) -> AssistantMessage:
+    return AssistantMessage(
+        content=content, model="claude-test", parent_tool_use_id=parent_tool_use_id
+    )
+
+
+# --- metadata contract -----------------------------------------------------
+
+
+def test_build_thinking_metadata_shape():
+    assert build_thinking_metadata("claude") == {"thinking": {"source": "claude"}}
+    assert build_thinking_metadata("codex") == {"thinking": {"source": "codex"}}
+
+
+# --- _thinking_text extraction ---------------------------------------------
+
+
+def test_thinking_text_extracts_thinking_before_text():
+    msg = _assistant([_thinking("weighing options"), TextBlock(text="the answer")])
+    assert HeadlessClaudeRunner._thinking_text(msg) == "weighing options"
+
+
+def test_thinking_text_joins_multiple_blocks():
+    msg = _assistant([_thinking("first"), _thinking("second")])
+    assert HeadlessClaudeRunner._thinking_text(msg) == "first\n\nsecond"
+
+
+def test_thinking_text_empty_without_thinking():
+    assert HeadlessClaudeRunner._thinking_text(_assistant([TextBlock(text="hi")])) == ""
+
+
+def test_thinking_text_empty_when_display_omitted():
+    # display="omitted" models (Opus 4.7+ / Fable 5) emit a signature-only
+    # block with empty ``thinking`` — nothing to show.
+    msg = _assistant([ThinkingBlock(thinking="", signature="sig")])
+    assert HeadlessClaudeRunner._thinking_text(msg) == ""
+
+
+# --- main-stream emit ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_main_stream_thinking_card_precedes_text(make_runner):
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore[assignment]
+
+    await runner._process_sdk_message(
+        _assistant([_thinking("let me think"), TextBlock(text="done")])
+    )
+
+    # Thinking card first (tagged), then the plain text.
+    assert sends[0] == ("let me think", {"thinking": {"source": "claude"}})
+    assert sends[1] == ("done", None)
+
+
+@pytest.mark.asyncio
+async def test_main_stream_no_card_without_thinking(make_runner):
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore[assignment]
+
+    await runner._process_sdk_message(_assistant([TextBlock(text="just text")]))
+
+    assert sends == [("just text", None)]
+
+
+# --- sub-agent emit --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subagent_thinking_card_is_tagged_with_both_keys(make_runner):
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore[assignment]
+    runner._subagent_tracker.remember_task("tu-1", "Explore", "map")
+
+    handled = await runner._maybe_handle_subagent_message(
+        _assistant(
+            [_thinking("sub reasoning"), TextBlock(text="found it")],
+            parent_tool_use_id="tu-1",
+        )
+    )
+
+    assert handled is True
+    # Thinking card carries BOTH subagent grouping and the thinking marker.
+    thinking_content, thinking_md = sends[0]
+    assert thinking_content == "sub reasoning"
+    assert thinking_md["thinking"] == {"source": "claude"}
+    assert thinking_md["subagent"]["tool_use_id"] == "tu-1"
+    assert thinking_md["subagent"]["subagent_type"] == "Explore"
+    # Then the sub-agent's own text, tagged with subagent only (no thinking).
+    text_content, text_md = sends[1]
+    assert text_content == "found it"
+    assert "thinking" not in text_md
+    assert text_md["subagent"]["tool_use_id"] == "tu-1"
+
+
+@pytest.mark.asyncio
+async def test_subagent_thinking_only_turn_still_surfaces(make_runner):
+    """A sub-agent turn that is thinking-only (no text/tool) still POSTs the
+    thinking card rather than being dropped as an empty child turn."""
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore[assignment]
+    runner._subagent_tracker.remember_task("tu-1", "Explore", "map")
+
+    handled = await runner._maybe_handle_subagent_message(
+        _assistant([_thinking("quietly reasoning")], parent_tool_use_id="tu-1")
+    )
+
+    assert handled is True
+    assert len(sends) == 1
+    assert sends[0][0] == "quietly reasoning"
+    assert sends[0][1]["thinking"] == {"source": "claude"}

--- a/backend/src/integrations/headless/thinking.py
+++ b/backend/src/integrations/headless/thinking.py
@@ -1,0 +1,34 @@
+"""Metadata contract for agent "thinking" / reasoning cards.
+
+Both Claude (the SDK's ``ThinkingBlock``) and Codex (a ``reasoning`` ThreadItem)
+surface the model's internal reasoning. Historically the two paths disagreed:
+the Claude headless path dropped thinking entirely (``format_message_content``
+has no ``ThinkingBlock`` branch), while Codex dumped it inline as a
+``🧠 Reasoning:`` agent bubble. Both now POST the reasoning as a normal
+``messages`` row whose ``message_metadata.thinking`` marks it so clients render
+a *collapsed* "Thinking" card instead of a plain agent message.
+
+Wire contract (mirrors ``subagent.build_metadata`` — structure in the metadata,
+text in the row ``content``):
+
+    message_metadata = {"thinking": {"source": "claude" | "codex"}}
+
+The reasoning text rides in the row ``content`` so clients that predate the
+card degrade gracefully to inline text (exactly the old Codex behaviour). The
+metadata is a structural *marker*, not a copy of the text — clients check for
+the key's presence and wrap ``content`` in a collapsed disclosure.
+"""
+
+from __future__ import annotations
+
+
+def build_thinking_metadata(source: str) -> dict:
+    """``message_metadata`` marking a row as an agent "thinking" card.
+
+    ``source`` is the producing agent (``"claude"`` / ``"codex"``) — purely
+    informational today; clients only test for the ``thinking`` key's presence.
+    """
+    return {"thinking": {"source": source}}
+
+
+__all__ = ["build_thinking_metadata"]


### PR DESCRIPTION
## What & why

Model reasoning was handled inconsistently across agents: **Claude dropped it**, **Codex dumped it inline** as a `🧠 Reasoning:` bubble, and **OpenCode/ACP hid it** while flooding the transcript with raw tool output as flat text. This unifies reasoning into a **collapsed "Thinking" card** and makes ACP tool output render as collapsible tool cards like Claude/Codex.

## Backend (headless runners)

- **New contract** `message_metadata.thinking` (`integrations/headless/thinking.py`): reasoning text rides in `content`, metadata marks the row so clients collapse it; pre-card clients degrade to inline text.
- **Claude** (`claude_code.py`): emit `ThinkingBlock` text as a thinking card on the main stream and inside sub-agents. Adds a diagnostic log distinguishing "empty/omitted thinking" (Opus 4.7+/Fable 5 emit no thinking text) from "no thinking at all".
- **Codex** (`codex_app_server.py` / `item_renderer.py`): tag `reasoning` items as thinking cards; drop the `🧠 Reasoning:` emoji label (clients supply the icon).
- **ACP** — opencode/cursor/gemini/copilot/kimi/hermes (`acp_base.py`):
  - `agent_thought_chunk` → collapsed thinking card (was hidden), flushed **before** the answer.
  - `tool_call_update` output → a `Using tool:` card (was flat text glued into the narration buffer).
  - **Fix:** hyphenated filenames (`pricing-cards.tsx`) were severed because the tool `title` (a path) was used as the tool *name* and the client splits `name - arg` on the first `-`. Now the name comes from the clean `kind` enum and the path rides in the arg slot.

## Web + mobile

- Collapsed **Thinking card** mirroring the sub-agent card, rendered from `message_metadata.thinking` (web: `Brain` icon; mobile: lightbulb — Flutter has no brain glyph).

## Testing

- Backend `make lint` clean; **497 headless tests pass** (new thinking, ACP tool-card/thought-chunk, and codex cases).
- Web: `tsc` 0 errors; parser tests added.
- Mobile: `flutter analyze` clean on changed files; helper tests added.

Verified live: OpenCode thinking cards render correctly. Claude thinking cards are wired but only appear when the model emits non-empty thinking text (newer models omit it — see the diagnostic log).

## Notes for reviewers

- The ACP change is in the **shared base** → affects all ACP agents; worth a sanity check on cursor/gemini.
- The model's own narration ("Let me read…") stays as normal text — it's regular output, not the thinking channel, and can't be cleanly separated from the answer.