### PR TITLE
chore: worktree dev-DB sharing + backend dev-setup + asyncpg 3.13 fix

### DIFF
--- a/.vicoa/config.json
+++ b/.vicoa/config.json
@@ -9,6 +9,8 @@
       "cp \"$VICOA_ROOT_PATH/apps/web/.env\" \"$VICOA_WORKTREE_PATH/apps/web/.env\" && echo 'copied apps/web/.env'",
       "cp \"$VICOA_ROOT_PATH/backend/.env\" \"$VICOA_WORKTREE_PATH/backend/.env\" && echo 'copied backend/.env'",
       "cp \"$VICOA_ROOT_PATH/apps/mobile/env.json\" \"$VICOA_WORKTREE_PATH/apps/mobile/env.json\" && echo 'copied apps/mobile/env.json'",
+      "echo '--- linking backend/postgres-data -> main (shared dev DB) ---'",
+      "[ -d \"$VICOA_ROOT_PATH/backend/postgres-data\" ] && ln -sfn \"$VICOA_ROOT_PATH/backend/postgres-data\" \"$VICOA_WORKTREE_PATH/backend/postgres-data\" && echo 'linked postgres-data -> main' || echo 'skip: main DB not initialized yet'",
       "echo '--- pnpm install (apps/web) ---'",
       "cd \"$VICOA_WORKTREE_PATH/apps/web\" && pnpm install",
       "echo '=== vicoa worktree setup done ==='"

--- a/backend/scripts/dev-setup.sh
+++ b/backend/scripts/dev-setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# One-shot backend dev-environment setup for a fresh checkout or worktree.
+#
+# OPTIONAL and opt-in: run this only in a worktree where you actually work on
+# the backend. It is intentionally NOT part of the automatic worktree setup
+# (.vicoa/config.json) because installing the Python deps is slow and most
+# worktrees never touch the backend.
+#
+# Creates a .venv on the project's target Python (3.12), installs runtime +
+# dev deps, and installs the local package editable. Idempotent — safe to
+# re-run; it reuses an existing .venv.
+#
+# Usage:  ./scripts/dev-setup.sh    (from the backend/ directory)
+
+set -e
+
+PYTHON_VERSION="3.12"
+
+# Resolve backend/ so the script works no matter where it is called from.
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$BACKEND_DIR"
+
+echo "=== backend dev-setup ($BACKEND_DIR) ==="
+
+if ! command -v uv > /dev/null 2>&1; then
+    echo "Error: 'uv' is not installed."
+    echo "Install it (https://docs.astral.sh/uv/) or create the venv manually:"
+    echo "  python3.${PYTHON_VERSION#3.} -m venv .venv && source .venv/bin/activate && make dev-install && pip install -e ."
+    exit 1
+fi
+
+# 1) venv on the project's target Python (uv auto-downloads 3.12 if missing).
+if [ ! -d .venv ]; then
+    echo "--- creating .venv on Python $PYTHON_VERSION ---"
+    uv venv --python "$PYTHON_VERSION" .venv
+else
+    echo "--- reusing existing .venv ---"
+fi
+
+# 2) install into the venv. Activation persists for the rest of THIS script
+#    (PATH points pip/python at .venv), but not into your interactive shell.
+#    Guard the sourcing against 'set -e'/unset-var quirks in older activate
+#    scripts.
+set +u
+# shellcheck disable=SC1091
+source .venv/bin/activate
+set -u
+
+echo "--- make dev-install ---"
+make dev-install
+
+echo "--- pip install -e . (editable local package) ---"
+pip install -e .
+
+echo "=== done ==="
+echo "Activate it in your shell:  source backend/.venv/bin/activate"

--- a/backend/src/backend/requirements.txt
+++ b/backend/src/backend/requirements.txt
@@ -7,7 +7,7 @@ cryptography==48.0.0
 email-validator==2.1.0
 exponent-server-sdk>=2.1.0
 stripe==10.8.0
-asyncpg==0.29.0
+asyncpg==0.30.0
 -r ../shared/requirements.txt
 pillow>=10.0
 python-multipart>=0.0.9


### PR DESCRIPTION
Three independent dev-environment changes surfaced while running the backend in a git worktree.

## 1. `fix(backend)`: asyncpg 0.29.0 → 0.30.0
`asyncpg==0.29.0` has no cp313 wheel, so pip builds it from source and fails against CPython 3.13 (`make dev-install` breaks) — the private APIs it uses changed/were removed: `_PyLong_AsByteArray` (now 6-arg), `_PyInterpreterState_GetConfig`, `_PyUnicode_FastCopyCharacters`. 0.30.0 is the first release with 3.13 support + prebuilt wheels, and still ships cp312 wheels (what CI/Docker use), so the 3.12 target is unaffected.

## 2. `chore(worktree)`: share main's dev DB
`dev-start.sh` derives the Postgres data dir from cwd (`$(pwd)/postgres-data`). Running it from a worktree therefore spins up a **fresh empty DB**, so the daemon's stored api key gets rejected (`credential rejected (401)`). The worktree `setup` now symlinks `backend/postgres-data` → main's, mirroring the existing "copy main's `.env`" pattern. Guarded: if main has never initialized a DB, it's skipped rather than left as a dangling link.

> Caveat: don't run `./dev-start.sh --reset-db` inside a worktree afterwards — it would remove the symlink. Reset from main.

## 3. `chore(backend)`: opt-in `dev-setup.sh`
Standalone, idempotent backend bootstrap: `uv venv --python 3.12` → `make dev-install` → `pip install -e .`. Deliberately **not** in the automatic worktree setup because it's slow and most worktrees never touch the backend — run it on demand where needed.

## Notes
- No schema/migration changes.
- `.vicoa/config.json` and `requirements.txt` were identical between `main` and `happy-maple`, so this branches cleanly off `main` (independent of open PR #15).