### PR TITLE
feat: unify project identity — auto-create, archive, DB image icons (sidebar + Tasks + Settings)

### DIFF
--- a/apps/web/app/api/projects/[projectId]/icon/route.ts
+++ b/apps/web/app/api/projects/[projectId]/icon/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseToken } from '@/lib/auth/supabase-helpers';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Stream a project's icon bytes through cookie-authenticated Next.js, so plain
+ * <img src="/api/projects/{id}/icon"> tags work without the client ever holding
+ * the backend bearer token — mirrors /api/attachments/[attachmentId]. The
+ * backend URL (projects.icon_image_uri) is stable across replacements, so
+ * callers cache-bust with the project's updated_at (see lib/project-icons.ts).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const { projectId } = await params;
+    if (!UUID_PATTERN.test(projectId)) {
+      return NextResponse.json({ error: 'Invalid project id' }, { status: 400 });
+    }
+
+    const accessToken = await getSupabaseToken(true);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8000';
+    const response = await fetch(`${backendUrl}/api/v1/projects/${projectId}/icon`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok || !response.body) {
+      return NextResponse.json(
+        { error: `Backend responded with ${response.status}` },
+        { status: response.status }
+      );
+    }
+
+    return new NextResponse(response.body, {
+      status: 200,
+      headers: {
+        'Content-Type': response.headers.get('content-type') ?? 'application/octet-stream',
+        'Cache-Control': 'private, max-age=300',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (error) {
+    console.error('Project icon fetch failed:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/dashboard/dashboard-layout.tsx
+++ b/apps/web/app/dashboard/dashboard-layout.tsx
@@ -31,6 +31,7 @@ import {
   Flag,
   PanelLeft,
   Search,
+  Settings,
 } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { AgentDashboardProvider, useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
@@ -552,6 +553,8 @@ function DashboardSidebar({
       {/* User Menu at Bottom */}
         <div className="border-border p-1">
           {user ? (
+            <div className={cn('flex items-center', showSideBar ? 'gap-1' : 'flex-col')}>
+            <div className={cn(showSideBar && 'min-w-0 flex-1')}>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -667,6 +670,20 @@ function DashboardSidebar({
                 </div>
               </DropdownMenuContent>
             </DropdownMenu>
+            </div>
+            {/* Settings shortcut beside the avatar — straight to the page,
+                skipping the account menu (session ask). Expanded rail only. */}
+            {showSideBar && (
+              <Link
+                href="/dashboard/settings"
+                title="Settings"
+                aria-label="Settings"
+                className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <Settings className="h-4 w-4" />
+              </Link>
+            )}
+            </div>
           ) : (
             <div className="text-center p-2">
               <div className="text-sm text-muted-foreground">Not logged in</div>

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -4,20 +4,19 @@ import { useMemo, useState, useEffect, type FormEvent, Suspense } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useSWR, { useSWRConfig } from 'swr';
-import { Loader2, LogOut, Trash2, PlayCircle, Folder } from 'lucide-react';
+import { Loader2, LogOut, Trash2, PlayCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
-import { projectSettingsTargets } from '@/components/dashboard/session-grouping';
 import { WorktreeSetupSection } from '@/components/dashboard/worktree-setup-section';
 import { ProjectDisplaySection } from '@/components/dashboard/project-display-section';
+import { ProjectIcon } from '@/components/dashboard/task-ui';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
 import { createClient } from '@/lib/auth/supabase-client';
 import { isBuiltinAuth } from '@/lib/auth/auth-provider';
 import { signOutBrowser } from '@/lib/auth/sign-out';
-import { getBackendAPI } from '@/lib/backend-api';
+import { getBackendAPI, type ProjectResponse } from '@/lib/backend-api';
 import {
   Dialog,
   DialogContent,
@@ -67,8 +66,15 @@ function SettingsContent() {
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const { data: supabaseUser } = useSWR<SupabaseUser | null>('/api/supabase-user', fetcher);
-  const { recentInstances } = useAgentDashboard();
-  const projectTargets = useMemo(() => projectSettingsTargets(recentInstances), [recentInstances]);
+  // The Projects nav lists real DB projects (identity source of truth), not
+  // session-derived groups — so it works on web even without a live session.
+  const [dbProjects, setDbProjects] = useState<ProjectResponse[]>([]);
+  useEffect(() => {
+    getBackendAPI(true)
+      .listProjects()
+      .then((list) => setDbProjects(list.filter((p) => !p.is_inbox)))
+      .catch(() => setDbProjects([]));
+  }, []);
 
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -89,6 +95,7 @@ function SettingsContent() {
     return tabs.some((tab) => tab.id === tabFromParams) ? tabFromParams! : defaultTab;
   }, [searchParams]);
 
+  const projectId = searchParams.get('projectId') ?? '';
   const projectMachineId = searchParams.get('machineId') ?? '';
   const projectDir = searchParams.get('dir') ?? '';
   const projectLabel = searchParams.get('label') ?? '';
@@ -128,7 +135,8 @@ function SettingsContent() {
   const getNavHref = (tabId: string) => {
     const params = new URLSearchParams(searchParams.toString());
     // Drop the per-project params so a static tab never carries a stale
-    // machine/dir over from a project pane.
+    // project id / machine / dir over from a project pane.
+    params.delete('projectId');
     params.delete('machineId');
     params.delete('dir');
     params.delete('label');
@@ -141,10 +149,18 @@ function SettingsContent() {
     return `/dashboard/settings?${params.toString()}`;
   };
 
-  const getProjectHref = (machineId: string, dir: string, label: string) =>
-    `/dashboard/settings?tab=project&machineId=${encodeURIComponent(machineId)}&dir=${encodeURIComponent(
-      dir,
-    )}&label=${encodeURIComponent(label)}`;
+  const getProjectHref = (project: ProjectResponse) => {
+    // Prefer the first linked directory so the worktree-setup section (which is
+    // keyed by machine+dir) can render; Display works off project_id regardless.
+    const directory = project.directories[0];
+    const params = new URLSearchParams({ tab: 'project', projectId: project.id });
+    if (directory) {
+      params.set('machineId', directory.machine_id);
+      params.set('dir', directory.local_path);
+    }
+    params.set('label', project.name);
+    return `/dashboard/settings?${params.toString()}`;
+  };
 
 
   return (
@@ -179,21 +195,18 @@ function SettingsContent() {
                 </Link>
               ))}
             </div>
-            {projectTargets.length > 0 && (
+            {dbProjects.length > 0 && (
               <div>
                 <div className="px-2 pb-1.5 text-xs font-light text-muted-foreground/70">
                   Projects
                 </div>
                 <div className="rounded-xl border border-border/70 bg-card p-1">
-                  {projectTargets.map((target) => {
-                    const active =
-                      activeTab === 'project' &&
-                      projectMachineId === target.machineId &&
-                      projectDir === target.dir;
+                  {dbProjects.map((project) => {
+                    const active = activeTab === 'project' && projectId === project.id;
                     return (
                       <Link
-                        key={target.key}
-                        href={getProjectHref(target.machineId, target.dir, target.label)}
+                        key={project.id}
+                        href={getProjectHref(project)}
                         className={cn(
                           'flex items-center gap-2 rounded-lg px-4 py-2 text-sm transition-colors',
                           active
@@ -202,8 +215,8 @@ function SettingsContent() {
                         )}
                         scroll={false}
                       >
-                        <Folder className="h-3.5 w-3.5 shrink-0" />
-                        <span className="truncate">{target.label}</span>
+                        <ProjectIcon project={project} className="size-4" />
+                        <span className="truncate">{project.name}</span>
                       </Link>
                     );
                   })}
@@ -351,10 +364,18 @@ function SettingsContent() {
                   )}
                 </CardHeader>
                 <CardContent className="space-y-8">
-                  {projectMachineId && projectDir ? (
+                  {projectId || (projectMachineId && projectDir) ? (
                     <>
-                      <ProjectDisplaySection machineId={projectMachineId} dir={projectDir} />
-                      <WorktreeSetupSection machineId={projectMachineId} dir={projectDir} />
+                      <ProjectDisplaySection
+                        projectId={projectId || undefined}
+                        machineId={projectMachineId || undefined}
+                        dir={projectDir || undefined}
+                      />
+                      {/* Worktree setup is committed-repo config edited over a
+                          daemon RPC, so it needs a machine + directory. */}
+                      {projectMachineId && projectDir && (
+                        <WorktreeSetupSection machineId={projectMachineId} dir={projectDir} />
+                      )}
                     </>
                   ) : (
                     <div className="text-sm text-muted-foreground">

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
 import { projectSettingsTargets } from '@/components/dashboard/session-grouping';
 import { WorktreeSetupSection } from '@/components/dashboard/worktree-setup-section';
+import { ProjectDisplaySection } from '@/components/dashboard/project-display-section';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
@@ -349,9 +350,12 @@ function SettingsContent() {
                     <p className="truncate font-mono text-xs text-muted-foreground">{projectDir}</p>
                   )}
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-8">
                   {projectMachineId && projectDir ? (
-                    <WorktreeSetupSection machineId={projectMachineId} dir={projectDir} />
+                    <>
+                      <ProjectDisplaySection machineId={projectMachineId} dir={projectDir} />
+                      <WorktreeSetupSection machineId={projectMachineId} dir={projectDir} />
+                    </>
                   ) : (
                     <div className="text-sm text-muted-foreground">
                       Pick a project from the list to edit its settings.

--- a/apps/web/app/dashboard/tasks/page.tsx
+++ b/apps/web/app/dashboard/tasks/page.tsx
@@ -443,6 +443,26 @@ function TasksPageInner() {
           void refreshProjects();
         }
       },
+      uploadProjectIcon: async (projectId, file) => {
+        if (!api) return;
+        try {
+          await api.uploadProjectIcon(projectId, file);
+          await refreshProjects();
+        } catch (err) {
+          console.error('Failed to upload project icon:', err);
+          alert(err instanceof Error ? err.message : 'Failed to upload icon');
+        }
+      },
+      clearProjectIcon: async (projectId) => {
+        if (!api) return;
+        try {
+          await api.deleteProjectIcon(projectId);
+          await refreshProjects();
+        } catch (err) {
+          console.error('Failed to clear project icon:', err);
+          alert(err instanceof Error ? err.message : 'Failed to clear icon');
+        }
+      },
       // Confirmation lives in the settings dialog (ConfirmDeleteDialog), so
       // these two just delete.
       deleteProject: async (project) => {

--- a/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
+++ b/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
@@ -311,11 +311,15 @@ function ProjectRow({
   // Re-seed when the project is replaced by a server response.
   useEffect(() => setName(project.name), [project.name]);
 
-  // "Reset to default" drops any custom image AND emoji so the project falls
-  // back to the git-avatar seed (if the remote has one) or the generated square.
-  const resetIconToDefault = async () => {
+  // "Reset to default" → the generated square. The backend clears the image AND
+  // emoji and pins icon_source so it won't be re-seeded back into an image.
+  const resetIconToDefault = () => handlers.clearProjectIcon(project.id);
+
+  // Picking an emoji must win over a current image (render order is
+  // image → emoji), so drop the image first.
+  const setEmoji = async (emoji: string) => {
     if (project.icon_image_uri) await handlers.clearProjectIcon(project.id);
-    if (project.icon) await handlers.updateProject(project.id, { icon: null });
+    await handlers.updateProject(project.id, { icon: emoji });
   };
 
   const commitName = () => {
@@ -338,7 +342,7 @@ function ProjectRow({
           triggerClassName="size-7"
           iconClassName="size-5"
           onUploadImage={(file) => handlers.uploadProjectIcon(project.id, file)}
-          onSetEmoji={(emoji) => handlers.updateProject(project.id, { icon: emoji })}
+          onSetEmoji={setEmoji}
           onClearEmoji={() => handlers.updateProject(project.id, { icon: null })}
           onResetToDefault={resetIconToDefault}
         />

--- a/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
+++ b/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
@@ -6,16 +6,14 @@
 // shell, so putting workspace vocabulary there would mean maintaining two nav
 // surfaces for something you only ever reach from the board.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ChevronRight,
   Circle,
   FolderOpen,
-  ImagePlus,
   Loader2,
   MoreHorizontal,
   Plus,
-  RotateCcw,
   Settings,
   Trash2,
   X,
@@ -37,9 +35,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { EmojiPicker } from '@/components/ui/emoji-picker';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { DirectoryPickerPopover } from '@/components/dashboard/directory-picker-popover';
+import { ProjectIconEditor } from '@/components/dashboard/project-icon-editor';
 import { INLINE_LABEL_COLORS, LabelChip, ProjectIcon } from '@/components/dashboard/task-ui';
 import {
   MachineSummary,
@@ -309,38 +307,13 @@ function ProjectRow({
   onRequestDelete: () => void;
 }) {
   const [name, setName] = useState(project.name);
-  const [iconPickerOpen, setIconPickerOpen] = useState(false);
-  const [uploadingIcon, setUploadingIcon] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Re-seed when the project is replaced by a server response.
   useEffect(() => setName(project.name), [project.name]);
 
-  const onIconFilePicked = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    event.target.value = ''; // allow re-picking the same file
-    if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      alert('Please choose an image file.');
-      return;
-    }
-    if (file.size > 8 * 1024 * 1024) {
-      alert('Image must be under 8MB.');
-      return;
-    }
-    setIconPickerOpen(false);
-    setUploadingIcon(true);
-    try {
-      await handlers.uploadProjectIcon(project.id, file);
-    } finally {
-      setUploadingIcon(false);
-    }
-  };
-
   // "Reset to default" drops any custom image AND emoji so the project falls
   // back to the git-avatar seed (if the remote has one) or the generated square.
   const resetIconToDefault = async () => {
-    setIconPickerOpen(false);
     if (project.icon_image_uri) await handlers.clearProjectIcon(project.id);
     if (project.icon) await handlers.updateProject(project.id, { icon: null });
   };
@@ -360,63 +333,14 @@ function ProjectRow({
   return (
     <div className={cn('rounded-lg border', project.is_archived && 'opacity-60')}>
       <div className="flex items-center gap-2 px-2 py-1.5">
-        <Popover open={iconPickerOpen} onOpenChange={setIconPickerOpen}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              aria-label={`Icon for ${project.name}`}
-              className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-sm transition-colors hover:bg-accent"
-            >
-              {uploadingIcon ? (
-                <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-              ) : (
-                <ProjectIcon project={project} className="size-5" />
-              )}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-auto p-0">
-            <div className="flex items-center gap-1 border-b p-1.5">
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              >
-                <ImagePlus className="size-3.5" />
-                Upload image
-              </button>
-              {(project.icon_image_uri || project.icon) && (
-                <button
-                  type="button"
-                  onClick={() => void resetIconToDefault()}
-                  className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                >
-                  <RotateCcw className="size-3.5" />
-                  Reset to default
-                </button>
-              )}
-            </div>
-            <EmojiPicker
-              onSelect={(emoji) => {
-                setIconPickerOpen(false);
-                void handlers.updateProject(project.id, { icon: emoji });
-              }}
-              onClear={
-                project.icon
-                  ? () => {
-                      setIconPickerOpen(false);
-                      void handlers.updateProject(project.id, { icon: null });
-                    }
-                  : undefined
-              }
-            />
-          </PopoverContent>
-        </Popover>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*"
-          hidden
-          onChange={(e) => void onIconFilePicked(e)}
+        <ProjectIconEditor
+          project={project}
+          triggerClassName="size-7"
+          iconClassName="size-5"
+          onUploadImage={(file) => handlers.uploadProjectIcon(project.id, file)}
+          onSetEmoji={(emoji) => handlers.updateProject(project.id, { icon: emoji })}
+          onClearEmoji={() => handlers.updateProject(project.id, { icon: null })}
+          onResetToDefault={resetIconToDefault}
         />
 
         <input

--- a/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
+++ b/apps/web/app/dashboard/tasks/task-settings-dialog.tsx
@@ -6,14 +6,16 @@
 // shell, so putting workspace vocabulary there would mean maintaining two nav
 // surfaces for something you only ever reach from the board.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ChevronRight,
   Circle,
   FolderOpen,
+  ImagePlus,
   Loader2,
   MoreHorizontal,
   Plus,
+  RotateCcw,
   Settings,
   Trash2,
   X,
@@ -58,6 +60,10 @@ export interface TaskSettingsHandlers {
     projectId: string,
     patch: { name?: string; icon?: string | null; is_archived?: boolean },
   ) => Promise<void>;
+  /** Upload a custom image icon ('user' source — wins over the git seed). */
+  uploadProjectIcon: (projectId: string, file: File) => Promise<void>;
+  /** Clear the image icon → re-eligible for the git-avatar seed / generated default. */
+  clearProjectIcon: (projectId: string) => Promise<void>;
   deleteProject: (project: ProjectResponse) => Promise<void>;
   setProjectDirectory: (
     projectId: string,
@@ -166,7 +172,7 @@ export function TaskSettingsDialog({
       description={
         confirming?.kind === 'label'
           ? 'Are you sure you want to delete this label? It will be removed from every task that uses it. This action cannot be undone.'
-          : 'Are you sure you want to delete this project? Its tasks will be deleted with it. This action cannot be undone.'
+          : 'Deleting a project removes its tasks (this can’t be undone) — and if a session later runs in its folder, the project re-appears automatically. To hide it for good, use Archive instead.'
       }
       subject={
         confirming?.kind === 'label' ? (
@@ -304,9 +310,40 @@ function ProjectRow({
 }) {
   const [name, setName] = useState(project.name);
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const [uploadingIcon, setUploadingIcon] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Re-seed when the project is replaced by a server response.
   useEffect(() => setName(project.name), [project.name]);
+
+  const onIconFilePicked = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = ''; // allow re-picking the same file
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      alert('Please choose an image file.');
+      return;
+    }
+    if (file.size > 8 * 1024 * 1024) {
+      alert('Image must be under 8MB.');
+      return;
+    }
+    setIconPickerOpen(false);
+    setUploadingIcon(true);
+    try {
+      await handlers.uploadProjectIcon(project.id, file);
+    } finally {
+      setUploadingIcon(false);
+    }
+  };
+
+  // "Reset to default" drops any custom image AND emoji so the project falls
+  // back to the git-avatar seed (if the remote has one) or the generated square.
+  const resetIconToDefault = async () => {
+    setIconPickerOpen(false);
+    if (project.icon_image_uri) await handlers.clearProjectIcon(project.id);
+    if (project.icon) await handlers.updateProject(project.id, { icon: null });
+  };
 
   const commitName = () => {
     const trimmed = name.trim();
@@ -330,10 +367,34 @@ function ProjectRow({
               aria-label={`Icon for ${project.name}`}
               className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-sm transition-colors hover:bg-accent"
             >
-              <ProjectIcon project={project} />
+              {uploadingIcon ? (
+                <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+              ) : (
+                <ProjectIcon project={project} className="size-5" />
+              )}
             </button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-auto p-0">
+            <div className="flex items-center gap-1 border-b p-1.5">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <ImagePlus className="size-3.5" />
+                Upload image
+              </button>
+              {(project.icon_image_uri || project.icon) && (
+                <button
+                  type="button"
+                  onClick={() => void resetIconToDefault()}
+                  className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                >
+                  <RotateCcw className="size-3.5" />
+                  Reset to default
+                </button>
+              )}
+            </div>
             <EmojiPicker
               onSelect={(emoji) => {
                 setIconPickerOpen(false);
@@ -350,6 +411,13 @@ function ProjectRow({
             />
           </PopoverContent>
         </Popover>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => void onIconFilePicked(e)}
+        />
 
         <input
           value={name}

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -70,6 +70,7 @@ import { activeSettingsTab } from './desktop-settings-sidebar';
 import { ProvidersSettingsSection } from './providers-settings-section';
 import { MachinesSettingsSection } from './machines-settings-section';
 import { WorktreeSetupSection } from './worktree-setup-section';
+import { ProjectDisplaySection } from './project-display-section';
 import { useMobileSidebarHidden, setMobileSidebarHidden } from '@/lib/mobile-sidebar-pref';
 
 /**
@@ -96,6 +97,7 @@ export function DesktopSettings() {
             <MachinesSettingsSection />
           ) : tab === 'project' ? (
             <ProjectSection
+              projectId={searchParams.get('projectId') ?? ''}
               machineId={searchParams.get('machineId') ?? ''}
               dir={searchParams.get('dir') ?? ''}
               label={searchParams.get('label') ?? ''}
@@ -113,10 +115,12 @@ export function DesktopSettings() {
  *  sidebar project 3-dots → "Project settings" and the settings nav's Projects
  *  group; carries the repo's machineId + dir. */
 function ProjectSection({
+  projectId,
   machineId,
   dir,
   label,
 }: {
+  projectId: string;
   machineId: string;
   dir: string;
   label: string;
@@ -127,8 +131,15 @@ function ProjectSection({
         <SectionTitle>{label || 'Project settings'}</SectionTitle>
         {dir && <p className="mt-1 truncate text-xs text-muted-foreground">{dir}</p>}
       </div>
-      {machineId && dir ? (
-        <WorktreeSetupSection machineId={machineId} dir={dir} />
+      {projectId || (machineId && dir) ? (
+        <>
+          <ProjectDisplaySection
+            projectId={projectId || undefined}
+            machineId={machineId || undefined}
+            dir={dir || undefined}
+          />
+          {machineId && dir && <WorktreeSetupSection machineId={machineId} dir={dir} />}
+        </>
       ) : (
         <p className="text-sm text-muted-foreground">
           Pick a project from the list to edit its settings.

--- a/apps/web/components/dashboard/project-display-section.tsx
+++ b/apps/web/components/dashboard/project-display-section.tsx
@@ -11,6 +11,7 @@ import { Loader2 } from 'lucide-react';
 
 import { ProjectIconEditor } from '@/components/dashboard/project-icon-editor';
 import { getBackendAPI, type ProjectResponse } from '@/lib/backend-api';
+import { cn } from '@/lib/utils';
 
 /** True when `sessionPath` is `linkedPath` or nested under it (path boundary). */
 function pathAtOrUnder(sessionPath: string, linkedPath: string): boolean {
@@ -94,6 +95,8 @@ export function ProjectDisplaySection({
   }
 
   const api = getBackendAPI(true);
+  const isImage = Boolean(project.icon_image_uri);
+  const isEmoji = !isImage && Boolean(project.icon);
 
   const commitName = async () => {
     const trimmed = name.trim();
@@ -121,13 +124,18 @@ export function ProjectDisplaySection({
       <div className="flex items-center gap-3">
         <ProjectIconEditor
           project={project}
-          triggerClassName="size-12 border border-border"
-          iconClassName="size-8"
+          // Border only for a (transparent) emoji, so it reads as a framed box;
+          // an image or the generated square is already self-contained. Same
+          // height (h-9) as the name input beside it.
+          triggerClassName={cn('h-9 w-9', isEmoji && 'border border-border')}
+          iconClassName={isEmoji ? 'size-9 text-xl' : 'size-9'}
           onUploadImage={async (file) => {
             await api.uploadProjectIcon(project.id, file);
             await refresh();
           }}
           onSetEmoji={async (emoji) => {
+            // Emoji wins over a current image (render order image → emoji).
+            if (project.icon_image_uri) await api.deleteProjectIcon(project.id);
             await api.updateProject(project.id, { icon: emoji });
             await refresh();
           }}
@@ -136,8 +144,7 @@ export function ProjectDisplaySection({
             await refresh();
           }}
           onResetToDefault={async () => {
-            if (project.icon_image_uri) await api.deleteProjectIcon(project.id);
-            if (project.icon) await api.updateProject(project.id, { icon: null });
+            await api.deleteProjectIcon(project.id);
             await refresh();
           }}
         />
@@ -152,7 +159,7 @@ export function ProjectDisplaySection({
               e.currentTarget.blur();
             }
           }}
-          className="min-w-0 flex-1 rounded-md border bg-transparent px-2.5 py-1.5 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="h-9 min-w-0 flex-1 rounded-md border bg-transparent px-2.5 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Project name"
         />
       </div>

--- a/apps/web/components/dashboard/project-display-section.tsx
+++ b/apps/web/components/dashboard/project-display-section.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+// The "Display" block of /dashboard/settings' per-project pane: edit a project's
+// name + icon (image / emoji / generated) so the sidebar and Tasks board show the
+// same identity (project-identity-unification §5d). The pane is opened by
+// (machineId, dir); this resolves that to the DB project via its linked
+// directories, so the settings entry and the sidebar/Tasks share one identity.
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+import { ProjectIconEditor } from '@/components/dashboard/project-icon-editor';
+import { getBackendAPI, type ProjectResponse } from '@/lib/backend-api';
+
+/** True when `sessionPath` is `linkedPath` or nested under it (path boundary). */
+function pathAtOrUnder(sessionPath: string, linkedPath: string): boolean {
+  const base = linkedPath.replace(/\/+$/, '');
+  return sessionPath === base || sessionPath.startsWith(base + '/');
+}
+
+/** The project whose directory on `machineId` best matches `dir` (longest wins). */
+function resolveProject(
+  projects: ProjectResponse[],
+  machineId: string,
+  dir: string,
+): ProjectResponse | null {
+  let best: ProjectResponse | null = null;
+  let bestLen = -1;
+  for (const project of projects) {
+    for (const directory of project.directories) {
+      if (directory.machine_id !== machineId) continue;
+      const matches =
+        pathAtOrUnder(dir, directory.local_path) ||
+        pathAtOrUnder(directory.local_path, dir);
+      if (matches && directory.local_path.length > bestLen) {
+        best = project;
+        bestLen = directory.local_path.length;
+      }
+    }
+  }
+  return best;
+}
+
+export function ProjectDisplaySection({
+  machineId,
+  dir,
+}: {
+  machineId: string;
+  dir: string;
+}) {
+  // undefined = loading, null = no project linked to this directory yet.
+  const [project, setProject] = useState<ProjectResponse | null | undefined>(undefined);
+  const [name, setName] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      const projects = await getBackendAPI(true).listProjects(true);
+      const match = resolveProject(projects, machineId, dir);
+      setProject(match ?? null);
+      if (match) setName(match.name);
+    } catch {
+      setProject(null);
+    }
+  }, [machineId, dir]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (project === undefined) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading project…
+      </div>
+    );
+  }
+
+  if (project === null) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No project is linked to this folder yet. Start a session here and one is created
+        automatically — then its name and icon can be set.
+      </p>
+    );
+  }
+
+  const api = getBackendAPI(true);
+
+  const commitName = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === project.name) {
+      setName(project.name);
+      return;
+    }
+    try {
+      await api.updateProject(project.id, { name: trimmed });
+      await refresh();
+    } catch (err) {
+      console.error('Failed to rename project:', err);
+      setName(project.name);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium text-foreground">Display</p>
+        <p className="text-xs text-muted-foreground">
+          The name and icon shown in the sidebar and Tasks board.
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <ProjectIconEditor
+          project={project}
+          triggerClassName="size-12"
+          iconClassName="size-8"
+          onUploadImage={async (file) => {
+            await api.uploadProjectIcon(project.id, file);
+            await refresh();
+          }}
+          onSetEmoji={async (emoji) => {
+            await api.updateProject(project.id, { icon: emoji });
+            await refresh();
+          }}
+          onClearEmoji={async () => {
+            await api.updateProject(project.id, { icon: null });
+            await refresh();
+          }}
+          onResetToDefault={async () => {
+            if (project.icon_image_uri) await api.deleteProjectIcon(project.id);
+            if (project.icon) await api.updateProject(project.id, { icon: null });
+            await refresh();
+          }}
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => void commitName()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.currentTarget.blur();
+            if (e.key === 'Escape') {
+              setName(project.name);
+              e.currentTarget.blur();
+            }
+          }}
+          className="min-w-0 flex-1 rounded-md border bg-transparent px-2.5 py-1.5 text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Project name"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/project-display-section.tsx
+++ b/apps/web/components/dashboard/project-display-section.tsx
@@ -128,7 +128,9 @@ export function ProjectDisplaySection({
           // an image or the generated square is already self-contained. Same
           // height (h-9) as the name input beside it.
           triggerClassName={cn('h-9 w-9', isEmoji && 'border border-border')}
-          iconClassName={isEmoji ? 'size-9 text-xl' : 'size-9'}
+          // Larger shared radius on the big Display icon; sidebar/nav keep the
+          // small default. Emoji's frame radius comes from the trigger.
+          iconClassName={isEmoji ? 'size-9 text-xl' : 'size-9 rounded-md'}
           onUploadImage={async (file) => {
             await api.uploadProjectIcon(project.id, file);
             await refresh();

--- a/apps/web/components/dashboard/project-display-section.tsx
+++ b/apps/web/components/dashboard/project-display-section.tsx
@@ -42,11 +42,15 @@ function resolveProject(
 }
 
 export function ProjectDisplaySection({
+  projectId,
   machineId,
   dir,
 }: {
-  machineId: string;
-  dir: string;
+  /** Preferred: the DB project id (from the Projects nav). */
+  projectId?: string;
+  /** Legacy fallback (sidebar "Project settings" link): resolve by directory. */
+  machineId?: string;
+  dir?: string;
 }) {
   // undefined = loading, null = no project linked to this directory yet.
   const [project, setProject] = useState<ProjectResponse | null | undefined>(undefined);
@@ -55,13 +59,17 @@ export function ProjectDisplaySection({
   const refresh = useCallback(async () => {
     try {
       const projects = await getBackendAPI(true).listProjects(true);
-      const match = resolveProject(projects, machineId, dir);
+      const match = projectId
+        ? (projects.find((p) => p.id === projectId) ?? null)
+        : machineId && dir
+          ? resolveProject(projects, machineId, dir)
+          : null;
       setProject(match ?? null);
       if (match) setName(match.name);
     } catch {
       setProject(null);
     }
-  }, [machineId, dir]);
+  }, [projectId, machineId, dir]);
 
   useEffect(() => {
     void refresh();

--- a/apps/web/components/dashboard/project-display-section.tsx
+++ b/apps/web/components/dashboard/project-display-section.tsx
@@ -121,7 +121,7 @@ export function ProjectDisplaySection({
       <div className="flex items-center gap-3">
         <ProjectIconEditor
           project={project}
-          triggerClassName="size-12"
+          triggerClassName="size-12 border border-border"
           iconClassName="size-8"
           onUploadImage={async (file) => {
             await api.uploadProjectIcon(project.id, file);

--- a/apps/web/components/dashboard/project-icon-editor.tsx
+++ b/apps/web/components/dashboard/project-icon-editor.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+// Shared project-icon editor: a ProjectIcon trigger opening a popover with
+// "Upload image" / "Reset to default" and the emoji picker. Used by both the
+// Tasks settings dialog and the /dashboard/settings Project pane so the two
+// surfaces edit a project's identity identically (project-identity-unification
+// §5d). Purely controlled — the caller supplies the mutation callbacks.
+
+import { useRef, useState } from 'react';
+import { ImagePlus, Loader2, RotateCcw } from 'lucide-react';
+
+import { EmojiPicker } from '@/components/ui/emoji-picker';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ProjectIcon } from '@/components/dashboard/task-ui';
+import type { ProjectResponse } from '@/lib/backend-api';
+import { cn } from '@/lib/utils';
+
+type IconProject = Pick<
+  ProjectResponse,
+  'id' | 'name' | 'icon' | 'icon_image_uri' | 'updated_at' | 'is_inbox'
+>;
+
+const MAX_ICON_BYTES = 8 * 1024 * 1024;
+
+export function ProjectIconEditor({
+  project,
+  triggerClassName,
+  iconClassName,
+  onUploadImage,
+  onSetEmoji,
+  onClearEmoji,
+  onResetToDefault,
+}: {
+  project: IconProject;
+  /** Sizes the trigger button box (e.g. `size-7` compact, `size-14` large). */
+  triggerClassName?: string;
+  /** Sizes the icon/spinner inside the trigger. */
+  iconClassName?: string;
+  onUploadImage: (file: File) => Promise<void> | void;
+  onSetEmoji: (emoji: string) => Promise<void> | void;
+  onClearEmoji: () => Promise<void> | void;
+  /** Drop any custom image AND emoji → git-avatar seed / generated default. */
+  onResetToDefault: () => Promise<void> | void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const onFilePicked = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = ''; // allow re-picking the same file
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      alert('Please choose an image file.');
+      return;
+    }
+    if (file.size > MAX_ICON_BYTES) {
+      alert('Image must be under 8MB.');
+      return;
+    }
+    setOpen(false);
+    setUploading(true);
+    try {
+      await onUploadImage(file);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const hasCustomIcon = Boolean(project.icon_image_uri || project.icon);
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Icon for ${project.name ?? 'project'}`}
+            className={cn(
+              'flex shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-accent',
+              triggerClassName,
+            )}
+          >
+            {uploading ? (
+              <Loader2 className={cn('animate-spin text-muted-foreground', iconClassName)} />
+            ) : (
+              <ProjectIcon project={project} className={iconClassName} />
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-auto p-0">
+          <div className="flex items-center gap-1 border-b p-1.5">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ImagePlus className="size-3.5" />
+              Upload image
+            </button>
+            {hasCustomIcon && (
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  void onResetToDefault();
+                }}
+                className="flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <RotateCcw className="size-3.5" />
+                Reset to default
+              </button>
+            )}
+          </div>
+          <EmojiPicker
+            onSelect={(emoji) => {
+              setOpen(false);
+              void onSetEmoji(emoji);
+            }}
+            onClear={
+              project.icon
+                ? () => {
+                    setOpen(false);
+                    void onClearEmoji();
+                  }
+                : undefined
+            }
+          />
+        </PopoverContent>
+      </Popover>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={(e) => void onFilePicked(e)}
+      />
+    </>
+  );
+}

--- a/apps/web/components/dashboard/session-grouping.test.ts
+++ b/apps/web/components/dashboard/session-grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { AgentInstanceResponse } from '@/lib/backend-api';
+import type { AgentInstanceResponse, ProjectResponse } from '@/lib/backend-api';
 import {
   distinctAgentNames,
   distinctProjects,
@@ -29,6 +29,25 @@ const make = (over: Partial<AgentInstanceResponse>): AgentInstanceResponse => ({
   ...base,
   ...over,
 });
+
+const proj = (over: Partial<ProjectResponse> & { id: string }): ProjectResponse => ({
+  name: over.id,
+  git_remote_url: null,
+  color: null,
+  icon: null,
+  icon_image_uri: null,
+  icon_source: null,
+  is_inbox: false,
+  is_archived: false,
+  archived_at: null,
+  directories: [],
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...over,
+});
+
+const projectMap = (...ps: ProjectResponse[]) =>
+  new Map(ps.map((p) => [p.id, p]));
 
 describe('getLastPathPart', () => {
   it('returns the last segment, ignoring trailing slashes', () => {
@@ -126,20 +145,30 @@ describe('groupSessions project order', () => {
   });
 });
 
-describe('groupSessions hidden projects', () => {
-  it('hides deselected projects, keeps no-project sessions and pinned ones', () => {
-    const a = make({ id: 'a', project: '/x/alpha' });
-    const b = make({ id: 'b', project: '/x/beta' });
+describe('groupSessions archived projects', () => {
+  it('drops archived projects, keeps no-project sessions and pinned ones', () => {
+    const a = make({ id: 'a', project: '/x/alpha', project_id: 'PA' });
+    const b = make({ id: 'b', project: '/x/beta', project_id: 'PB' });
     const none = make({ id: 'n', project: null });
+    // Pinned sessions bypass filters (explicit "keep visible"), even if archived.
     const pinnedBeta = make({
       id: 'pinned-beta',
       project: '/x/beta',
+      project_id: 'PB',
       pinned_at: '2026-01-01T00:00:00.000Z',
     });
 
-    const groups = groupSessions([a, b, none, pinnedBeta], 'all', 'time', 'all', [], ['beta']);
+    const map = projectMap(proj({ id: 'PA' }), proj({ id: 'PB', is_archived: true }));
+    const groups = groupSessions([a, b, none, pinnedBeta], 'all', 'time', 'all', [], map);
     const ids = groups.flatMap((g) => g.instances.map((i) => i.id));
     expect(ids).toEqual(['pinned-beta', 'a', 'n']);
+  });
+
+  it('labels a project group with the DB name, not the path basename', () => {
+    const a = make({ id: 'a', project: '/home/me/alpha', project_id: 'PA' });
+    const map = projectMap(proj({ id: 'PA', name: 'Alpha Project' }));
+    const groups = groupSessions([a], 'all', 'project', 'all', [], map);
+    expect(groups.find((g) => g.key === 'PA')?.label).toBe('Alpha Project');
   });
 });
 
@@ -265,11 +294,12 @@ describe('groupSessions by project_id', () => {
     expect(p1?.label).toBe('vicoa'); // display stays the basename, not the id
   });
 
-  it('hides a linked project by its project_id key', () => {
+  it('drops an archived linked project by its project_id', () => {
     const a = make({ id: 'a', project: '/home/me/alpha', project_id: 'PA' });
     const b = make({ id: 'b', project: '/home/me/beta', project_id: 'PB' });
 
-    const groups = groupSessions([a, b], 'all', 'project', 'all', [], ['PA']);
+    const map = projectMap(proj({ id: 'PA', is_archived: true }), proj({ id: 'PB' }));
+    const groups = groupSessions([a, b], 'all', 'project', 'all', [], map);
     const ids = groups.flatMap((g) => g.instances.map((i) => i.id));
     expect(ids).toEqual(['b']);
   });

--- a/apps/web/components/dashboard/session-grouping.ts
+++ b/apps/web/components/dashboard/session-grouping.ts
@@ -1,4 +1,4 @@
-import type { AgentInstanceResponse } from '@/lib/backend-api';
+import type { AgentInstanceResponse, ProjectResponse } from '@/lib/backend-api';
 import { isManagedWorktreePath } from '@/lib/worktree-selection';
 
 /**
@@ -28,7 +28,6 @@ export const STATUS_FILTER_STORAGE_KEY = 'sidebar-status-filter';
 export const GROUP_BY_STORAGE_KEY = 'sidebar-group-by';
 export const AGENT_FILTER_STORAGE_KEY = 'sidebar-agent-filter';
 export const PROJECT_ORDER_STORAGE_KEY = 'sidebar-project-order';
-export const HIDDEN_PROJECTS_STORAGE_KEY = 'sidebar-hidden-projects';
 /** Desktop-only (see the divergence note above): sub-group projects by worktree. */
 export const DISPLAY_WORKTREE_STORAGE_KEY = 'sidebar-display-worktree';
 
@@ -51,10 +50,21 @@ export function projectGroupKey(instance: AgentInstanceResponse): string {
   return instance.project ? getLastPathPart(instance.project) : NO_PROJECT_KEY;
 }
 
-/** Human label for a project group — the path basename (never the raw id). */
-function projectDisplayName(instances: AgentInstanceResponse[]): string {
+/**
+ * Human label for a project group. Prefers the DB project's `name` when the
+ * group is a linked project (identity-unification §5a) so the sidebar and Tasks
+ * board show the same identity; falls back to the path basename for sessions
+ * with no linked project. Never the raw id.
+ */
+function projectDisplayName(
+  instances: AgentInstanceResponse[],
+  projectsById?: Map<string, ProjectResponse>,
+): string {
+  const key = projectGroupKey(instances[0]);
+  const dbName = projectsById?.get(key)?.name;
+  if (dbName) return dbName;
   const first = instances.find((i) => i.project);
-  return first?.project ? getLastPathPart(first.project) : projectGroupKey(instances[0]);
+  return first?.project ? getLastPathPart(first.project) : key;
 }
 
 /** Distinct project groups present in the list, as `{ key, label }` pairs. */
@@ -269,7 +279,7 @@ export function groupSessions(
   groupBy: GroupBy,
   agentFilter: string = 'all',
   projectOrder: string[] = [],
-  hiddenProjects: string[] = [],
+  projectsById?: Map<string, ProjectResponse>,
 ): SessionGroup[] {
   const sortedInstances = [...instances].sort((a, b) => {
     const aTime = new Date(a.latest_message_at || a.started_at).getTime();
@@ -298,15 +308,15 @@ export function groupSessions(
       ? statusVisible
       : statusVisible.filter((i) => i.agent_type_name === agentFilter);
 
-  // Deselected projects are hidden; sessions without a project always show.
-  // Hidden set holds group keys (project_id or basename), matching the menu.
-  const hidden = new Set(hiddenProjects);
+  // Archived projects drop out of the sidebar (cross-device declutter, §5b —
+  // replaces the old per-device localStorage hide). Sessions with no project, or
+  // whose project isn't loaded yet, always show.
   const visibleInstances =
-    hidden.size === 0
+    !projectsById || projectsById.size === 0
       ? agentVisible
       : agentVisible.filter((i) => {
-          const key = projectGroupKey(i);
-          return key === NO_PROJECT_KEY || !hidden.has(key);
+          const project = i.project_id ? projectsById.get(i.project_id) : undefined;
+          return !project?.is_archived;
         });
 
   let groups: SessionGroup[];
@@ -334,7 +344,10 @@ export function groupSessions(
       })
       .map(([key, groupInstances]) => ({
         key,
-        label: key !== NO_PROJECT_KEY ? projectDisplayName(groupInstances) : null,
+        label:
+          key !== NO_PROJECT_KEY
+            ? projectDisplayName(groupInstances, projectsById)
+            : null,
         instances: groupInstances,
       }));
   } else if (groupBy === 'time') {

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -42,7 +42,8 @@ import {
 } from '@/components/dashboard/session-actions-menu';
 import { NewSessionButton } from '@/components/dashboard/new-session-button';
 import { WorktreeSubGroupHeader } from '@/components/dashboard/worktree-sub-group-header';
-import type { AgentInstanceResponse } from '@/lib/backend-api';
+import type { AgentInstanceResponse, ProjectResponse } from '@/lib/backend-api';
+import { ProjectIcon } from '@/components/dashboard/task-ui';
 import {
   formatSidebarTime,
   getSessionTitle,
@@ -53,12 +54,10 @@ import {
   DEFAULT_STATUS_FILTER,
   DISPLAY_WORKTREE_STORAGE_KEY,
   distinctAgentNames,
-  distinctProjects,
   filterWantsActiveOnly,
   groupSessions,
   splitProjectByWorktree,
   GROUP_BY_STORAGE_KEY,
-  HIDDEN_PROJECTS_STORAGE_KEY,
   PROJECT_ORDER_STORAGE_KEY,
   STATUS_FILTER_OPTIONS,
   STATUS_FILTER_STORAGE_KEY,
@@ -318,10 +317,6 @@ export function SidebarSessions({
     if (Array.isArray(savedOrder) && savedOrder.every((k) => typeof k === 'string')) {
       setProjectOrder(savedOrder);
     }
-    const savedHidden = getPref<string[]>(HIDDEN_PROJECTS_STORAGE_KEY);
-    if (Array.isArray(savedHidden) && savedHidden.every((k) => typeof k === 'string')) {
-      setHiddenProjects(savedHidden);
-    }
     const savedWorktrees = getPref<boolean>(DISPLAY_WORKTREE_STORAGE_KEY);
     if (typeof savedWorktrees === 'boolean') setDisplayWorktrees(savedWorktrees);
     const filter = getPref<StatusFilter>(STATUS_FILTER_STORAGE_KEY) ?? DEFAULT_STATUS_FILTER;
@@ -350,22 +345,61 @@ export function SidebarSessions({
     setPref(DISPLAY_WORKTREE_STORAGE_KEY, value);
   }, []);
 
-  // Agent / project names present in the loaded list (submenu options).
+  // Agent names present in the loaded list (submenu options).
   const agentNames = useMemo(() => distinctAgentNames(recentInstances), [recentInstances]);
-  // `{ key, label }` per project group: key is the project_id (or basename
-  // fallback) used for hide/order, label is the display name.
-  const projects = useMemo(() => distinctProjects(recentInstances), [recentInstances]);
 
-  // Deselected projects (hidden from the list). Stored as the hidden set so
-  // newly appearing projects default to visible.
-  const [hiddenProjects, setHiddenProjects] = useState<string[]>([]);
-  const toggleProjectVisible = useCallback((key: string) => {
-    setHiddenProjects((prev) => {
-      const next = prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key];
-      setPref(HIDDEN_PROJECTS_STORAGE_KEY, next);
-      return next;
-    });
-  }, []);
+  // The DB projects, by id — the source of truth for a group's name, icon, and
+  // archived state (identity-unification §5a/§5b). Refetched when the set of
+  // linked project ids changes so an auto-created project's name/icon appears
+  // and a just-archived one drops out. Empty until it loads → grouping falls
+  // back to the path basename (unchanged legacy behavior).
+  const [projectsById, setProjectsById] = useState<Map<string, ProjectResponse>>(
+    () => new Map(),
+  );
+  const linkedProjectIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const instance of recentInstances) {
+      if (instance.project_id) ids.add(instance.project_id);
+    }
+    return Array.from(ids).sort().join(',');
+  }, [recentInstances]);
+  const refreshProjects = useCallback(() => {
+    if (!api) return;
+    // include_archived so the map carries the archived flag (grouping needs it
+    // to drop archived groups); an unknown/loading id defaults to visible.
+    api
+      .listProjects(true)
+      .then((list) => setProjectsById(new Map(list.map((p) => [p.id, p]))))
+      .catch(() => {
+        /* best-effort: grouping falls back to basenames until it loads */
+      });
+  }, [api]);
+  useEffect(() => {
+    refreshProjects();
+    // linkedProjectIds re-runs this when a session's project link appears/changes.
+  }, [refreshProjects, linkedProjectIds]);
+
+  // Archive a project → it (and its sessions) leave every device's sidebar
+  // (§5b). Optimistically drop it locally, then reconcile from the server.
+  const handleArchiveProject = useCallback(
+    async (projectId: string) => {
+      if (!api) return;
+      setProjectsById((prev) => {
+        const next = new Map(prev);
+        const project = next.get(projectId);
+        if (project) next.set(projectId, { ...project, is_archived: true });
+        return next;
+      });
+      try {
+        await api.updateProject(projectId, { is_archived: true });
+      } catch (err) {
+        console.error('Failed to archive project:', err);
+      } finally {
+        refreshProjects();
+      }
+    },
+    [api, refreshProjects],
+  );
 
   // Custom project order (drag-and-drop when grouped by project). Reordered
   // live during dragover, persisted on drag end.
@@ -375,8 +409,8 @@ export function SidebarSessions({
   // Worktree display is applied in a second pass (renderLayout) with live git
   // data, so grouping itself stays a pure function of the sessions.
   const sidebarGroups = useMemo(
-    () => groupSessions(recentInstances, statusFilter, groupBy, agentFilter, projectOrder, hiddenProjects),
-    [recentInstances, statusFilter, groupBy, agentFilter, projectOrder, hiddenProjects],
+    () => groupSessions(recentInstances, statusFilter, groupBy, agentFilter, projectOrder, projectsById),
+    [recentInstances, statusFilter, groupBy, agentFilter, projectOrder, projectsById],
   );
 
   // Bumped after a worktree is removed so the per-project git views refetch
@@ -994,26 +1028,6 @@ export function SidebarSessions({
                     />
                   ))}
                 </FilterSubRow>
-                {projects.length > 0 && (
-                  <FilterSubRow
-                    label="Project"
-                    value={
-                      hiddenProjects.length === 0
-                        ? 'All'
-                        : `${Math.max(projects.length - hiddenProjects.length, 0)}/${projects.length}`
-                    }
-                  >
-                    {projects.map(({ key, label }) => (
-                      <FilterOptionItem
-                        key={key}
-                        label={label}
-                        selected={!hiddenProjects.includes(key)}
-                        keepOpen
-                        onSelect={() => toggleProjectVisible(key)}
-                      />
-                    ))}
-                  </FilterSubRow>
-                )}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -1058,6 +1072,12 @@ export function SidebarSessions({
                         label ? `&label=${encodeURIComponent(label)}` : ''
                       }`
                     : null;
+                // The DB project this group maps to (only meaningful when
+                // grouping by project — time/status keys aren't project ids).
+                // Drives the leading icon and the Archive action.
+                const dbProject = groupBy === 'project' ? projectsById.get(key) : undefined;
+                const canArchiveProject =
+                  dbProject !== undefined && !dbProject.is_inbox && !dbProject.is_archived;
                 const projectHeader = label ? (
                   // Wrapper carries the drag handle and hover group so the
                   // collapse toggle, actions menu, and "+" can be sibling buttons
@@ -1083,9 +1103,18 @@ export function SidebarSessions({
                       type="button"
                       onClick={() => toggleGroupCollapsed(key)}
                       aria-expanded={!isGroupCollapsed}
-                      className="flex min-w-0 flex-1 items-center gap-1 text-left"
+                      className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
                     >
-                      <span className="text-xs font-light text-muted-foreground/70 truncate">
+                      {/* Project groups show the DB project's icon/image/emoji
+                          (or a generated square from the name); time/status
+                          groups have no project identity, so no icon (§5a). */}
+                      {groupBy === 'project' && (
+                        <ProjectIcon
+                          project={dbProject ?? { id: key, name: label, is_inbox: false }}
+                          className="size-4"
+                        />
+                      )}
+                      <span className="truncate text-[0.8rem] font-normal text-muted-foreground">
                         {label}
                       </span>
                       <ChevronRight
@@ -1095,7 +1124,7 @@ export function SidebarSessions({
                         )}
                       />
                     </button>
-                    {projectSettingsHref && (
+                    {(projectSettingsHref || canArchiveProject) && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <button
@@ -1108,13 +1137,24 @@ export function SidebarSessions({
                           </button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="font-mono">
-                          <DropdownMenuItem
-                            className="cursor-pointer gap-2 text-xs"
-                            onSelect={() => router.push(projectSettingsHref)}
-                          >
-                            <SlidersHorizontal className="h-3.5 w-3.5" />
-                            Project settings
-                          </DropdownMenuItem>
+                          {projectSettingsHref && (
+                            <DropdownMenuItem
+                              className="cursor-pointer gap-2 text-xs"
+                              onSelect={() => router.push(projectSettingsHref)}
+                            >
+                              <SlidersHorizontal className="h-3.5 w-3.5" />
+                              Project settings
+                            </DropdownMenuItem>
+                          )}
+                          {canArchiveProject && dbProject && (
+                            <DropdownMenuItem
+                              className="cursor-pointer gap-2 text-xs"
+                              onSelect={() => void handleArchiveProject(dbProject.id)}
+                            >
+                              <Archive className="h-3.5 w-3.5" />
+                              Archive project
+                            </DropdownMenuItem>
+                          )}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     )}

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -376,8 +376,19 @@ export function SidebarSessions({
   }, [api]);
   useEffect(() => {
     refreshProjects();
-    // linkedProjectIds re-runs this when a session's project link appears/changes.
-  }, [refreshProjects, linkedProjectIds]);
+    // Re-run when a session's project link appears/changes (linkedProjectIds)
+    // and when navigating back to a dashboard route (pathname) — so an icon/name
+    // edited in /dashboard/settings shows up without a hard refresh. The image
+    // <img src> is cache-busted by the project's updated_at, so a refetched row
+    // reloads the picture.
+  }, [refreshProjects, linkedProjectIds, pathname]);
+
+  // Also refresh when the window/tab regains focus (edited in another tab/window).
+  useEffect(() => {
+    const onFocus = () => refreshProjects();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [refreshProjects]);
 
   // Archive a project → it (and its sessions) leave every device's sidebar
   // (§5b). Optimistically drop it locally, then reconcile from the server.
@@ -1204,7 +1215,10 @@ export function SidebarSessions({
                         projectHeader
                       ))}
                     {!isGroupCollapsed && (
-                      <div className="space-y-0.5">
+                      // Indent sessions a step in from their group header so they
+                      // read as children, not siblings — matching the worktree
+                      // split's pl-2, whether or not worktree display is on.
+                      <div className={cn('space-y-0.5', !split && 'pl-2')}>
                         {!split
                           ? instances.map(renderSession)
                           : subs.map((rsub) => {

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -10,7 +10,7 @@ import {
   ChevronRight,
   Kanban,
   MoreHorizontal,
-  SlidersHorizontal,
+  Settings,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -1154,7 +1154,7 @@ export function SidebarSessions({
                               className="cursor-pointer gap-2 text-xs"
                               onSelect={() => router.push(projectSettingsHref)}
                             >
-                              <SlidersHorizontal className="h-3.5 w-3.5" />
+                              <Settings className="h-3.5 w-3.5" />
                               Project settings
                             </DropdownMenuItem>
                           )}
@@ -1206,7 +1206,7 @@ export function SidebarSessions({
                               className="cursor-pointer gap-2 text-xs"
                               onSelect={() => router.push(projectSettingsHref)}
                             >
-                              <SlidersHorizontal className="h-3.5 w-3.5" />
+                              <Settings className="h-3.5 w-3.5" />
                               Project settings
                             </ContextMenuItem>
                           </ContextMenuContent>

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -1059,25 +1059,26 @@ export function SidebarSessions({
                 const { isDraggableProject, split, newSessionDirectory, subs } = entry;
                 if (!split && instances.length === 0) return null;
                 const isGroupCollapsed = label !== null && collapsedGroups.has(key);
-                // "Project settings" opens the per-project pane in Settings
-                // (its worktree config is a committed `.vicoa/config.json`
-                // edited on the repo's machine), so it needs both a machine to
-                // route the file RPC and the repo's directory.
                 const projectMachineId = instances[0]?.machine_id ?? null;
-                const projectSettingsHref =
-                  projectMachineId && newSessionDirectory
-                    ? `/dashboard/settings?tab=project&machineId=${encodeURIComponent(
-                        projectMachineId,
-                      )}&dir=${encodeURIComponent(newSessionDirectory)}${
-                        label ? `&label=${encodeURIComponent(label)}` : ''
-                      }`
-                    : null;
                 // The DB project this group maps to (only meaningful when
                 // grouping by project — time/status keys aren't project ids).
-                // Drives the leading icon and the Archive action.
+                // Drives the leading icon, the Archive action, and the settings
+                // link's project identity.
                 const dbProject = groupBy === 'project' ? projectsById.get(key) : undefined;
                 const canArchiveProject =
                   dbProject !== undefined && !dbProject.is_inbox && !dbProject.is_archived;
+                // "Project settings" opens the per-project pane in Settings:
+                // Display (name/icon) keys off project_id; the worktree-config
+                // section needs a machine + repo dir to route its daemon RPC.
+                const projectSettingsHref = (() => {
+                  if (!dbProject && !(projectMachineId && newSessionDirectory)) return null;
+                  const params = new URLSearchParams({ tab: 'project' });
+                  if (dbProject) params.set('projectId', dbProject.id);
+                  if (projectMachineId) params.set('machineId', projectMachineId);
+                  if (newSessionDirectory) params.set('dir', newSessionDirectory);
+                  if (label) params.set('label', label);
+                  return `/dashboard/settings?${params.toString()}`;
+                })();
                 const projectHeader = label ? (
                   // Wrapper carries the drag handle and hover group so the
                   // collapse toggle, actions menu, and "+" can be sibling buttons

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -432,16 +432,16 @@ export function ProjectIcon({
   }
 
   // A real (non-Inbox) project with a name and no icon gets a generated square:
-  // a soft tint of the hashed palette color with the initial in that same color
-  // (a light, pastel feel rather than a hard saturated fill).
+  // a light tint of the hashed palette color with the initial in the theme's
+  // foreground color (a soft, pastel feel — not a hard saturated fill).
   if (project && !project.is_inbox && project.name) {
     const color = projectAvatarColor(project.id ?? project.name);
     return (
       <span
         aria-hidden="true"
-        style={{ backgroundColor: `${color}2b`, color }}
+        style={{ backgroundColor: `${color}1f` }}
         className={cn(
-          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-semibold leading-none',
+          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-semibold leading-none text-foreground/80',
           box,
         )}
       >

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -415,7 +415,7 @@ export function ProjectIcon({
         src={src}
         alt=""
         aria-hidden="true"
-        className={cn('rounded-[0.28em] object-cover', box)}
+        className={cn('rounded-md object-cover', box)}
       />
     );
   }
@@ -432,16 +432,17 @@ export function ProjectIcon({
   }
 
   // A real (non-Inbox) project with a name and no icon gets a generated square:
-  // a light tint of the hashed palette color with the initial in the theme's
-  // foreground color (a soft, pastel feel — not a hard saturated fill).
+  // a muted paseo-palette fill with a white initial (the palette is tuned for a
+  // white letter on top). Same rounded-md as the image variant so every icon
+  // shape shares one corner radius.
   if (project && !project.is_inbox && project.name) {
     const color = projectAvatarColor(project.id ?? project.name);
     return (
       <span
         aria-hidden="true"
-        style={{ backgroundColor: `${color}1f` }}
+        style={{ backgroundColor: color }}
         className={cn(
-          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-semibold leading-none text-foreground/80',
+          'inline-flex items-center justify-center rounded-md text-[10px] font-semibold leading-none text-white',
           box,
         )}
       >

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -415,7 +415,9 @@ export function ProjectIcon({
         src={src}
         alt=""
         aria-hidden="true"
-        className={cn('rounded-md object-cover', box)}
+        // Small default radius for sidebar/nav sizes; the Display pane overrides
+        // it (via className) to a larger, shared radius on its big icon.
+        className={cn('rounded-[3px] object-cover', box)}
       />
     );
   }
@@ -433,8 +435,8 @@ export function ProjectIcon({
 
   // A real (non-Inbox) project with a name and no icon gets a generated square:
   // a muted paseo-palette fill with a white initial (the palette is tuned for a
-  // white letter on top). Same rounded-md as the image variant so every icon
-  // shape shares one corner radius.
+  // white letter on top). Small default radius, matching the image variant;
+  // the Display pane overrides it to a larger shared radius on its big icon.
   if (project && !project.is_inbox && project.name) {
     const color = projectAvatarColor(project.id ?? project.name);
     return (
@@ -442,7 +444,7 @@ export function ProjectIcon({
         aria-hidden="true"
         style={{ backgroundColor: color }}
         className={cn(
-          'inline-flex items-center justify-center rounded-md text-[10px] font-semibold leading-none text-white',
+          'inline-flex items-center justify-center rounded-[3px] text-[10px] font-semibold leading-none text-white',
           box,
         )}
       >

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -431,14 +431,17 @@ export function ProjectIcon({
     );
   }
 
-  // A real (non-Inbox) project with a name and no icon gets a generated square.
+  // A real (non-Inbox) project with a name and no icon gets a generated square:
+  // a soft tint of the hashed palette color with the initial in that same color
+  // (a light, pastel feel rather than a hard saturated fill).
   if (project && !project.is_inbox && project.name) {
+    const color = projectAvatarColor(project.id ?? project.name);
     return (
       <span
         aria-hidden="true"
-        style={{ backgroundColor: projectAvatarColor(project.id ?? project.name) }}
+        style={{ backgroundColor: `${color}2b`, color }}
         className={cn(
-          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-medium leading-none text-white',
+          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-semibold leading-none',
           box,
         )}
       >

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -56,6 +56,7 @@ import {
   TaskStatus,
   UpdateTaskRequest,
 } from '@/lib/backend-api';
+import { projectAvatarColor, projectIconSrc, projectInitial } from '@/lib/project-icons';
 import { cn } from '@/lib/utils';
 import { pointerWithin, closestCenter, type CollisionDetection } from '@dnd-kit/core';
 
@@ -379,33 +380,75 @@ export function PriorityIcon({
  * default emoji: 📁/📥 read as a *chosen* icon and sat oddly next to the line
  * icons on the neighbouring pills (status, priority, dates).
  */
+/**
+ * A project's icon, rendering the full fallback chain (identity-unification
+ * §5d): uploaded/seeded image → emoji `icon` → a generated initial-square
+ * (paseo-style hashed color + first letter) → Inbox/Folder glyph when there's no
+ * name to seed one. `className` sizes the box (default `size-3.5`); the image and
+ * square fill it, so a larger box just needs a bigger `size-*`.
+ */
 export function ProjectIcon({
   project,
   className,
 }: {
-  project?: Pick<ProjectResponse, 'icon' | 'is_inbox'> | null;
+  project?: {
+    id?: string;
+    name?: string | null;
+    icon?: string | null;
+    icon_image_uri?: string | null;
+    updated_at?: string;
+    is_inbox?: boolean;
+  } | null;
   className?: string;
 }) {
-  if (!project?.icon) {
-    const Icon = project?.is_inbox ? Inbox : Folder;
+  const box = cn('size-3.5 shrink-0', className);
+
+  const src = project && project.id ? projectIconSrc({
+    id: project.id,
+    icon_image_uri: project.icon_image_uri,
+    updated_at: project.updated_at,
+  }) : null;
+  if (src) {
+    // eslint-disable-next-line @next/next/no-img-element -- authed proxy stream, not a static asset
     return (
-      <Icon
+      <img
+        src={src}
+        alt=""
         aria-hidden="true"
-        className={cn('size-3.5 shrink-0 text-muted-foreground', className)}
+        className={cn('rounded-[0.28em] object-cover', box)}
       />
     );
   }
-  return (
-    <span
-      aria-hidden="true"
-      className={cn(
-        'inline-flex size-3.5 shrink-0 items-center justify-center text-xs leading-none',
-        className,
-      )}
-    >
-      {project.icon}
-    </span>
-  );
+
+  if (project?.icon) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn('inline-flex items-center justify-center text-xs leading-none', box)}
+      >
+        {project.icon}
+      </span>
+    );
+  }
+
+  // A real (non-Inbox) project with a name and no icon gets a generated square.
+  if (project && !project.is_inbox && project.name) {
+    return (
+      <span
+        aria-hidden="true"
+        style={{ backgroundColor: projectAvatarColor(project.id ?? project.name) }}
+        className={cn(
+          'inline-flex items-center justify-center rounded-[0.28em] text-[10px] font-medium leading-none text-white',
+          box,
+        )}
+      >
+        {projectInitial(project.name)}
+      </span>
+    );
+  }
+
+  const Icon = project?.is_inbox ? Inbox : Folder;
+  return <Icon aria-hidden="true" className={cn('text-muted-foreground', box)} />;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -1159,7 +1159,8 @@ class BackendAPI {
     return response.json();
   }
 
-  /** Clear a project's image icon → falls back to emoji/generated (re-seedable). */
+  /** Reset a project's icon to the generated default: clears the image AND emoji
+   *  and pins it so the git seed won't re-add an image. */
   async deleteProjectIcon(projectId: string): Promise<ProjectResponse> {
     return this.request<ProjectResponse>(`/api/v1/projects/${projectId}/icon`, {
       method: 'DELETE',

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -346,6 +346,15 @@ export interface ProjectResponse {
   git_remote_url: string | null;
   color: string | null;
   icon: string | null;
+  /**
+   * Served URL for an uploaded/seeded image icon, or null. Rendered via the
+   * same-origin proxy (see lib/project-icons.ts `projectIconSrc`) since an
+   * <img> can't carry the backend bearer. Fallback chain when null: emoji
+   * `icon` → generated initial-square.
+   */
+  icon_image_uri: string | null;
+  /** Who set the image: 'user' (upload, wins) | 'git' (seeded) | null. */
+  icon_source: string | null;
   /** The per-user "No project" bucket; not archivable or deletable. */
   is_inbox: boolean;
   is_archived: boolean;
@@ -1123,6 +1132,37 @@ class BackendAPI {
     return this.request<ProjectResponse>(`/api/v1/projects/${projectId}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
+    });
+  }
+
+  /** Upload a project's image icon (multipart). Sets icon_source='user'. */
+  async uploadProjectIcon(projectId: string, file: File | Blob): Promise<ProjectResponse> {
+    const headers = await this.getHeaders();
+    // Let the browser set the multipart boundary; a fixed JSON type breaks it.
+    delete headers['Content-Type'];
+    const form = new FormData();
+    form.append('file', file);
+    const response = await fetch(
+      `${this.config.baseUrl}/api/v1/projects/${projectId}/icon`,
+      { method: 'PUT', headers, body: form },
+    );
+    if (!response.ok) {
+      let message = `Backend API error: ${response.status} ${response.statusText}`;
+      try {
+        const body = await response.json();
+        if (typeof body?.detail === 'string' && body.detail.trim()) message = body.detail;
+      } catch {
+        // fall back to the generic HTTP error
+      }
+      throw Object.assign(new Error(message), { status: response.status });
+    }
+    return response.json();
+  }
+
+  /** Clear a project's image icon → falls back to emoji/generated (re-seedable). */
+  async deleteProjectIcon(projectId: string): Promise<ProjectResponse> {
+    return this.request<ProjectResponse>(`/api/v1/projects/${projectId}/icon`, {
+      method: 'DELETE',
     });
   }
 

--- a/apps/web/lib/project-icons.ts
+++ b/apps/web/lib/project-icons.ts
@@ -1,0 +1,58 @@
+import type { ProjectResponse } from './backend-api';
+
+/**
+ * Project image-icon helpers (project-identity-unification §5d).
+ *
+ * The DB stores a backend-relative `icon_image_uri`, but an <img> can't send the
+ * backend bearer, so the web renders through its own same-origin, cookie-authed
+ * proxy (`/api/projects/{id}/icon`, mirroring attachments). The served bytes sit
+ * behind a stable URL, so we cache-bust with the project's `updated_at`.
+ */
+
+type IconProject = Pick<ProjectResponse, 'id'> & {
+  icon_image_uri?: string | null;
+  updated_at?: string;
+};
+
+/** <img src> for a project's uploaded/seeded image, or null (→ emoji/generated). */
+export function projectIconSrc(project: IconProject | null | undefined): string | null {
+  if (!project?.icon_image_uri) return null;
+  const version = project.updated_at ? `?v=${encodeURIComponent(project.updated_at)}` : '';
+  return `/api/projects/${project.id}/icon${version}`;
+}
+
+// Generated fallback — a paseo-style initial-square: a stable hash of the
+// project's identity picks one of a fixed, theme-friendly palette. Deterministic
+// so a project keeps the same color across sessions and devices.
+export const PROJECT_AVATAR_PALETTE = [
+  '#ef4444', // red
+  '#f97316', // orange
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#14b8a6', // teal
+  '#3b82f6', // blue
+  '#6366f1', // indigo
+  '#a855f7', // purple
+  '#ec4899', // pink
+  '#64748b', // slate
+] as const;
+
+function hashString(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0; // 32-bit
+  }
+  return Math.abs(hash);
+}
+
+/** Deterministic palette color for a project (seeded by id, then name). */
+export function projectAvatarColor(seed: string): string {
+  return PROJECT_AVATAR_PALETTE[hashString(seed) % PROJECT_AVATAR_PALETTE.length];
+}
+
+/** First visible character of a name, uppercased (a project's generated initial). */
+export function projectInitial(name: string | null | undefined): string {
+  const trimmed = (name ?? '').trim();
+  return trimmed ? Array.from(trimmed)[0].toUpperCase() : '·';
+}

--- a/apps/web/lib/project-icons.ts
+++ b/apps/web/lib/project-icons.ts
@@ -21,29 +21,32 @@ export function projectIconSrc(project: IconProject | null | undefined): string 
   return `/api/projects/${project.id}/icon${version}`;
 }
 
-// Generated fallback — a paseo-style initial-square: a stable hash of the
-// project's identity picks one of a fixed, theme-friendly palette. Deterministic
-// so a project keeps the same color across sessions and devices.
+// Generated fallback — an initial-square filled with one of a fixed palette,
+// picked by a stable hash of the project's identity. The palette is paseo's
+// `IDENTITY_COLORS` (packages/app/src/styles/identity-colors.ts): muted,
+// low-chroma tones tuned to one 4.2–4.8:1 contrast band against a white letter,
+// so the color *identifies* a project without shouting. Deterministic → a
+// project keeps its color across sessions and devices.
 export const PROJECT_AVATAR_PALETTE = [
-  '#ef4444', // red
-  '#f97316', // orange
-  '#eab308', // yellow
-  '#22c55e', // green
-  '#14b8a6', // teal
-  '#3b82f6', // blue
-  '#6366f1', // indigo
-  '#a855f7', // purple
-  '#ec4899', // pink
-  '#64748b', // slate
+  '#7a6aa8', // violet
+  '#3d7ea6', // sky
+  '#388068', // emerald
+  '#a4673a', // orange
+  '#b05c80', // pink
+  '#6a70b8', // indigo
+  '#368080', // teal
+  '#b06260', // red
+  '#8f7838', // amber
+  '#5179b0', // blue
 ] as const;
 
+// paseo's hashIdentityKey (hash*31 + charCode, unsigned) so the mapping matches.
 function hashString(seed: string): number {
   let hash = 0;
-  for (let i = 0; i < seed.length; i++) {
-    hash = (hash << 5) - hash + seed.charCodeAt(i);
-    hash |= 0; // 32-bit
+  for (const character of seed) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
   }
-  return Math.abs(hash);
+  return hash;
 }
 
 /** Deterministic palette color for a project (seeded by id, then name). */

--- a/backend/src/backend/api/tasks.py
+++ b/backend/src/backend/api/tasks.py
@@ -79,6 +79,8 @@ def list_projects_endpoint(
             and project.git_remote_url
             and project.icon_source is None
             and not project.icon_image_uri
+            # An emoji is an explicit choice — never overwrite it with a git seed.
+            and not project.icon
         ):
             background_tasks.add_task(project_icons.seed_project_icon, project.id)
     return [ProjectResponse.model_validate(p) for p in projects]
@@ -282,7 +284,8 @@ def delete_project_icon_endpoint(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> ProjectResponse:
-    """Clear the image icon → falls back to emoji/generated; re-eligible for seed."""
+    """Reset the icon to the generated default (drops the image AND emoji, and
+    pins icon_source so the git seed does not re-add an image)."""
     project = task_queries.get_accessible_project(db, current_user.id, project_id)
     if project is None:
         raise HTTPException(
@@ -292,11 +295,9 @@ def delete_project_icon_endpoint(
         try:
             storage.delete_object(storage.project_icon_key(str(project_id)))
         except Exception:
-            # Orphaned S3 object is harmless; never fail the clear on it.
+            # Orphaned S3 object is harmless; never fail the reset on it.
             logger.warning("project icon S3 delete failed for %s", project_id)
-    updated = task_queries.set_project_icon(
-        db, current_user.id, project_id, icon_image_uri=None, icon_source=None
-    )
+    updated = task_queries.reset_project_icon(db, current_user.id, project_id)
     assert updated is not None
     return ProjectResponse.model_validate(updated)
 

--- a/backend/src/backend/api/tasks.py
+++ b/backend/src/backend/api/tasks.py
@@ -4,13 +4,26 @@ Human-authored task tracker: issue-style tasks grouped by project. Distinct
 from agent sessions — the Kanban tab is sessions; this is the human backlog.
 """
 
+import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
+from shared import project_icons, storage
 from shared.database.models import User
 from shared.database.session import get_db
+from shared.images import InvalidImageError, process_image
 
 from ..auth.dependencies import get_current_user
 from ..db import task_queries
@@ -38,16 +51,36 @@ from ..models import (
     UpdateTaskRequest,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["tasks"])
+
+# Bounds the request body for an icon upload; decode memory is bounded
+# separately by shared.images.MAX_PIXELS.
+MAX_ICON_UPLOAD_BYTES = 8 * 1024 * 1024
+# The raster types process_image emits — served inline; anything else is a bug.
+_INLINE_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
 
 @router.get("/projects", response_model=list[ProjectResponse])
 def list_projects_endpoint(
+    background_tasks: BackgroundTasks,
     include_archived: bool = False,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[ProjectResponse]:
     projects = task_queries.list_projects(db, current_user.id, include_archived)
+    # Lazy, best-effort default-icon seed (§4e): first fetch of a git-backed
+    # project with no icon set kicks off a background owner-avatar seed. The
+    # task re-checks eligibility, so duplicate enqueues are harmless.
+    for project in projects:
+        if (
+            not project.is_inbox
+            and project.git_remote_url
+            and project.icon_source is None
+            and not project.icon_image_uri
+        ):
+            background_tasks.add_task(project_icons.seed_project_icon, project.id)
     return [ProjectResponse.model_validate(p) for p in projects]
 
 
@@ -161,6 +194,111 @@ def delete_project_directory_endpoint(
             status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
         )
     return ProjectResponse.model_validate(project)
+
+
+@router.put("/projects/{project_id}/icon", response_model=ProjectResponse)
+def upload_project_icon_endpoint(
+    project_id: UUID,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ProjectResponse:
+    """Set a project's image icon from an upload (§4d). 'user' beats a git seed."""
+    project = task_queries.get_accessible_project(db, current_user.id, project_id)
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+        )
+
+    raw = file.file.read(MAX_ICON_UPLOAD_BYTES + 1)
+    if len(raw) > MAX_ICON_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Image exceeds {MAX_ICON_UPLOAD_BYTES // (1024 * 1024)}MB limit",
+        )
+    if not raw:
+        raise HTTPException(status_code=400, detail="File is empty")
+    try:
+        processed = process_image(raw)
+    except InvalidImageError as exc:
+        raise HTTPException(
+            status_code=400, detail="Not a valid image in a supported format"
+        ) from exc
+
+    key = storage.project_icon_key(str(project_id))
+    try:
+        storage.upload_attachment(key, processed.data, processed.mime_type)
+    except Exception as exc:
+        logger.exception("project icon upload to S3 failed")
+        raise HTTPException(status_code=502, detail="Failed to store image") from exc
+
+    updated = task_queries.set_project_icon(
+        db,
+        current_user.id,
+        project_id,
+        icon_image_uri=project_icons.icon_served_url(project_id),
+        icon_source="user",
+    )
+    assert updated is not None  # access re-checked above under the same session
+    return ProjectResponse.model_validate(updated)
+
+
+@router.get("/projects/{project_id}/icon")
+def get_project_icon_endpoint(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Serve a project's icon bytes (uploaded or git-seeded)."""
+    project = task_queries.get_accessible_project(db, current_user.id, project_id)
+    if project is None or not project.icon_image_uri:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project icon not found"
+        )
+    try:
+        data, content_type = storage.download_object(
+            storage.project_icon_key(str(project_id))
+        )
+    except Exception as exc:
+        logger.exception("project icon download from S3 failed")
+        raise HTTPException(status_code=502, detail="Failed to fetch image") from exc
+    if content_type not in _INLINE_IMAGE_TYPES:
+        content_type = "application/octet-stream"
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={
+            # Short-lived: the URL is stable across replacements, so clients
+            # cache-bust with the project's updated_at instead of relying on this.
+            "Cache-Control": "private, max-age=300",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.delete("/projects/{project_id}/icon", response_model=ProjectResponse)
+def delete_project_icon_endpoint(
+    project_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ProjectResponse:
+    """Clear the image icon → falls back to emoji/generated; re-eligible for seed."""
+    project = task_queries.get_accessible_project(db, current_user.id, project_id)
+    if project is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+        )
+    if project.icon_image_uri:
+        try:
+            storage.delete_object(storage.project_icon_key(str(project_id)))
+        except Exception:
+            # Orphaned S3 object is harmless; never fail the clear on it.
+            logger.warning("project icon S3 delete failed for %s", project_id)
+    updated = task_queries.set_project_icon(
+        db, current_user.id, project_id, icon_image_uri=None, icon_source=None
+    )
+    assert updated is not None
+    return ProjectResponse.model_validate(updated)
 
 
 @router.get("/task-labels", response_model=list[TaskLabelResponse])

--- a/backend/src/backend/db/task_queries.py
+++ b/backend/src/backend/db/task_queries.py
@@ -4,12 +4,15 @@ All queries are user-scoped. The Inbox project is the per-user "No project"
 bucket: lazily created, never archivable or deletable.
 """
 
-from datetime import datetime, timezone
+import logging
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from shared.database import (
+    AgentInstance,
     Machine,
     Project,
     ProjectDirectory,
@@ -18,6 +21,17 @@ from shared.database import (
     get_or_create_inbox,
 )
 from shared.database.project_matching import backfill_project_id_for_directory
+
+logger = logging.getLogger(__name__)
+
+# A project with no session activity for this long — and no open tasks —
+# auto-archives (project-identity-unification §4b), the counterweight to
+# auto-create. A new session revives it instantly via the §4a self-heal rule.
+STALE_PROJECT_DAYS = 30
+
+# Tasks in these terminal states don't count as "open work" keeping a project
+# alive for auto-archive purposes.
+_CLOSED_TASK_STATUSES = ("done", "cancelled")
 
 
 class InboxImmutableError(Exception):
@@ -47,21 +61,92 @@ class ParentTaskError(Exception):
         self.not_found = not_found
 
 
+def _latest_activity_subquery(db: Session, user_id: UUID):
+    """Newest session start per project, for recency ordering / staleness."""
+    return (
+        db.query(
+            AgentInstance.project_id.label("pid"),
+            func.max(AgentInstance.started_at).label("last_at"),
+        )
+        .filter(AgentInstance.user_id == user_id)
+        .group_by(AgentInstance.project_id)
+        .subquery()
+    )
+
+
+def autoarchive_stale_projects(
+    db: Session, user_id: UUID, days: int = STALE_PROJECT_DAYS
+) -> int:
+    """Archive non-Inbox projects idle for ``days`` with no open tasks (§4b).
+
+    The counterweight to auto-create: touching a repo mints a project, so
+    long-untouched ones fall out of the way on their own. Conservative —
+    requires the project itself to predate the cutoff, its newest session (if
+    any) to predate it, and no open tasks — and fully reversible via the §4a
+    self-heal (a new session un-archives). Returns how many were archived.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days)
+    latest = _latest_activity_subquery(db, user_id)
+    open_task_projects = (
+        select(Task.project_id)
+        .where(
+            Task.user_id == user_id,
+            Task.status.notin_(_CLOSED_TASK_STATUSES),
+        )
+        .distinct()
+    )
+    stale = (
+        db.query(Project)
+        .outerjoin(latest, latest.c.pid == Project.id)
+        .filter(
+            Project.user_id == user_id,
+            Project.is_inbox.is_(False),
+            Project.is_archived.is_(False),
+            Project.created_at < cutoff,
+            or_(latest.c.last_at.is_(None), latest.c.last_at < cutoff),
+            Project.id.notin_(open_task_projects),
+        )
+        .all()
+    )
+    for project in stale:
+        project.is_archived = True
+        project.archived_at = now
+    if stale:
+        db.commit()
+        logger.info(
+            "auto-archived %d stale project(s) for user %s", len(stale), user_id
+        )
+    return len(stale)
+
+
 def list_projects(
     db: Session, user_id: UUID, include_archived: bool = False
 ) -> list[Project]:
-    """All the user's projects, Inbox first then by name.
+    """All the user's projects: Inbox first, then most-recent activity, then name.
 
-    Lazily creates the Inbox so clients always have the "No project" bucket
-    to group by.
+    Lazily creates the Inbox so clients always have the "No project" bucket to
+    group by, and opportunistically auto-archives stale projects on the default
+    (non-archived) fetch so the counterweight to auto-create needs no scheduler.
     """
     get_or_create_inbox(db, user_id)
     db.commit()
+    if not include_archived:
+        autoarchive_stale_projects(db, user_id)
 
-    query = db.query(Project).filter(Project.user_id == user_id)
+    latest = _latest_activity_subquery(db, user_id)
+    query = (
+        db.query(Project)
+        .outerjoin(latest, latest.c.pid == Project.id)
+        .filter(Project.user_id == user_id)
+    )
     if not include_archived:
         query = query.filter(Project.is_archived.is_(False))
-    return query.order_by(Project.is_inbox.desc(), Project.name.asc()).all()
+    return query.order_by(
+        Project.is_inbox.desc(),
+        latest.c.last_at.desc().nullslast(),
+        Project.name.asc(),
+    ).all()
 
 
 def create_project(
@@ -90,6 +175,38 @@ def _get_project(db: Session, user_id: UUID, project_id: UUID) -> Project | None
         .filter(Project.id == project_id, Project.user_id == user_id)
         .first()
     )
+
+
+def get_accessible_project(
+    db: Session, user_id: UUID, project_id: UUID
+) -> Project | None:
+    """The single project-access predicate (plan §9 constraint 3).
+
+    Every project-scoped read that isn't already a list — today just icon
+    serving/upload — routes through here so swapping single-owner scoping for
+    team membership later is one function, not dozens of call sites. Currently:
+    the project exists and belongs to ``user_id``.
+    """
+    return _get_project(db, user_id, project_id)
+
+
+def set_project_icon(
+    db: Session,
+    user_id: UUID,
+    project_id: UUID,
+    *,
+    icon_image_uri: str | None,
+    icon_source: str | None,
+) -> Project | None:
+    """Point a project at an uploaded/seeded icon (or clear it). None if foreign."""
+    project = _get_project(db, user_id, project_id)
+    if project is None:
+        return None
+    project.icon_image_uri = icon_image_uri
+    project.icon_source = icon_source
+    db.commit()
+    db.refresh(project)
+    return project
 
 
 def update_project(

--- a/backend/src/backend/db/task_queries.py
+++ b/backend/src/backend/db/task_queries.py
@@ -209,6 +209,23 @@ def set_project_icon(
     return project
 
 
+def reset_project_icon(db: Session, user_id: UUID, project_id: UUID) -> Project | None:
+    """Reset to the generated default: drop the image AND emoji, and pin
+    ``icon_source='user'`` so the git-avatar seed does NOT re-add an image on the
+    next fetch. Renders as the generated initial-square. None if foreign."""
+    project = _get_project(db, user_id, project_id)
+    if project is None:
+        return None
+    project.icon_image_uri = None
+    project.icon = None
+    # Sentinel: an explicit user reset. NULL would make the project seed-eligible
+    # again, which is exactly the "reset keeps turning back into the image" bug.
+    project.icon_source = "user"
+    db.commit()
+    db.refresh(project)
+    return project
+
+
 def update_project(
     db: Session, user_id: UUID, project_id: UUID, fields: dict
 ) -> Project | None:

--- a/backend/src/backend/db/task_queries.py
+++ b/backend/src/backend/db/task_queries.py
@@ -126,13 +126,13 @@ def list_projects(
     """All the user's projects: Inbox first, then most-recent activity, then name.
 
     Lazily creates the Inbox so clients always have the "No project" bucket to
-    group by, and opportunistically auto-archives stale projects on the default
-    (non-archived) fetch so the counterweight to auto-create needs no scheduler.
+    group by, and opportunistically auto-archives stale projects (on every fetch,
+    including the sidebar's include_archived read) so the counterweight to
+    auto-create needs no scheduler.
     """
     get_or_create_inbox(db, user_id)
     db.commit()
-    if not include_archived:
-        autoarchive_stale_projects(db, user_id)
+    autoarchive_stale_projects(db, user_id)
 
     latest = _latest_activity_subquery(db, user_id)
     query = (

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -608,6 +608,10 @@ class ProjectResponse(BaseModel):
     git_remote_url: str | None = None
     color: str | None = None
     icon: str | None = None
+    # Served image-icon URL + who set it ('user' | 'git' | None). Clients render
+    # the fallback chain icon_image_uri → emoji icon/color → generated default.
+    icon_image_uri: str | None = None
+    icon_source: str | None = None
     is_inbox: bool
     is_archived: bool
     archived_at: datetime | None = None

--- a/backend/src/backend/tests/test_project_icons.py
+++ b/backend/src/backend/tests/test_project_icons.py
@@ -170,6 +170,25 @@ class TestGitSeed:
         assert refreshed.icon_source == "user"
         assert refreshed.icon_image_uri == "/api/v1/projects/x/icon"
 
+    def test_seed_never_clobbers_emoji(
+        self, test_db, test_user, fake_icon_storage, monkeypatch
+    ):
+        # An emoji is an explicit choice — a git remote must not overwrite it.
+        project = self._make_project(
+            test_db,
+            test_user.id,
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            icon="🚀",
+        )
+        monkeypatch.setattr(
+            icons.httpx, "Client", lambda *a, **k: _FakeClient(_png_bytes())
+        )
+        icons.seed_project_icon(project.id)
+        test_db.expire_all()
+        refreshed = test_db.get(Project, project.id)
+        assert refreshed.icon == "🚀"
+        assert refreshed.icon_image_uri is None
+
 
 class TestIconEndpoints:
     def _project(self, client):
@@ -195,10 +214,41 @@ class TestIconEndpoints:
         deleted = authenticated_client.delete(f"/api/v1/projects/{pid}/icon")
         assert deleted.status_code == 200
         assert deleted.json()["icon_image_uri"] is None
-        assert deleted.json()["icon_source"] is None
+        # Reset pins the sentinel so the git seed won't re-add an image.
+        assert deleted.json()["icon_source"] == "user"
         assert (
             authenticated_client.get(f"/api/v1/projects/{pid}/icon").status_code == 404
         )
+
+    def test_reset_clears_image_and_emoji_and_blocks_reseed(
+        self, authenticated_client, test_db, fake_icon_storage
+    ):
+        # A git-backed project with an uploaded image + emoji.
+        project = authenticated_client.post(
+            "/api/v1/projects",
+            json={
+                "name": "Alpha",
+                "icon": "🚀",
+                "git_remote_url": "git@github.com:o/r.git",
+            },
+        ).json()
+        pid = project["id"]
+        authenticated_client.put(
+            f"/api/v1/projects/{pid}/icon",
+            files={"file": ("icon.png", _png_bytes(), "image/png")},
+        )
+
+        reset = authenticated_client.delete(f"/api/v1/projects/{pid}/icon").json()
+        assert reset["icon_image_uri"] is None
+        assert reset["icon"] is None
+        # Sentinel keeps the git seed from re-adding an image on the next fetch.
+        assert reset["icon_source"] == "user"
+
+        # Listing projects must not flip it back to seed-eligible.
+        listed = authenticated_client.get("/api/v1/projects").json()
+        row = next(p for p in listed if p["id"] == pid)
+        assert row["icon_image_uri"] is None
+        assert row["icon_source"] == "user"
 
     def test_upload_rejects_non_image(self, authenticated_client, fake_icon_storage):
         project = self._project(authenticated_client)

--- a/backend/src/backend/tests/test_project_icons.py
+++ b/backend/src/backend/tests/test_project_icons.py
@@ -1,0 +1,298 @@
+"""Project image-icon: upload/serve/delete, git-avatar seed, precedence (§4d/§4e)."""
+
+from datetime import datetime, timedelta, timezone
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from PIL import Image
+
+import shared.project_icons as icons
+import shared.storage as storage_module
+from shared.database import Project
+
+
+def _png_bytes(width: int = 64, height: int = 64, color=(20, 120, 200)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (width, height), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _seed_uses_test_engine(test_db, monkeypatch):
+    """Bind the seed's own-session factory to the test container's engine.
+
+    seed_project_icon() opens ``SessionLocal`` (module-level, bound to the
+    settings DB) because it runs as a background task; point it at the test DB so
+    both direct calls and GET /projects-triggered seeds hit the same database.
+    """
+    from sqlalchemy.orm import sessionmaker
+
+    local = sessionmaker(bind=test_db.get_bind(), autoflush=False, autocommit=False)
+    monkeypatch.setattr(icons, "SessionLocal", local)
+
+
+@pytest.fixture
+def fake_icon_storage(monkeypatch):
+    """In-memory stand-in for the S3 icon object store."""
+    store: dict[str, tuple[bytes, str]] = {}
+
+    def upload(key, data, mime_type):
+        store[key] = (data, mime_type)
+
+    def download_object(key):
+        return store[key]
+
+    def delete_object(key):
+        store.pop(key, None)
+
+    monkeypatch.setattr(storage_module, "upload_attachment", upload)
+    monkeypatch.setattr(storage_module, "download_object", download_object)
+    monkeypatch.setattr(storage_module, "delete_object", delete_object)
+    return store
+
+
+class TestOwnerAvatarUrl:
+    @pytest.mark.parametrize(
+        "remote,expected",
+        [
+            (
+                "git@github.com:vicoa-ai/vicoa.git",
+                "https://github.com/vicoa-ai.png?size=200",
+            ),
+            (
+                "https://github.com/vicoa-ai/vicoa.git",
+                "https://github.com/vicoa-ai.png?size=200",
+            ),
+            (
+                "https://github.com/vicoa-ai/vicoa",
+                "https://github.com/vicoa-ai.png?size=200",
+            ),
+            (
+                "ssh://git@github.com/octocat/hello",
+                "https://github.com/octocat.png?size=200",
+            ),
+            ("git@gitlab.com:group/proj.git", "https://gitlab.com/group.png"),
+        ],
+    )
+    def test_supported_hosts(self, remote, expected):
+        assert icons.owner_avatar_url(remote) == expected
+
+    @pytest.mark.parametrize(
+        "remote",
+        [
+            None,
+            "",
+            "git@bitbucket.org:team/repo.git",  # unsupported host
+            "https://example.com/a/b.git",  # unsupported host
+            "not a url",
+            "git@github.com:../evil",  # bad owner chars → skip
+        ],
+    )
+    def test_unsupported_or_bad(self, remote):
+        assert icons.owner_avatar_url(remote) is None
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    def __init__(self, content, *args, **kwargs):
+        self._content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, url):
+        return _FakeResp(self._content)
+
+
+class TestGitSeed:
+    def _make_project(self, db, user_id, **kw):
+        project = Project(user_id=user_id, name="alpha", **kw)
+        db.add(project)
+        db.commit()
+        return project
+
+    def test_seed_from_github_sets_git_source(
+        self, test_db, test_user, fake_icon_storage, monkeypatch
+    ):
+        project = self._make_project(
+            test_db, test_user.id, git_remote_url="git@github.com:vicoa-ai/alpha.git"
+        )
+        monkeypatch.setattr(
+            icons.httpx, "Client", lambda *a, **k: _FakeClient(_png_bytes())
+        )
+        icons.seed_project_icon(project.id)
+        test_db.expire_all()
+        refreshed = test_db.get(Project, project.id)
+        assert refreshed.icon_source == "git"
+        assert refreshed.icon_image_uri == f"/api/v1/projects/{project.id}/icon"
+        assert storage_module.project_icon_key(str(project.id)) in fake_icon_storage
+
+    def test_seed_unsupported_remote_marks_attempted(
+        self, test_db, test_user, fake_icon_storage
+    ):
+        project = self._make_project(
+            test_db, test_user.id, git_remote_url="git@bitbucket.org:t/r.git"
+        )
+        icons.seed_project_icon(project.id)
+        test_db.expire_all()
+        refreshed = test_db.get(Project, project.id)
+        assert refreshed.icon_source == "git"  # attempted → won't retry
+        assert refreshed.icon_image_uri is None
+
+    def test_seed_never_clobbers_user_icon(
+        self, test_db, test_user, fake_icon_storage, monkeypatch
+    ):
+        project = self._make_project(
+            test_db,
+            test_user.id,
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            icon_source="user",
+            icon_image_uri="/api/v1/projects/x/icon",
+        )
+        # Even if the fetch would succeed, a 'user' source is ineligible.
+        monkeypatch.setattr(
+            icons.httpx, "Client", lambda *a, **k: _FakeClient(_png_bytes())
+        )
+        icons.seed_project_icon(project.id)
+        test_db.expire_all()
+        refreshed = test_db.get(Project, project.id)
+        assert refreshed.icon_source == "user"
+        assert refreshed.icon_image_uri == "/api/v1/projects/x/icon"
+
+
+class TestIconEndpoints:
+    def _project(self, client):
+        return client.post("/api/v1/projects", json={"name": "Alpha"}).json()
+
+    def test_upload_get_delete_roundtrip(self, authenticated_client, fake_icon_storage):
+        project = self._project(authenticated_client)
+        pid = project["id"]
+
+        resp = authenticated_client.put(
+            f"/api/v1/projects/{pid}/icon",
+            files={"file": ("icon.png", _png_bytes(), "image/png")},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["icon_source"] == "user"
+        assert body["icon_image_uri"] == f"/api/v1/projects/{pid}/icon"
+
+        got = authenticated_client.get(f"/api/v1/projects/{pid}/icon")
+        assert got.status_code == 200
+        assert got.headers["content-type"] in ("image/jpeg", "image/png")
+
+        deleted = authenticated_client.delete(f"/api/v1/projects/{pid}/icon")
+        assert deleted.status_code == 200
+        assert deleted.json()["icon_image_uri"] is None
+        assert deleted.json()["icon_source"] is None
+        assert (
+            authenticated_client.get(f"/api/v1/projects/{pid}/icon").status_code == 404
+        )
+
+    def test_upload_rejects_non_image(self, authenticated_client, fake_icon_storage):
+        project = self._project(authenticated_client)
+        resp = authenticated_client.put(
+            f"/api/v1/projects/{project['id']}/icon",
+            files={"file": ("x.txt", b"not an image", "text/plain")},
+        )
+        assert resp.status_code == 400
+
+    def test_icon_endpoints_are_user_scoped(
+        self, authenticated_client, test_db, fake_icon_storage
+    ):
+        from shared.database.models import User
+
+        other = User(
+            id=uuid4(),
+            email="other-icons@example.com",
+            display_name="Other",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        test_db.add(other)
+        test_db.flush()
+        foreign = Project(user_id=other.id, name="Theirs")
+        test_db.add(foreign)
+        test_db.commit()
+        resp = authenticated_client.put(
+            f"/api/v1/projects/{foreign.id}/icon",
+            files={"file": ("icon.png", _png_bytes(), "image/png")},
+        )
+        assert resp.status_code == 404
+
+
+class TestAutoArchiveAndOrdering:
+    def _project(self, db, user_id, name, created_days_ago=0):
+        p = Project(
+            user_id=user_id,
+            name=name,
+            created_at=datetime.now(timezone.utc) - timedelta(days=created_days_ago),
+        )
+        db.add(p)
+        db.commit()
+        return p
+
+    def test_stale_project_autoarchives_but_task_bearing_survives(
+        self, test_db, test_user
+    ):
+        from backend.db.task_queries import autoarchive_stale_projects
+        from shared.database import Task
+
+        stale = self._project(test_db, test_user.id, "Stale", created_days_ago=60)
+        fresh = self._project(test_db, test_user.id, "Fresh", created_days_ago=1)
+        with_task = self._project(test_db, test_user.id, "Busy", created_days_ago=60)
+        test_db.add(
+            Task(
+                user_id=test_user.id,
+                project_id=with_task.id,
+                title="open",
+                status="todo",
+            )
+        )
+        test_db.commit()
+
+        n = autoarchive_stale_projects(test_db, test_user.id, days=30)
+        assert n == 1
+        for p in (stale, fresh, with_task):
+            test_db.refresh(p)
+        assert stale.is_archived is True
+        assert fresh.is_archived is False  # too young
+        assert with_task.is_archived is False  # has an open task
+
+    def test_list_orders_by_recent_activity(
+        self, authenticated_client, test_db, test_user, test_user_agent
+    ):
+        from shared.database import AgentInstance
+        from shared.database.enums import AgentStatus
+
+        old = self._project(test_db, test_user.id, "Old", created_days_ago=2)
+        recent = self._project(test_db, test_user.id, "Recent", created_days_ago=2)
+        now = datetime.now(timezone.utc)
+        for project, started in ((old, now - timedelta(days=1)), (recent, now)):
+            test_db.add(
+                AgentInstance(
+                    id=uuid4(),
+                    user_agent_id=test_user_agent.id,
+                    user_id=test_user.id,
+                    status=AgentStatus.ACTIVE,
+                    project_id=project.id,
+                    started_at=started,
+                )
+            )
+        test_db.commit()
+
+        names = [p["name"] for p in authenticated_client.get("/api/v1/projects").json()]
+        # Inbox first, then most-recent activity.
+        assert names[0] == "Inbox"
+        assert names.index("Recent") < names.index("Old")

--- a/backend/src/backend/tests/test_tasks.py
+++ b/backend/src/backend/tests/test_tasks.py
@@ -1036,13 +1036,21 @@ class TestProjectAutoCreate:
         machine_b = _make_machine(test_db, test_user.id, display_name="B")
         remote = "git@github.com:vicoa-ai/alpha.git"
         pid_a = resolve_or_create_project_id_for_session(
-            test_db, test_user.id, machine_a.id, "/a/alpha",
-            git_remote_url=remote, repo_root="/a/alpha",
+            test_db,
+            test_user.id,
+            machine_a.id,
+            "/a/alpha",
+            git_remote_url=remote,
+            repo_root="/a/alpha",
         )
         test_db.commit()
         pid_b = resolve_or_create_project_id_for_session(
-            test_db, test_user.id, machine_b.id, "/b/alpha",
-            git_remote_url=remote, repo_root="/b/alpha",
+            test_db,
+            test_user.id,
+            machine_b.id,
+            "/b/alpha",
+            git_remote_url=remote,
+            repo_root="/b/alpha",
         )
         test_db.commit()
         assert pid_a == pid_b
@@ -1061,7 +1069,10 @@ class TestProjectAutoCreate:
 
         machine = _make_machine(test_db, test_user.id)
         pid = resolve_or_create_project_id_for_session(
-            test_db, test_user.id, machine.id, "/home/nick/scratch",
+            test_db,
+            test_user.id,
+            machine.id,
+            "/home/nick/scratch",
             home_dir="/home/nick",
         )
         test_db.commit()
@@ -1075,7 +1086,11 @@ class TestProjectAutoCreate:
 
         machine = _make_machine(test_db, test_user.id)
         pid = resolve_or_create_project_id_for_session(
-            test_db, test_user.id, machine.id, "/home/nick", home_dir="/home/nick",
+            test_db,
+            test_user.id,
+            machine.id,
+            "/home/nick",
+            home_dir="/home/nick",
         )
         test_db.commit()
         assert pid is None
@@ -1102,7 +1117,10 @@ class TestProjectAutoCreate:
         test_db.commit()
 
         pid = resolve_or_create_project_id_for_session(
-            test_db, test_user.id, machine.id, "/home/nick/alpha/src/lib",
+            test_db,
+            test_user.id,
+            machine.id,
+            "/home/nick/alpha/src/lib",
         )
         test_db.commit()
         assert pid == project.id

--- a/backend/src/backend/tests/test_tasks.py
+++ b/backend/src/backend/tests/test_tasks.py
@@ -932,3 +932,184 @@ class TestProjectAutoMatch:
         assert worktree.project_id == project.id  # matched by repo_root
         assert already.project_id == other.id  # not stolen
         assert elsewhere.project_id is None
+
+
+class TestProjectAutoCreate:
+    """Match-or-create + self-heal (resolve_or_create_project_id_for_session)."""
+
+    def _count(self, db, user_id):
+        return (
+            db.query(Project)
+            .filter(Project.user_id == user_id, Project.is_inbox.is_(False))
+            .count()
+        )
+
+    def test_new_git_repo_creates_project_and_directory(self, test_db, test_user):
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        pid = resolve_or_create_project_id_for_session(
+            test_db,
+            test_user.id,
+            machine.id,
+            "/home/nick/alpha",
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            repo_root="/home/nick/alpha",
+            home_dir="/home/nick",
+        )
+        test_db.commit()
+        assert pid is not None
+        project = test_db.get(Project, pid)
+        assert project.name == "alpha"  # repo basename
+        assert project.git_remote_url == "git@github.com:vicoa-ai/alpha.git"
+        assert not project.is_inbox and not project.is_archived
+        dirs = (
+            test_db.query(ProjectDirectory)
+            .filter(ProjectDirectory.project_id == pid)
+            .all()
+        )
+        assert len(dirs) == 1
+        assert dirs[0].machine_id == machine.id
+        assert dirs[0].local_path == "/home/nick/alpha"
+
+    def test_second_call_same_repo_is_idempotent(self, test_db, test_user):
+        """A repeat register (incl. the concurrent-race re-check path) reuses it."""
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        args = dict(
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            repo_root="/home/nick/alpha",
+            home_dir="/home/nick",
+        )
+        first = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine.id, "/home/nick/alpha", **args
+        )
+        test_db.commit()
+        second = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine.id, "/home/nick/alpha", **args
+        )
+        test_db.commit()
+        assert first == second
+        assert self._count(test_db, test_user.id) == 1
+
+    def test_register_into_archived_project_unarchives(self, test_db, test_user):
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        project = Project(
+            user_id=test_user.id,
+            name="alpha",
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            is_archived=True,
+            archived_at=datetime.now(timezone.utc),
+        )
+        test_db.add(project)
+        test_db.commit()
+
+        pid = resolve_or_create_project_id_for_session(
+            test_db,
+            test_user.id,
+            machine.id,
+            "/home/nick/alpha",
+            git_remote_url="git@github.com:vicoa-ai/alpha.git",
+            repo_root="/home/nick/alpha",
+        )
+        test_db.commit()
+        assert pid == project.id  # matched, not duplicated
+        test_db.refresh(project)
+        assert not project.is_archived and project.archived_at is None
+        assert self._count(test_db, test_user.id) == 1
+
+    def test_second_machine_same_remote_reuses_project(self, test_db, test_user):
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine_a = _make_machine(test_db, test_user.id, display_name="A")
+        machine_b = _make_machine(test_db, test_user.id, display_name="B")
+        remote = "git@github.com:vicoa-ai/alpha.git"
+        pid_a = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine_a.id, "/a/alpha",
+            git_remote_url=remote, repo_root="/a/alpha",
+        )
+        test_db.commit()
+        pid_b = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine_b.id, "/b/alpha",
+            git_remote_url=remote, repo_root="/b/alpha",
+        )
+        test_db.commit()
+        assert pid_a == pid_b
+        assert self._count(test_db, test_user.id) == 1
+        dirs = (
+            test_db.query(ProjectDirectory)
+            .filter(ProjectDirectory.project_id == pid_a)
+            .all()
+        )
+        assert {d.machine_id for d in dirs} == {machine_a.id, machine_b.id}
+
+    def test_non_git_scratch_folder_creates_named_project(self, test_db, test_user):
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        pid = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine.id, "/home/nick/scratch",
+            home_dir="/home/nick",
+        )
+        test_db.commit()
+        assert pid is not None
+        assert test_db.get(Project, pid).name == "scratch"
+
+    def test_home_dir_is_not_a_project(self, test_db, test_user):
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        pid = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine.id, "/home/nick", home_dir="/home/nick",
+        )
+        test_db.commit()
+        assert pid is None
+        assert self._count(test_db, test_user.id) == 0
+
+    def test_existing_broad_link_not_narrowed_by_subdir(self, test_db, test_user):
+        """A session in a subdir of a linked repo keeps the broad link intact."""
+        from shared.database.project_matching import (
+            resolve_or_create_project_id_for_session,
+        )
+
+        machine = _make_machine(test_db, test_user.id)
+        project = Project(user_id=test_user.id, name="alpha")
+        test_db.add(project)
+        test_db.flush()
+        test_db.add(
+            ProjectDirectory(
+                user_id=test_user.id,
+                project_id=project.id,
+                machine_id=machine.id,
+                local_path="/home/nick/alpha",
+            )
+        )
+        test_db.commit()
+
+        pid = resolve_or_create_project_id_for_session(
+            test_db, test_user.id, machine.id, "/home/nick/alpha/src/lib",
+        )
+        test_db.commit()
+        assert pid == project.id
+        dirs = (
+            test_db.query(ProjectDirectory)
+            .filter(ProjectDirectory.project_id == project.id)
+            .all()
+        )
+        assert len(dirs) == 1
+        assert dirs[0].local_path == "/home/nick/alpha"  # not narrowed

--- a/backend/src/servers/api/routers.py
+++ b/backend/src/servers/api/routers.py
@@ -42,7 +42,9 @@ from shared.database import (
     FileMentions,
 )
 from shared.database.agent_instances import create_agent_instance
-from shared.database.project_matching import resolve_project_id_for_session
+from shared.database.project_matching import (
+    resolve_or_create_project_id_for_session,
+)
 from integrations.headless.usage import project_rate_limited_until
 from shared.websocket.connection_manager import connection_manager
 from shared.websocket.envelope import (
@@ -997,14 +999,17 @@ def register_agent_instance_endpoint(
                 existing.project = request.project
                 # Now that the wrapper has reported its real cwd (+ repo
                 # root/remote for worktrees), attach the session to a project
-                # set up for that checkout, or None.
-                existing.project_id = resolve_project_id_for_session(
+                # set up for that checkout — auto-creating one if this is the
+                # first session in an unseen dir/repo (plan §4a), or None for
+                # paths not worth a project (home dir, etc.).
+                existing.project_id = resolve_or_create_project_id_for_session(
                     db,
                     UUID(user_id),
                     existing.machine_id,
                     request.project,
                     git_remote_url=request.git_remote_url,
                     repo_root=request.repo_root,
+                    home_dir=request.home_dir or existing.home_dir,
                 )
             if request.home_dir:
                 existing.home_dir = request.home_dir
@@ -1056,13 +1061,14 @@ def register_agent_instance_endpoint(
                 name=request.name,
                 instance_metadata=instance_metadata,
                 project=request.project,
-                project_id=resolve_project_id_for_session(
+                project_id=resolve_or_create_project_id_for_session(
                     db,
                     UUID(user_id),
                     resolved_machine_id,
                     request.project,
                     git_remote_url=request.git_remote_url,
                     repo_root=request.repo_root,
+                    home_dir=request.home_dir,
                 ),
                 home_dir=request.home_dir,
                 machine_id=resolved_machine_id,

--- a/backend/src/shared/alembic/versions/f4a7c2e9b1d3_add_project_icon_image_columns.py
+++ b/backend/src/shared/alembic/versions/f4a7c2e9b1d3_add_project_icon_image_columns.py
@@ -24,9 +24,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "projects", sa.Column("icon_image_uri", sa.Text(), nullable=True)
-    )
+    op.add_column("projects", sa.Column("icon_image_uri", sa.Text(), nullable=True))
     op.add_column(
         "projects", sa.Column("icon_source", sa.String(length=16), nullable=True)
     )

--- a/backend/src/shared/alembic/versions/f4a7c2e9b1d3_add_project_icon_image_columns.py
+++ b/backend/src/shared/alembic/versions/f4a7c2e9b1d3_add_project_icon_image_columns.py
@@ -1,0 +1,37 @@
+"""add project icon image columns
+
+Adds the image-icon fields for the project-identity-unification plan (§4d):
+``icon_image_uri`` (a served URL pointing at our own storage, never an external
+hot-link) and ``icon_source`` ('user' | 'git' | NULL). The existing emoji
+``icon`` + ``color`` stay as the lightweight default; ``icon_source`` governs
+precedence (user upload wins) and re-seed safety.
+
+Revision ID: f4a7c2e9b1d3
+Revises: b2f6a1c8e4d7
+Create Date: 2026-09-02 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a7c2e9b1d3"
+down_revision: Union[str, None] = "b2f6a1c8e4d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects", sa.Column("icon_image_uri", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "projects", sa.Column("icon_source", sa.String(length=16), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "icon_source")
+    op.drop_column("projects", "icon_image_uri")

--- a/backend/src/shared/database/project_matching.py
+++ b/backend/src/shared/database/project_matching.py
@@ -1,11 +1,23 @@
-"""Session ↔ project auto-match.
+"""Session ↔ project auto-match (and auto-create).
 
-Connects an ``agent_instance`` to the formal ``projects`` entity WITHOUT
-creating one: given a session's machine, working directory, and (when the
-wrapper reports them) the git remote and source-repo root, find an existing
-project the user already set up for that checkout. No match ⇒ NULL (the sidebar
-keeps deriving its top-level group from the ``project`` path string until a
-project is linked; NULL is *not* the Inbox — Inbox is a task concept).
+Connects an ``agent_instance`` to the formal ``projects`` entity. Two entry
+points share one matcher:
+
+  * ``resolve_project_id_for_session`` — read-only. Finds an existing project
+    for a checkout, or ``None``. Used by the link-a-folder backfill, where
+    minting a project would be wrong.
+  * ``resolve_or_create_project_id_for_session`` — match-or-create. The register
+    hooks call this so the *first* session in any new dir/repo materializes a
+    real ``projects`` row (orca-style), rather than leaving the sidebar to
+    derive a phantom basename-only group forever (project-identity-unification
+    plan §4a). It also **self-heals**: activity in an archived project
+    un-archives it (running an agent there contradicts "no active work"), and it
+    ensures a ``project_directories`` row for this machine so subsequent
+    path-tier matches hit.
+
+The matcher intentionally does **not** filter out archived projects: a session
+in a repo the user archived must re-match (and un-archive) that project, never
+mint a duplicate.
 
 Match order (identity strength, high → low):
 
@@ -29,13 +41,23 @@ Both the register hooks (servers routers) and the link-a-folder backfill
 
 from __future__ import annotations
 
+import hashlib
+import logging
 from uuid import UUID
 
-from sqlalchemy import or_
+from sqlalchemy import or_, text
 from sqlalchemy.orm import Session
 
 from .models import AgentInstance
 from .task_models import Project, ProjectDirectory
+
+logger = logging.getLogger(__name__)
+
+
+def _basename(path: str) -> str:
+    """Last path segment (the project's default display name)."""
+    parts = path.rstrip("/").split("/")
+    return parts[-1] if parts else path
 
 
 def _path_at_or_under(session_path: str, local_path: str) -> bool:
@@ -52,25 +74,23 @@ def _path_at_or_under(session_path: str, local_path: str) -> bool:
     )
 
 
-def resolve_project_id_for_session(
+def _match_project(
     db: Session,
     user_id: UUID,
     machine_id: UUID | None,
     project_path: str | None,
-    git_remote_url: str | None = None,
-    repo_root: str | None = None,
-) -> UUID | None:
-    """Best-effort project for a session; ``None`` when nothing is set up for it.
+    git_remote_url: str | None,
+    repo_root: str | None,
+) -> Project | None:
+    """The shared matcher — returns the matched project (archived or not), or None.
 
-    ``project_path`` is the session's cwd; ``repo_root`` is the top-level of the
-    git repository the session runs in (the *main* checkout, even for a linked
-    worktree) — reported by the wrapper so a worktree can be attributed to the
-    same project as its main checkout.
+    Deliberately does not exclude ``is_archived`` rows: activity in an archived
+    project must re-match it so the caller can un-archive rather than duplicate.
     """
     # Tier 1 — canonical git remote (dormant until the daemon reports a remote).
     if git_remote_url:
         matched = (
-            db.query(Project.id)
+            db.query(Project)
             .filter(
                 Project.user_id == user_id,
                 Project.git_remote_url == git_remote_url,
@@ -78,7 +98,7 @@ def resolve_project_id_for_session(
             )
             .order_by(Project.created_at.asc())
             .limit(1)
-            .scalar()
+            .first()
         )
         if matched is not None:
             return matched
@@ -100,9 +120,164 @@ def resolve_project_id_for_session(
                 if best is None or len(row.local_path) > len(best.local_path):
                     best = row
         if best is not None:
-            return best.project_id
+            return db.get(Project, best.project_id)
 
     return None
+
+
+def resolve_project_id_for_session(
+    db: Session,
+    user_id: UUID,
+    machine_id: UUID | None,
+    project_path: str | None,
+    git_remote_url: str | None = None,
+    repo_root: str | None = None,
+) -> UUID | None:
+    """Best-effort project for a session; ``None`` when nothing is set up for it.
+
+    Read-only — never creates. ``project_path`` is the session's cwd;
+    ``repo_root`` is the top-level of the git repository the session runs in (the
+    *main* checkout, even for a linked worktree) — reported by the wrapper so a
+    worktree can be attributed to the same project as its main checkout.
+    """
+    project = _match_project(
+        db, user_id, machine_id, project_path, git_remote_url, repo_root
+    )
+    return project.id if project is not None else None
+
+
+def _should_skip_autocreate(name_source: str | None, home_dir: str | None) -> bool:
+    """True when a session should NOT mint a project (routes to Inbox/NULL).
+
+    Auto-create names a project after ``repo_root or cwd``; some paths are not
+    worth a project of their own: a session whose cwd is the home directory (no
+    repo), the filesystem root, or anything with an empty basename. A real repo
+    always has a ``repo_root``, so a git session is never skipped.
+    """
+    if not name_source:
+        return True
+    base = name_source.rstrip("/")
+    if base in ("", "/"):
+        return True
+    if home_dir and base == home_dir.rstrip("/"):
+        return True
+    return not _basename(base)
+
+
+def _ensure_directory_row(
+    db: Session,
+    *,
+    user_id: UUID,
+    project_id: UUID,
+    machine_id: UUID | None,
+    local_path: str | None,
+) -> None:
+    """Insert a ``project_directories`` row for this machine if absent.
+
+    Insert-only: never overwrites an existing (project, machine) link, so a
+    session in ``/repo/subdir`` can't narrow a link the user made to ``/repo``.
+    """
+    if machine_id is None or not local_path:
+        return
+    exists = (
+        db.query(ProjectDirectory.id)
+        .filter(
+            ProjectDirectory.project_id == project_id,
+            ProjectDirectory.machine_id == machine_id,
+        )
+        .first()
+    )
+    if exists is not None:
+        return
+    db.add(
+        ProjectDirectory(
+            user_id=user_id,
+            project_id=project_id,
+            machine_id=machine_id,
+            local_path=local_path.rstrip("/") or local_path,
+        )
+    )
+    db.flush()
+
+
+def _advisory_lock(db: Session, user_id: UUID, key_source: str) -> None:
+    """Serialize concurrent auto-creates for the same (user, repo) checkout.
+
+    Two sessions registering in a fresh repo at the same instant would otherwise
+    each miss the match and mint a duplicate project. A transaction-scoped
+    Postgres advisory lock keyed on (user, remote-or-path) makes the loser block
+    until the winner commits, so its post-lock re-match finds the new project.
+    No-op on non-Postgres backends (single-threaded tests never race).
+    """
+    if db.bind is None or db.bind.dialect.name != "postgresql":
+        return
+    digest = hashlib.sha256(f"{user_id}:{key_source}".encode()).digest()
+    # A signed 64-bit key for pg_advisory_xact_lock(bigint).
+    key = int.from_bytes(digest[:8], "big", signed=True)
+    db.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": key})
+
+
+def resolve_or_create_project_id_for_session(
+    db: Session,
+    user_id: UUID,
+    machine_id: UUID | None,
+    project_path: str | None,
+    git_remote_url: str | None = None,
+    repo_root: str | None = None,
+    home_dir: str | None = None,
+) -> UUID | None:
+    """Match a session to a project, creating one if none exists (plan §4a).
+
+    Unlike :func:`resolve_project_id_for_session`, this materializes a real
+    project the first time a session runs in an unseen dir/repo, self-heals an
+    archived match back to active, and ensures a directory row for this machine.
+    Returns ``None`` only when the path isn't worth a project (see
+    :func:`_should_skip_autocreate`) — the session then falls back to NULL.
+
+    Does not commit — the register handler owns the surrounding transaction.
+    """
+    name_source = repo_root or project_path
+    project = _match_project(
+        db, user_id, machine_id, project_path, git_remote_url, repo_root
+    )
+    if project is None:
+        if _should_skip_autocreate(name_source, home_dir):
+            return None
+        # Re-check under the lock: a concurrent register may have created it
+        # while we waited (the lock is held until this request commits).
+        _advisory_lock(db, user_id, git_remote_url or name_source or "")
+        project = _match_project(
+            db, user_id, machine_id, project_path, git_remote_url, repo_root
+        )
+        if project is None:
+            assert name_source is not None  # guarded by _should_skip_autocreate
+            project = Project(
+                user_id=user_id,
+                name=_basename(name_source),
+                git_remote_url=git_remote_url,
+            )
+            db.add(project)
+            db.flush()
+            logger.info(
+                "auto-created project %s (%s) for user %s",
+                project.id,
+                project.name,
+                user_id,
+            )
+
+    # Self-heal: a session is live work — an archived match is no longer stale.
+    if project.is_archived:
+        project.is_archived = False
+        project.archived_at = None
+
+    _ensure_directory_row(
+        db,
+        user_id=user_id,
+        project_id=project.id,
+        machine_id=machine_id,
+        local_path=name_source,
+    )
+    return project.id
 
 
 def backfill_project_id_for_directory(

--- a/backend/src/shared/database/task_models.py
+++ b/backend/src/shared/database/task_models.py
@@ -78,6 +78,14 @@ class Project(Base):
     )
     color: Mapped[str | None] = mapped_column(String(16), default=None)
     icon: Mapped[str | None] = mapped_column(String(64), default=None)
+    # Image icon (project-identity-unification §4d): a served URL pointing at
+    # OUR storage (never an external hot-link), plus who set it. icon_source
+    # governs precedence and re-seed safety: 'user' (uploaded) always wins over
+    # 'git' (owner avatar seeded from the remote); NULL ⇒ fall back to the emoji
+    # `icon`/`color` default. The S3 object is keyed by project_id alone (not
+    # user_id) so a project can later move to a team without rekeying (§9).
+    icon_image_uri: Mapped[str | None] = mapped_column(Text, default=None)
+    icon_source: Mapped[str | None] = mapped_column(String(16), default=None)
     # The per-user "No project" bucket; non-archivable, non-deletable.
     is_inbox: Mapped[bool] = mapped_column(default=False)
     is_archived: Mapped[bool] = mapped_column(default=False)

--- a/backend/src/shared/project_icons.py
+++ b/backend/src/shared/project_icons.py
@@ -98,8 +98,9 @@ def seed_project_icon(project_id: UUID) -> None:
         if project is None or project.is_inbox:
             return
         # Only NULL icon_source is eligible: 'git' = already attempted, 'user' =
-        # uploaded (must win). icon_image_uri set = already have one.
-        if project.icon_source is not None or project.icon_image_uri:
+        # uploaded / explicitly reset (must win). icon_image_uri set = already
+        # have one; an emoji `icon` is an explicit choice we must not overwrite.
+        if project.icon_source is not None or project.icon_image_uri or project.icon:
             return
         avatar = owner_avatar_url(project.git_remote_url)
         if avatar is None:

--- a/backend/src/shared/project_icons.py
+++ b/backend/src/shared/project_icons.py
@@ -1,0 +1,132 @@
+"""Default project-icon seeding from the git remote (identity-unification §4e).
+
+Best-effort, async, untrusted-I/O-aware. On auto-create a project's icon starts
+empty; a background pass derives the owner avatar from the git remote for the
+hosts we trust (github.com, gitlab.com), fetches it *server-side*, normalizes it
+through the same image pipeline as user uploads, stores it in OUR S3, and points
+the project at it. Anything unexpected leaves the emoji/generated default in
+place — seeding must never break project creation.
+
+Constraints baked in:
+  * The outbound fetch only ever targets an allowlisted host's public avatar
+    endpoint — not an arbitrary URL — so the SSRF surface is those hosts alone.
+  * The S3 object is keyed by ``project_id`` (``storage.project_icon_key``), so a
+    project can later move to a team without rekeying (plan §9).
+  * ``icon_source`` is stamped ``'git'`` on every attempt (success *or* miss) so
+    a failed lookup is never retried on each ``GET /projects``; only a NULL
+    ``icon_source`` is eligible, which also means a user upload ('user') is never
+    clobbered.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from uuid import UUID
+
+import httpx
+
+from shared import storage
+from shared.database import Project
+from shared.database.session import SessionLocal
+from shared.images import InvalidImageError, process_image
+
+logger = logging.getLogger(__name__)
+
+# host -> avatar-URL template keyed on {owner}. Only hosts whose public avatar
+# endpoint needs no auth and resolves to an image belong here.
+_AVATAR_URL = {
+    "github.com": "https://github.com/{owner}.png?size=200",
+    "gitlab.com": "https://gitlab.com/{owner}.png",
+}
+
+# git@host:owner/repo(.git)
+_SCP_LIKE = re.compile(r"^[\w.+-]+@([\w.-]+):(.+)$")
+# scheme://[user@]host[:port]/owner/repo(.git)
+_URL_LIKE = re.compile(r"^[a-z][\w+.-]*://(?:[^@/]+@)?([\w.-]+)(?::\d+)?/(.+)$", re.I)
+_OWNER_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Avatars are tiny; anything larger is not one, and bounds the fetch.
+MAX_ICON_BYTES = 8 * 1024 * 1024
+_FETCH_TIMEOUT_S = 8.0
+
+
+def _host_and_path(remote: str) -> tuple[str, str] | None:
+    remote = remote.strip()
+    if not remote:
+        return None
+    m = _SCP_LIKE.match(remote) or _URL_LIKE.match(remote)
+    if m:
+        return m.group(1).lower(), m.group(2)
+    return None
+
+
+def owner_avatar_url(git_remote_url: str | None) -> str | None:
+    """Public owner-avatar URL for a supported host, or None to skip seeding."""
+    if not git_remote_url:
+        return None
+    parsed = _host_and_path(git_remote_url)
+    if parsed is None:
+        return None
+    host, path = parsed
+    template = _AVATAR_URL.get(host)
+    if template is None:
+        return None
+    # path is "owner/repo(.git)" (or deeper for GitLab groups); the first
+    # segment is the owner/org whose avatar we want.
+    owner = path.strip("/").split("/")[0]
+    # `.`/`..` are valid against _OWNER_RE (dots are allowed in real handles) but
+    # would be path traversal in the avatar URL — reject them explicitly.
+    if not owner or owner in (".", "..") or not _OWNER_RE.fullmatch(owner):
+        return None
+    return template.format(owner=owner)
+
+
+def icon_served_url(project_id: UUID | str) -> str:
+    """Backend-relative URL clients render (stored in ``projects.icon_image_uri``)."""
+    return f"/api/v1/projects/{project_id}/icon"
+
+
+def seed_project_icon(project_id: UUID) -> None:
+    """Background task: seed a project's icon from its git remote (best-effort).
+
+    Runs in its own DB session (invoked via FastAPI ``BackgroundTasks``), re-checks
+    eligibility to stay idempotent under concurrent enqueues, and never raises.
+    """
+    with SessionLocal() as db:
+        project = db.get(Project, project_id)
+        if project is None or project.is_inbox:
+            return
+        # Only NULL icon_source is eligible: 'git' = already attempted, 'user' =
+        # uploaded (must win). icon_image_uri set = already have one.
+        if project.icon_source is not None or project.icon_image_uri:
+            return
+        avatar = owner_avatar_url(project.git_remote_url)
+        if avatar is None:
+            project.icon_source = "git"  # mark attempted so we don't retry
+            db.commit()
+            return
+        try:
+            with httpx.Client(
+                timeout=_FETCH_TIMEOUT_S, follow_redirects=True
+            ) as client:
+                resp = client.get(avatar)
+            resp.raise_for_status()
+            data = resp.content
+            if len(data) > MAX_ICON_BYTES:
+                raise ValueError(f"avatar too large: {len(data)} bytes")
+            processed = process_image(data)
+            storage.upload_attachment(
+                storage.project_icon_key(str(project_id)),
+                processed.data,
+                processed.mime_type,
+            )
+            project.icon_image_uri = icon_served_url(project_id)
+            project.icon_source = "git"
+        except (httpx.HTTPError, InvalidImageError, ValueError, OSError) as exc:
+            logger.info("git icon seed skipped for %s: %s", project_id, exc)
+            project.icon_source = "git"  # attempted; leave uri NULL → emoji default
+        except Exception:  # noqa: BLE001 — seeding must never break the caller
+            logger.warning("git icon seed errored for %s", project_id, exc_info=True)
+            project.icon_source = "git"
+        db.commit()

--- a/backend/src/shared/storage.py
+++ b/backend/src/shared/storage.py
@@ -30,6 +30,15 @@ def attachment_key(user_id: str, attachment_id: str, mime_type: str) -> str:
     return f"attachments/{user_id}/{attachment_id}.{ext}"
 
 
+def project_icon_key(project_id: str) -> str:
+    # Keyed by project_id ALONE (not {user_id}/…): a project may later move to a
+    # team, so the object path must not encode a single owner (plan §9). No
+    # extension — the served Content-Type comes from the stored object's own
+    # metadata (download_object), so one deterministic key survives png↔jpeg
+    # re-encodes across uploads.
+    return f"project-icons/{project_id}"
+
+
 def _client():
     kwargs: dict[str, Any] = {}
     if settings.aws_access_key_id and settings.aws_secret_access_key:
@@ -52,3 +61,13 @@ def upload_attachment(key: str, data: bytes, mime_type: str) -> None:
 def download_attachment(key: str) -> bytes:
     obj = _client().get_object(Bucket=ATTACHMENTS_BUCKET, Key=key)
     return obj["Body"].read()
+
+
+def download_object(key: str) -> tuple[bytes, str]:
+    """Fetch bytes plus the stored Content-Type (for keys with no DB mime row)."""
+    obj = _client().get_object(Bucket=ATTACHMENTS_BUCKET, Key=key)
+    return obj["Body"].read(), obj.get("ContentType") or "application/octet-stream"
+
+
+def delete_object(key: str) -> None:
+    _client().delete_object(Bucket=ATTACHMENTS_BUCKET, Key=key)


### PR DESCRIPTION
Implements the **project-identity-unification** plan: the sessions sidebar, the Tasks board, and Project Settings now all speak one DB `projects` identity, projects auto-materialize as you work, and every project can carry a real image icon.

## Backend
- **Auto-create + self-heal** (`resolve_or_create_project_id_for_session`): the first session in an unseen dir/repo mints a real `projects` row (+ a `project_directories` row), orca-style, instead of leaving a basename-only phantom group. A session in an *archived* project un-archives it; an advisory lock guards concurrent registers; home/rootless paths route to NULL.
- **Image icons** (migration `f4a7c2e9b1d3`: `icon_image_uri`, `icon_source`): `PUT/GET/DELETE /api/v1/projects/{id}/icon`. Uploads go through the existing `process_image` + S3 layer, keyed by `project_id` alone (team-forward-compat, plan §9). A best-effort, async **git-avatar seed** (GitHub/GitLab allowlist, SSRF-limited) fills a default icon; a user upload or an emoji always wins over it.
- **Recency ordering + auto-archive**: `list_projects` returns Inbox → most-recent-activity → name, and opportunistically archives stale (30d, no open tasks) projects — reversible via the self-heal rule.
- Centralized `get_accessible_project` access predicate (plan §9).

## Web + Desktop
- **Sidebar** reads the DB project's name + icon (image → emoji → generated square) when grouped by project; sessions indent under their group; **Archive** replaces the old per-device localStorage hide (cross-device).
- **Tasks** project settings and the **`/dashboard/settings` → Projects** pane share one `ProjectIconEditor` (upload image / emoji / reset-to-default); the settings Projects nav is DB-backed so it works on web without a live session; Delete is guarded (warns it resurrects under auto-create).
- Settings gear beside the avatar → `/dashboard/settings`.
- Generated squares use paseo's muted identity palette; icon corner radius is small in the sidebar/nav and a larger shared radius on the Display page.

## Tests / checks
- Backend: new `test_project_icons.py` + auto-create tests in `test_tasks.py` (match-or-create, self-heal, race idempotency, git seed skips emoji, reset blocks re-seed, recency/auto-archive). Migration verified upgrade+downgrade; WebSocket-freeze check passes.
- Web: `next build` green; `session-grouping` vitest updated for the archived-map behavior.

## Notes
- Backend changes are **not yet deployed**; local dirs won't appear as projects on the hosted backend until this ships and a session re-registers in them. Same-git-remote checkouts fold into one project by design.
- Mobile UI for icons/archive is a follow-up (it gets the DB fields for free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
