### PR TITLE
feat(plugins): declarative plugin system (P0+P1 — themes, sidebar, composer)

### DIFF
--- a/apps/web/app/dashboard/dashboard-layout.tsx
+++ b/apps/web/app/dashboard/dashboard-layout.tsx
@@ -55,6 +55,9 @@ import { useDesktopNotificationNavigation } from '@/lib/hooks/use-desktop-sessio
 import { DesktopConnectionBanner } from '@/components/dashboard/desktop-connection-banner';
 import { DesktopNotificationNudge } from '@/components/dashboard/desktop-notification-nudge';
 import { DesktopChromeProvider } from '@/components/dashboard/desktop-chrome-context';
+import { PluginSidebarItems } from '@/components/plugins/plugin-sidebar-items';
+import { PluginCatalogSync } from '@/components/plugins/plugin-catalog-sync';
+import { PluginTrustGate } from '@/components/plugins/plugin-trust-gate';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
 import { DesktopTitlebarLead, useDesktopWindows } from '@/components/desktop/window-chrome';
 import type { AgentInstanceResponse } from '@/lib/backend-api';
@@ -491,6 +494,13 @@ function DashboardSidebar({
             <Layers2 className={cn("h-4 w-4", showSideBar && "mr-2")} />
             {showSideBar ? 'Skills' : null}
           </Button>
+
+          {/* Nav entries contributed by installed plugins (Tier 1). */}
+          <PluginSidebarItems
+            slot="nav"
+            collapsed={!showSideBar}
+            onNavigate={onMobileClose}
+          />
 
           {/* Workspace search across sessions, tasks, automations (also ⌘K). */}
           <Button
@@ -1069,6 +1079,10 @@ export default function DashboardLayout({
             their keep-alive provider wraps the whole dashboard shell. */}
         <TerminalSessionsProvider>
         <OnboardingModal />
+        {/* Plugin system (Tier 1): keep the registry in sync with each machine's
+            daemon, and surface the first-load trust prompt for new plugins. */}
+        <PluginCatalogSync />
+        <PluginTrustGate />
         <DashboardShell
           children={children}
           activeTab={activeTab}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from 'geist/font/mono';
 import Script from 'next/script';
 import { SWRConfig } from 'swr';
 import { ThemeProvider } from '@/components/theme-provider';
+import { PluginThemeStyle } from '@/components/plugins/plugin-theme-style';
 import { PostHogIdentify } from '@/components/posthog-identify';
 import { DesktopAuthGate } from '@/components/dashboard/desktop-auth-gate';
 import { DesktopAuthHandoff } from '@/components/dashboard/desktop-auth-handoff';
@@ -201,6 +202,9 @@ export default function RootLayout({
         />
         <PostHogIdentify />
         <ThemeProvider defaultTheme="dark">
+          {/* Injects token overrides for the active plugin theme (Tier 1); renders
+              nothing for the built-in dark/light/system themes. */}
+          <PluginThemeStyle />
           <SWRConfig value={{}}>
             {/* Desktop: mint the CLI key whenever a Supabase session appears in
                 local mode. Mounted here (not just in the dashboard layout) so it

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -10,6 +10,11 @@ import { MentionTextarea } from '@/components/mention-textarea';
 import type { SlashCommand, AgentType } from '@/lib/constants/slash-commands';
 import { SessionConfigChips } from '@/components/dashboard/session-config-dropdown';
 import { AddToChatMenu } from '@/components/dashboard/add-to-chat-menu';
+import {
+  PluginComposerActions,
+  usePluginComposerMenuItems,
+} from '@/components/plugins/plugin-composer-actions';
+import type { ComposerContext } from '@/lib/plugins/composer';
 import { ChatUsageIndicator } from '@/components/chat-usage-indicator';
 import { fetchClaudeUsageWindows } from '@/lib/claude-usage';
 import type { SessionUsage } from '@/lib/backend-api';
@@ -508,6 +513,52 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
     requestAnimationFrame(() => fileInputRef.current?.click());
   }, []);
 
+  // ---- Plugin composer bridge (Tier 1) ----------------------------------
+  // The narrowed handle a plugin action gets: insert text at the caret, or open
+  // one of the built-in pickers. Nothing here exposes composer internals.
+  const insertAtCaret = useCallback(
+    (text: string) => {
+      const el = textareaRef.current;
+      const start = el?.selectionStart ?? message.length;
+      const end = el?.selectionEnd ?? start;
+      const next = message.slice(0, start) + text + message.slice(end);
+      setMessage(next);
+      autoResizeTextarea();
+      const pos = start + text.length;
+      requestAnimationFrame(() => {
+        const t = textareaRef.current;
+        if (t) {
+          t.focus({ preventScroll: true });
+          t.setSelectionRange(pos, pos);
+        }
+      });
+    },
+    [message, setMessage, autoResizeTextarea],
+  );
+
+  const openComposerPanel = useCallback(
+    (panel: 'mention' | 'commands' | 'files' | 'folder') => {
+      if (panel === 'mention') handleInsertMention();
+      else if (panel === 'commands') handleInsertSlash();
+      else if (panel === 'files') handleAddFiles();
+      else if (panel === 'folder') handleInsertFolder();
+    },
+    [handleInsertMention, handleInsertSlash, handleAddFiles, handleInsertFolder],
+  );
+
+  const composerCtx = useMemo<ComposerContext>(
+    () => ({
+      instanceId,
+      machineId,
+      cwd: projectPath ?? null,
+      agentType,
+      insertText: insertAtCaret,
+      openPanel: openComposerPanel,
+    }),
+    [instanceId, machineId, projectPath, agentType, insertAtCaret, openComposerPanel],
+  );
+  const pluginMenuItems = usePluginComposerMenuItems(composerCtx);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Handle slash command navigation
     if (showSlashCommands) {
@@ -785,6 +836,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
             onCommands={handleInsertSlash}
             hasSkills={hasSkills}
             disabled={disabled || !canSendMessage}
+            extraItems={pluginMenuItems}
           />
 
           {showControlSettings && (
@@ -818,6 +870,9 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
               Claude session refreshes the rate-limit windows from the
               machine's daemon (Codex limits stay in-band only). */}
           <ChatUsageIndicator usage={usage} fetchLimits={usageFetchLimits} />
+
+          {/* Standalone toolbar buttons contributed by plugins (Tier 1). */}
+          <PluginComposerActions ctx={composerCtx} disabled={disabled || !canSendMessage} />
 
         </div>
 

--- a/apps/web/components/dashboard/add-to-chat-menu.tsx
+++ b/apps/web/components/dashboard/add-to-chat-menu.tsx
@@ -1,13 +1,24 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { Plus, AtSign, Paperclip, FolderPlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+
+/** An additional "+" menu row, e.g. contributed by a plugin. */
+export interface AddToChatExtraItem {
+  id: string;
+  label: string;
+  /** Pre-rendered icon node so this component stays plugin-agnostic. */
+  icon?: ReactNode;
+  onSelect: () => void;
+}
 
 /**
  * "+" (Add to chat) affordance shared by the chat input and the new-session
@@ -31,6 +42,7 @@ export function AddToChatMenu({
   onCommands,
   hasSkills,
   disabled,
+  extraItems,
 }: {
   // Opens the system file picker for attachments (images or any other file).
   // Optional — surfaces without an instance to upload against omit it.
@@ -45,6 +57,8 @@ export function AddToChatMenu({
   // trigger ("Skills or Commands"); Codex (and ACP agents) only have commands.
   hasSkills: boolean;
   disabled?: boolean;
+  // Extra rows contributed by plugins (Tier 1 composer actions, placement "menu").
+  extraItems?: AddToChatExtraItem[];
 }) {
   return (
     <DropdownMenu>
@@ -105,6 +119,23 @@ export function AddToChatMenu({
           <SlashGlyph />
           <span className="truncate">{hasSkills ? 'Skills or Commands' : 'Commands'}</span>
         </DropdownMenuItem>
+        {extraItems && extraItems.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            {extraItems.map((item) => (
+              <DropdownMenuItem
+                key={item.id}
+                onClick={item.onSelect}
+                className="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer"
+              >
+                <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center text-muted-foreground">
+                  {item.icon}
+                </span>
+                <span className="truncate">{item.label}</span>
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/components/dashboard/desktop-settings-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-settings-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useCallback, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Bot, Folder, Keyboard, Monitor, Settings, User } from 'lucide-react';
+import { ArrowLeft, Bot, Folder, Keyboard, Monitor, Puzzle, Settings, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
 import { DesktopTitlebarLead } from '@/components/desktop/window-chrome';
@@ -25,6 +25,7 @@ export const DESKTOP_SETTINGS_TABS = [
   { id: 'profile', label: 'Profile', Icon: User },
   { id: 'providers', label: 'Providers', Icon: Bot },
   { id: 'machines', label: 'Machines', Icon: Monitor },
+  { id: 'plugins', label: 'Plugins', Icon: Puzzle },
   { id: 'shortcuts', label: 'Keyboard shortcuts', Icon: Keyboard },
 ] as const;
 

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { getDesktopConfig, type DesktopRuntimeConfig } from '@/lib/runtime-config';
+import { ThemeSelect } from '@/components/plugins/theme-select';
 import {
   checkForUpdates,
   downloadUpdate,
@@ -69,6 +70,7 @@ import {
 import { activeSettingsTab } from './desktop-settings-sidebar';
 import { ProvidersSettingsSection } from './providers-settings-section';
 import { MachinesSettingsSection } from './machines-settings-section';
+import { PluginsSettingsSection } from './plugins-settings-section';
 import { WorktreeSetupSection } from './worktree-setup-section';
 import { ProjectDisplaySection } from './project-display-section';
 import { useMobileSidebarHidden, setMobileSidebarHidden } from '@/lib/mobile-sidebar-pref';
@@ -95,6 +97,8 @@ export function DesktopSettings() {
             <ProvidersSettingsSection />
           ) : tab === 'machines' ? (
             <MachinesSettingsSection />
+          ) : tab === 'plugins' ? (
+            <PluginsSettingsSection />
           ) : tab === 'project' ? (
             <ProjectSection
               projectId={searchParams.get('projectId') ?? ''}
@@ -418,6 +422,17 @@ function GeneralSection() {
   return (
     <section>
       <SectionTitle>General</SectionTitle>
+      <div className="mt-8">
+        <h2 className="mb-3 text-sm text-foreground/90">Appearance</h2>
+        <SettingsCard>
+          <SettingsRow
+            title="Theme"
+            description="Base mode, or a theme installed from a plugin"
+          >
+            <ThemeSelect />
+          </SettingsRow>
+        </SettingsCard>
+      </div>
       <div className="mt-8">
         <h2 className="mb-3 text-sm text-foreground/90">Notifications</h2>
         <SettingsCard>

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -25,6 +25,7 @@ import { ReportIssueDialog } from '@/components/dashboard/report-issue-dialog';
 import { SidebarUpdateCallout } from '@/components/dashboard/sidebar-update-callout';
 import { comboKeycaps, getShortcutCombo } from '@/lib/desktop-shortcuts';
 import { SidebarSessions } from '@/components/dashboard/sidebar-sessions';
+import { PluginSidebarItems } from '@/components/plugins/plugin-sidebar-items';
 import { SetupChecklist } from '@/components/dashboard/setup-checklist';
 import { useTerminalSessions } from '@/components/terminal-pane/terminal-sessions';
 
@@ -259,6 +260,9 @@ export function DesktopSidebar({
           <BookOpen className="h-4 w-4 mr-1.5" />
           Skills
         </Button>
+
+        {/* Nav entries contributed by installed plugins (Tier 1). */}
+        <PluginSidebarItems slot="nav" />
 
         {/* Workspace search across sessions, tasks, automations (also ⌘K). */}
         <Button

--- a/apps/web/components/dashboard/plugins-settings-section.tsx
+++ b/apps/web/components/dashboard/plugins-settings-section.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+/**
+ * Settings > Plugins. The management surface for locally-installed plugins,
+ * grouped by machine. Reads each online machine's `plugin-list` RPC (the
+ * authoritative management view — includes malformed plugins and raw enable
+ * state) and drives enable / trust / remove through the daemon, updating the
+ * shared registry optimistically so the rest of the app reflects changes at
+ * once. Desktop-only (rendered inside the desktop settings page).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, Puzzle, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
+import type { MachineSummary } from '@/lib/backend-api';
+import { getRpcClient } from '@/lib/ws-client';
+import { isMachineOnline, sortMachinesOnlineFirst } from '@/lib/session-liveness';
+import { getDesktopConfig } from '@/lib/runtime-config';
+import { ensureLocalMachineId } from '@/lib/local-machine';
+import { pluginRegistry } from '@/lib/plugins/registry';
+
+interface PluginListItem {
+  id: string;
+  dir: string;
+  name: string;
+  valid: boolean;
+  errors: string[];
+  enabled: boolean;
+  trusted: boolean;
+  source?: string | null;
+  contributes: Record<string, number>;
+}
+
+interface PluginListPayload {
+  plugins_enabled: boolean;
+  plugins: PluginListItem[];
+}
+
+interface MachinePlugins {
+  machine: MachineSummary;
+  data: PluginListPayload | null;
+  error: boolean;
+}
+
+function machineLabel(m: MachineSummary): string {
+  return m.display_name || m.hostname || m.machine_id;
+}
+
+function contributionText(contributes: Record<string, number>): string {
+  const parts = Object.entries(contributes)
+    .filter(([, n]) => n > 0)
+    .map(([k, n]) => `${n} ${k}`);
+  return parts.join(' · ') || 'no visible contributions';
+}
+
+export function PluginsSettingsSection() {
+  const { api } = useAgentDashboard();
+  const [groups, setGroups] = useState<MachinePlugins[] | null>(null);
+
+  const load = useCallback(async () => {
+    let machines: MachineSummary[] = [];
+    if (api) {
+      try {
+        machines = await api.listMachines();
+      } catch {
+        machines = [];
+      }
+    }
+    const now = Date.now();
+    const online = sortMachinesOnlineFirst(machines.filter((m) => isMachineOnline(m, now)));
+
+    // On desktop, always include this computer — its local daemon is reachable
+    // even in logged-out local mode, where `listMachines` may return nothing.
+    if (getDesktopConfig()) {
+      const localId = await ensureLocalMachineId();
+      if (localId && !online.some((m) => m.machine_id === localId)) {
+        online.unshift({ machine_id: localId, display_name: 'This machine', recent_directories: [] });
+      }
+    }
+
+    const results = await Promise.all(
+      online.map(async (machine): Promise<MachinePlugins> => {
+        try {
+          const data = (await getRpcClient(machine.machine_id).callRpc(
+            machine.machine_id,
+            'plugin-list',
+            {},
+          )) as unknown as PluginListPayload;
+          return { machine, data, error: false };
+        } catch {
+          return { machine, data: null, error: true };
+        }
+      }),
+    );
+    setGroups(results);
+  }, [api]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const setEnabledGlobally = async (machineId: string, enabled: boolean) => {
+    try {
+      await getRpcClient(machineId).callRpc(machineId, 'plugin-set-enabled', { enabled });
+    } catch {
+      /* ignore */
+    }
+    await load();
+  };
+
+  const setEnabled = async (machineId: string, dir: string, enabled: boolean) => {
+    try {
+      await getRpcClient(machineId).callRpc(machineId, 'plugin-enable', {
+        plugin_id: dir,
+        enabled,
+      });
+      pluginRegistry.setEnabled(machineId, dir, enabled);
+    } catch {
+      /* ignore */
+    }
+    await load();
+  };
+
+  const trust = async (machineId: string, dir: string) => {
+    try {
+      await getRpcClient(machineId).callRpc(machineId, 'plugin-trust-grant', { plugin_id: dir });
+      pluginRegistry.setTrusted(machineId, dir, true);
+    } catch {
+      /* ignore */
+    }
+    await load();
+  };
+
+  const remove = async (machineId: string, dir: string) => {
+    try {
+      await getRpcClient(machineId).callRpc(machineId, 'plugin-remove', { plugin_id: dir });
+      pluginRegistry.removePlugin(machineId, dir);
+    } catch {
+      /* ignore */
+    }
+    await load();
+  };
+
+  return (
+    <section>
+      <h1 className="text-2xl font-light tracking-tight text-foreground">Plugins</h1>
+      <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+        Plugins customize Vicoa — themes, sidebar entries, and composer actions —
+        from files on your machine. Install with{' '}
+        <code className="rounded bg-foreground/10 px-1 py-0.5 text-xs">vicoa plugin add</code>.
+        Approve a new plugin before it takes effect; disable or remove any here.
+      </p>
+
+      {groups === null ? (
+        <div className="mt-8 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading plugins…
+        </div>
+      ) : groups.length === 0 ? (
+        <p className="mt-8 text-sm text-muted-foreground">
+          No machines are online. Connect a machine to manage its plugins.
+        </p>
+      ) : (
+        groups.map(({ machine, data, error }) => (
+          <div key={machine.machine_id} className="mt-8">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-sm text-foreground/90">{machineLabel(machine)}</h2>
+              {data && (
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  Plugins enabled
+                  <Switch
+                    checked={data.plugins_enabled}
+                    onCheckedChange={(v) => void setEnabledGlobally(machine.machine_id, v)}
+                  />
+                </label>
+              )}
+            </div>
+
+            {error || !data ? (
+              <p className="text-xs text-muted-foreground">
+                Couldn&apos;t reach this machine&apos;s daemon.
+              </p>
+            ) : data.plugins.length === 0 ? (
+              <div className="flex items-center gap-2 rounded-xl border border-dashed border-border/60 px-4 py-6 text-sm text-muted-foreground">
+                <Puzzle className="h-4 w-4" /> No plugins installed on this machine.
+              </div>
+            ) : (
+              <div className="divide-y divide-border/50 rounded-xl border border-border/60 bg-foreground/[0.03]">
+                {data.plugins.map((p) => (
+                  <div key={p.dir} className="flex items-start justify-between gap-4 px-4 py-3.5">
+                    <div className="min-w-0 space-y-0.5">
+                      <div className="flex items-center gap-2 text-[13px] text-foreground">
+                        {p.name}
+                        <span className="font-mono text-xs text-muted-foreground">{p.id}</span>
+                        {!p.valid && (
+                          <span className="rounded bg-destructive/15 px-1.5 py-0.5 text-[10px] text-destructive">
+                            invalid
+                          </span>
+                        )}
+                        {p.valid && !p.trusted && (
+                          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-500">
+                            untrusted
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {p.valid ? contributionText(p.contributes) : p.errors[0] ?? 'unreadable manifest'}
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {p.valid && !p.trusted && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          onClick={() => void trust(machine.machine_id, p.dir)}
+                        >
+                          Trust
+                        </Button>
+                      )}
+                      {p.valid && (
+                        <Switch
+                          checked={p.enabled}
+                          onCheckedChange={(v) => void setEnabled(machine.machine_id, p.dir, v)}
+                          aria-label="Enable plugin"
+                        />
+                      )}
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className={cn('h-7 w-7 text-muted-foreground hover:text-destructive')}
+                        title="Remove plugin"
+                        onClick={() => void remove(machine.machine_id, p.dir)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/plugins/plugin-catalog-sync.tsx
+++ b/apps/web/components/plugins/plugin-catalog-sync.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * Populates the plugin registry from every online machine's daemon.
+ *
+ * Mounted once inside the dashboard. On a 60s cadence (and on the machine list
+ * changing) it calls each online machine's `plugin-catalog` RPC with the last
+ * ETag; unchanged catalogs return `not_modified` and cost nothing. The RPC
+ * routes through the same channel as every other daemon call — the local socket
+ * on desktop, the cloud relay for a remote machine — so Tier 1 plugins light up
+ * on plain web too, for any machine whose daemon is connected.
+ *
+ * Renders nothing.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
+import { getRpcClient } from '@/lib/ws-client';
+import { isMachineOnline } from '@/lib/session-liveness';
+import { getDesktopConfig } from '@/lib/runtime-config';
+import { ensureLocalMachineId } from '@/lib/local-machine';
+import { pluginRegistry } from '@/lib/plugins/registry';
+import { mapCatalog, type CatalogWire } from '@/lib/plugins/catalog';
+
+const POLL_MS = 60_000;
+
+export function PluginCatalogSync() {
+  const { api } = useAgentDashboard();
+  const etags = useRef<Record<string, string>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      // Target set = online cloud machines + this desktop's local machine. The
+      // local daemon is always reachable on desktop even in logged-out local
+      // mode (where `listMachines` may be unavailable), so include it directly
+      // — that's the primary desktop-first path.
+      const targets = new Set<string>();
+      if (api) {
+        try {
+          const now = Date.now();
+          for (const m of await api.listMachines()) {
+            if (isMachineOnline(m, now)) targets.add(m.machine_id);
+          }
+        } catch {
+          // fall through — the local machine below may still be reachable
+        }
+      }
+      if (getDesktopConfig()) {
+        const localId = await ensureLocalMachineId();
+        if (localId) targets.add(localId);
+      }
+      if (cancelled) return;
+
+      // Forget catalogs from machines no longer in the target set.
+      for (const id of Object.keys(etags.current)) {
+        if (!targets.has(id)) {
+          delete etags.current[id];
+          pluginRegistry.clearMachine(id);
+        }
+      }
+
+      await Promise.all(
+        [...targets].map(async (machineId) => {
+          try {
+            const res = (await getRpcClient(machineId).callRpc(machineId, 'plugin-catalog', {
+              etag: etags.current[machineId],
+            })) as CatalogWire;
+            if (cancelled) return;
+            if (res.not_modified) return;
+            if (res.etag) etags.current[machineId] = res.etag;
+            pluginRegistry.setMachinePlugins(machineId, mapCatalog(machineId, res));
+          } catch {
+            // Machine unreachable or daemon too old to know the RPC; keep prior
+            // state rather than dropping the plugins mid-session.
+          }
+        }),
+      );
+    };
+
+    void tick();
+    const id = window.setInterval(() => void tick(), POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [api]);
+
+  return null;
+}

--- a/apps/web/components/plugins/plugin-composer-actions.tsx
+++ b/apps/web/components/plugins/plugin-composer-actions.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * Plugin-contributed composer actions (Tier 1).
+ *
+ * - `<PluginComposerActions>` renders the `placement:"toolbar"` actions as small
+ *   icon buttons alongside the composer's own controls.
+ * - `usePluginComposerMenuItems(ctx)` builds `placement:"menu"` actions into the
+ *   `AddToChatMenu` `extraItems` shape.
+ *
+ * Both run their behavior through the narrowed `ComposerContext`, so a plugin
+ * only ever inserts text or opens an existing picker — never touches composer
+ * internals.
+ */
+
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { usePluginComposerActions } from '@/lib/plugins/hooks';
+import { applyComposerBehavior, type ComposerContext } from '@/lib/plugins/composer';
+import type { AddToChatExtraItem } from '@/components/dashboard/add-to-chat-menu';
+import { PluginIcon } from './plugin-icon';
+
+export function PluginComposerActions({
+  ctx,
+  disabled,
+}: {
+  ctx: ComposerContext;
+  disabled?: boolean;
+}) {
+  const actions = usePluginComposerActions('toolbar');
+  if (actions.length === 0) return null;
+  return (
+    <>
+      {actions.map(({ action, pluginId, machineId }) => (
+        <Button
+          key={`${machineId}:${pluginId}:${action.id}`}
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={disabled}
+          title={action.label}
+          className="shrink-0 rounded-full w-8 h-8 p-0 border-0 outline-none ring-0 hover:bg-muted-foreground/10 focus-visible:ring-0"
+          onClick={() => applyComposerBehavior(action.behavior, ctx)}
+        >
+          <PluginIcon name={action.icon} className="w-4 h-4" />
+        </Button>
+      ))}
+    </>
+  );
+}
+
+/** The `placement:"menu"` composer actions as AddToChatMenu extra rows. */
+export function usePluginComposerMenuItems(ctx: ComposerContext): AddToChatExtraItem[] {
+  const actions = usePluginComposerActions('menu');
+  return useMemo(
+    () =>
+      actions.map(({ action }) => ({
+        id: action.id,
+        label: action.label,
+        icon: <PluginIcon name={action.icon} className="h-3.5 w-3.5" />,
+        onSelect: () => applyComposerBehavior(action.behavior, ctx),
+      })),
+    [actions, ctx],
+  );
+}

--- a/apps/web/components/plugins/plugin-icon.tsx
+++ b/apps/web/components/plugins/plugin-icon.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/**
+ * Controlled icon set for plugins. A plugin references an icon by whitelisted
+ * name (see ICON_WHITELIST in backend/src/protocol/plugin_manifest.py) and this
+ * component maps it to a concrete lucide-react glyph. An unknown/absent name
+ * falls back to the Puzzle icon, so a plugin can never pull in an arbitrary
+ * component. Keep this map in sync with the backend whitelist.
+ */
+
+import {
+  Bell,
+  BookOpen,
+  Bot,
+  Bug,
+  CalendarClock,
+  Check,
+  Clipboard,
+  Cloud,
+  Code,
+  Command,
+  Database,
+  Download,
+  ExternalLink,
+  File,
+  Folder,
+  GitBranch,
+  Globe,
+  Key,
+  Layers,
+  Link as LinkIcon,
+  ListTodo,
+  Lock,
+  MessageSquare,
+  Palette,
+  PanelLeft,
+  Play,
+  Plus,
+  Puzzle,
+  RefreshCw,
+  Rocket,
+  Search,
+  Settings,
+  Shield,
+  Sparkles,
+  Star,
+  Terminal,
+  Upload,
+  Wrench,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react';
+
+const ICONS: Record<string, LucideIcon> = {
+  'book-open': BookOpen,
+  'list-todo': ListTodo,
+  'calendar-clock': CalendarClock,
+  layers: Layers,
+  settings: Settings,
+  terminal: Terminal,
+  sparkles: Sparkles,
+  zap: Zap,
+  star: Star,
+  link: LinkIcon,
+  'external-link': ExternalLink,
+  folder: Folder,
+  file: File,
+  search: Search,
+  plus: Plus,
+  play: Play,
+  'refresh-cw': RefreshCw,
+  bell: Bell,
+  bot: Bot,
+  code: Code,
+  'git-branch': GitBranch,
+  'message-square': MessageSquare,
+  bug: Bug,
+  wrench: Wrench,
+  palette: Palette,
+  puzzle: Puzzle,
+  rocket: Rocket,
+  globe: Globe,
+  database: Database,
+  cloud: Cloud,
+  key: Key,
+  lock: Lock,
+  shield: Shield,
+  check: Check,
+  clipboard: Clipboard,
+  download: Download,
+  upload: Upload,
+  command: Command,
+  'panel-left': PanelLeft,
+};
+
+export function PluginIcon({
+  name,
+  className,
+}: {
+  name?: string;
+  className?: string;
+}) {
+  const Icon = (name && ICONS[name]) || Puzzle;
+  return <Icon className={className} />;
+}

--- a/apps/web/components/plugins/plugin-sidebar-items.tsx
+++ b/apps/web/components/plugins/plugin-sidebar-items.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * Renders the sidebar rows contributed by active plugins for a given slot.
+ * Drops into both dashboard sidebars (the always-expanded `desktop-sidebar` and
+ * the collapsible `dashboard-layout` rail) — pass `collapsed` to match the host.
+ * Renders nothing when no plugin contributes to the slot.
+ */
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { usePluginSidebarItems } from '@/lib/plugins/hooks';
+import { runSidebarAction } from '@/lib/plugins/actions';
+import { PluginIcon } from './plugin-icon';
+
+export function PluginSidebarItems({
+  slot = 'nav',
+  collapsed = false,
+  onNavigate,
+}: {
+  slot?: 'nav' | 'footer';
+  collapsed?: boolean;
+  onNavigate?: () => void;
+}) {
+  const items = usePluginSidebarItems(slot);
+  const router = useRouter();
+
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      {items.map(({ item, pluginId, machineId }) => (
+        <Button
+          key={`${machineId}:${pluginId}:${item.id}`}
+          variant="subtle"
+          title={item.label}
+          className={cn(
+            collapsed
+              ? 'h-9 w-9 justify-center rounded-lg px-0 bg-transparent'
+              : 'w-full justify-start h-auto py-1.5 mb-0.5 text-xs font-normal',
+          )}
+          onClick={() => {
+            void runSidebarAction(item.action, pluginId, {
+              machineId,
+              navigate: (href) => router.push(href),
+            });
+            onNavigate?.();
+          }}
+        >
+          <PluginIcon name={item.icon} className={cn('h-4 w-4', !collapsed && 'mr-1.5')} />
+          {collapsed ? <span className="sr-only">{item.label}</span> : item.label}
+        </Button>
+      ))}
+    </>
+  );
+}

--- a/apps/web/components/plugins/plugin-theme-style.tsx
+++ b/apps/web/components/plugins/plugin-theme-style.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * Injects the token overrides for the currently-selected plugin theme.
+ *
+ * The ThemeProvider applies the theme's *base* class (`.dark`/`.light`); this
+ * component renders a single `<style>` that overrides the specific shadcn
+ * tokens the plugin declared. Non-overridden tokens keep inheriting the base
+ * palette from `globals.css`, which is why a plugin only has to specify the
+ * handful of colors it actually changes.
+ *
+ * Safety: only whitelisted token names are emitted, and every value is
+ * validated against a strict character set + length cap, so a plugin can never
+ * break out of the declaration to inject arbitrary CSS. It renders nothing when
+ * a non-plugin theme (dark/light/system) is active.
+ *
+ * It also registers the built-in example theme plugins on mount so the picker
+ * has something to show before any real plugin catalog loads (P0).
+ */
+
+import { useEffect } from 'react';
+import { useTheme } from '@/components/theme-provider';
+import { usePluginThemes } from '@/lib/plugins/hooks';
+import { pluginRegistry } from '@/lib/plugins/registry';
+import { BUILTIN_PLUGIN_MANIFESTS } from '@/lib/plugins/builtin-themes';
+import { isThemeToken, parsePluginThemeValue } from '@/lib/plugins/types';
+
+/**
+ * Permitted value characters: digits, letters, whitespace, and the punctuation
+ * that appears in HSL triplets / lengths / hex / rgb()/hsl() functions. Notably
+ * excludes `;` `{` `}` `<` `>` `"` `'` `\` `:` and `@`, so a value cannot close
+ * the declaration or start a new rule/at-rule.
+ */
+const SAFE_VALUE = /^[0-9a-zA-Z%.,()/#\s_-]{1,64}$/;
+
+function sanitizeTokenValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (!SAFE_VALUE.test(trimmed)) return null;
+  // Defense in depth: reject the two CSS constructs that could still fetch or
+  // execute despite passing the char class if `(` is allowed for hsl()/rgb().
+  const lower = trimmed.toLowerCase();
+  if (lower.includes('url(') || lower.includes('expression')) return null;
+  return trimmed;
+}
+
+export function PluginThemeStyle() {
+  const { theme } = useTheme();
+  const themes = usePluginThemes();
+
+  // Register the built-in example themes once, after mount (idempotent).
+  useEffect(() => {
+    pluginRegistry.registerBuiltins(BUILTIN_PLUGIN_MANIFESTS);
+  }, []);
+
+  const parsed = parsePluginThemeValue(theme);
+  if (!parsed) return null;
+
+  const active = themes.find(
+    (t) => t.pluginId === parsed.pluginId && t.id === parsed.themeId,
+  );
+  if (!active) return null;
+
+  const declarations: string[] = [];
+  for (const [name, rawValue] of Object.entries(active.tokens)) {
+    if (!isThemeToken(name)) continue;
+    const value = sanitizeTokenValue(rawValue);
+    if (value === null) continue;
+    declarations.push(`--${name}:${value};`);
+  }
+  if (declarations.length === 0) return null;
+
+  // `:root` after globals.css wins over both the `:root` and `.dark` base
+  // blocks by equal specificity + later source order, so these overrides apply
+  // regardless of which base class the provider set.
+  const css = `:root{${declarations.join('')}}`;
+
+  return (
+    <style
+      data-plugin-theme={`${active.pluginId}/${active.id}`}
+      // Values are whitelisted + sanitized above; this is a static CSS string.
+      dangerouslySetInnerHTML={{ __html: css }}
+    />
+  );
+}

--- a/apps/web/components/plugins/plugin-trust-gate.tsx
+++ b/apps/web/components/plugins/plugin-trust-gate.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * First-load trust prompt. A plugin reported by a machine's daemon contributes
+ * nothing until the user approves it here (the registry filters on
+ * `enabled && trusted`). Editing a plugin's manifest changes its hash on the
+ * daemon side, which flips it back to untrusted and re-arms this prompt.
+ *
+ * Prompts one pending plugin at a time; "Not now" dismisses for this session
+ * (it reappears next launch until trusted). Renders nothing when there's
+ * nothing to approve.
+ */
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { usePluginRegistry } from '@/lib/plugins/hooks';
+import { grantPluginTrust } from '@/lib/plugins/actions';
+
+function contributionSummary(manifest: {
+  themes?: unknown[];
+  sidebarItems?: unknown[];
+  composerActions?: unknown[];
+  slashCommands?: unknown[];
+}): string {
+  const parts: string[] = [];
+  if (manifest.themes?.length) parts.push(`${manifest.themes.length} theme(s)`);
+  if (manifest.sidebarItems?.length) parts.push(`${manifest.sidebarItems.length} sidebar item(s)`);
+  if (manifest.composerActions?.length)
+    parts.push(`${manifest.composerActions.length} composer action(s)`);
+  if (manifest.slashCommands?.length)
+    parts.push(`${manifest.slashCommands.length} slash command(s)`);
+  return parts.join(' · ') || 'no visible contributions';
+}
+
+export function PluginTrustGate() {
+  const all = usePluginRegistry();
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState(false);
+
+  const pending = all.filter(
+    (p) =>
+      !p.builtin &&
+      !p.trusted &&
+      p.enabled &&
+      !dismissed.has(`${p.machineId}::${p.pluginId}`),
+  );
+  const current = pending[0];
+  if (!current) return null;
+
+  const key = `${current.machineId}::${current.pluginId}`;
+
+  const onTrust = async () => {
+    setBusy(true);
+    await grantPluginTrust(current.machineId, current.pluginId);
+    setBusy(false);
+  };
+
+  const onDismiss = () => {
+    setDismissed((prev) => new Set(prev).add(key));
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onDismiss()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Trust this plugin?</DialogTitle>
+          <DialogDescription>
+            A plugin was found on one of your machines. Approve it to let it
+            change Vicoa&apos;s appearance and add sidebar / composer actions.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 rounded-lg border border-border/60 bg-foreground/[0.03] p-3 text-sm">
+          <div className="flex items-center justify-between gap-3">
+            <span className="font-medium">{current.manifest.name ?? current.pluginId}</span>
+            <span className="font-mono text-xs text-muted-foreground">{current.pluginId}</span>
+          </div>
+          {current.manifest.description && (
+            <div className="text-xs text-muted-foreground">{current.manifest.description}</div>
+          )}
+          <div className="text-xs text-muted-foreground">
+            Contributes: {contributionSummary(current.manifest)}
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            Machine: <span className="font-mono">{current.machineId}</span>
+          </div>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Only approve plugins from sources you trust. You can disable or remove
+          it later in Settings &rsaquo; Plugins.
+        </p>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onDismiss} disabled={busy}>
+            Not now
+          </Button>
+          <Button onClick={onTrust} disabled={busy}>
+            {busy ? 'Trusting…' : 'Trust plugin'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/plugins/theme-select.tsx
+++ b/apps/web/components/plugins/theme-select.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * Theme picker that lists the three built-in modes plus every theme contributed
+ * by an active plugin, grouped by plugin. Selecting a plugin theme stores the
+ * `plugin:<pluginId>/<themeId>` value; the ThemeProvider applies its base class
+ * and <PluginThemeStyle/> injects the token overrides.
+ *
+ * Styled to match the settings selects (see GeneralSection's notifications row).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useTheme } from '@/components/theme-provider';
+import { usePluginThemes } from '@/lib/plugins/hooks';
+import { pluginThemeValue } from '@/lib/plugins/types';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const BASE_LABELS: Record<string, string> = {
+  dark: 'Dark',
+  light: 'Light',
+  system: 'System',
+};
+
+export function ThemeSelect() {
+  const { theme, setTheme } = useTheme();
+  const pluginThemes = usePluginThemes();
+  const [mounted, setMounted] = useState(false);
+
+  // `theme` is only meaningful after the provider reads localStorage post-mount.
+  useEffect(() => setMounted(true), []);
+
+  // Group plugin themes by their owning plugin for a tidy menu.
+  const grouped = useMemo(() => {
+    const byPlugin = new Map<string, { name: string; themes: typeof pluginThemes }>();
+    for (const t of pluginThemes) {
+      const entry = byPlugin.get(t.pluginId) ?? { name: t.pluginName, themes: [] };
+      entry.themes.push(t);
+      byPlugin.set(t.pluginId, entry);
+    }
+    return Array.from(byPlugin.values());
+  }, [pluginThemes]);
+
+  const currentLabel = useMemo(() => {
+    if (BASE_LABELS[theme]) return BASE_LABELS[theme];
+    const active = pluginThemes.find((t) => pluginThemeValue(t.pluginId, t.id) === theme);
+    return active?.label ?? 'Dark';
+  }, [theme, pluginThemes]);
+
+  if (!mounted) return null;
+
+  return (
+    <Select value={theme} onValueChange={(v) => setTheme(v as Parameters<typeof setTheme>[0])}>
+      <SelectTrigger
+        aria-label="Theme"
+        className="h-7 w-auto gap-1.5 border-border/70 bg-foreground/[0.06] px-2.5 py-0 text-xs shadow-none focus:ring-0 focus:ring-offset-0"
+      >
+        <SelectValue>{currentLabel}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="end" className="bg-[#2D2D2D] font-mono">
+        <SelectGroup>
+          {Object.entries(BASE_LABELS).map(([value, label]) => (
+            <SelectItem key={value} value={value} className="text-xs">
+              {label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+        {grouped.map((g) => (
+          <SelectGroup key={g.name}>
+            <SelectSeparator />
+            <SelectLabel className="text-[11px] text-muted-foreground">{g.name}</SelectLabel>
+            {g.themes.map((t) => (
+              <SelectItem
+                key={`${t.pluginId}/${t.id}`}
+                value={pluginThemeValue(t.pluginId, t.id)}
+                className="text-xs"
+              >
+                {t.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/web/components/theme-provider.tsx
+++ b/apps/web/components/theme-provider.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
+import { usePluginRegistry } from "@/lib/plugins/hooks";
+import { findPluginTheme } from "@/lib/plugins/registry";
+import { isPluginThemeValue, parsePluginThemeValue } from "@/lib/plugins/types";
 
-type Theme = "dark" | "light" | "system";
+// A theme is one of the three built-in modes, or a plugin theme encoded as
+// `plugin:<pluginId>/<themeId>` (see lib/plugins/types.ts). The plugin theme's
+// token overrides are injected by <PluginThemeStyle/>; here we only resolve and
+// apply its base palette class.
+type Theme = "dark" | "light" | "system" | `plugin:${string}`;
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -30,6 +37,10 @@ export function ThemeProvider({
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(defaultTheme);
   const [mounted, setMounted] = useState(false);
+  // Re-run the class effect when plugins load: a `plugin:` theme restored from
+  // localStorage may arrive before its owning plugin's catalog does, so we need
+  // to re-resolve its base palette once the registry is populated.
+  const plugins = usePluginRegistry();
 
   // Initialize theme from localStorage on client side only
   useEffect(() => {
@@ -42,7 +53,7 @@ export function ThemeProvider({
 
   useEffect(() => {
     if (!mounted) return;
-    
+
     const root = window.document.documentElement;
 
     root.classList.remove("light", "dark");
@@ -57,8 +68,20 @@ export function ThemeProvider({
       return;
     }
 
+    if (isPluginThemeValue(theme)) {
+      // Apply the plugin theme's base palette class (dark/light). If the plugin
+      // hasn't loaded yet, fall back to dark until this effect re-runs with a
+      // populated `plugins` snapshot.
+      const parsed = parsePluginThemeValue(theme);
+      const resolved = parsed
+        ? findPluginTheme(parsed.pluginId, parsed.themeId, plugins)
+        : null;
+      root.classList.add(resolved?.base ?? "dark");
+      return;
+    }
+
     root.classList.add(theme);
-  }, [theme, mounted]);
+  }, [theme, mounted, plugins]);
 
   const value = {
     theme,

--- a/apps/web/lib/plugins/actions.ts
+++ b/apps/web/lib/plugins/actions.ts
@@ -1,0 +1,60 @@
+/**
+ * Executing plugin actions (sidebar items) and the trust round-trip.
+ * Composer behaviors live in `composer.ts` (they need the live composer handle).
+ */
+
+import { openExternalUrl } from '@/lib/open-external';
+import { getRpcClient } from '@/lib/ws-client';
+import { pluginRegistry } from './registry';
+import type { SidebarItemAction } from './types';
+
+export interface SidebarActionEnv {
+  machineId: string;
+  /** Router push for in-app navigation (internal open-url / surface routes). */
+  navigate: (href: string) => void;
+}
+
+/** Run a Tier 1 sidebar item's action. */
+export async function runSidebarAction(
+  action: SidebarItemAction,
+  pluginId: string,
+  env: SidebarActionEnv,
+): Promise<void> {
+  switch (action.type) {
+    case 'open-url':
+      if (action.external || /^https?:\/\//.test(action.url)) {
+        openExternalUrl(action.url);
+      } else {
+        env.navigate(action.url);
+      }
+      return;
+    case 'rpc':
+      try {
+        await getRpcClient(env.machineId).callRpc(env.machineId, action.method, action.params ?? {});
+      } catch {
+        // A failed plugin RPC must not surface as an app error; the plugin's own
+        // UI (a surface/panel) is where richer feedback belongs.
+      }
+      return;
+    case 'surface':
+      // Tier 2 surfaces are wired in P2; route to the (future) surface page.
+      env.navigate(`/dashboard/plugin/${env.machineId}/${pluginId}/${action.surfaceId}`);
+      return;
+  }
+}
+
+/** Grant trust for a plugin and reflect it locally so it starts contributing. */
+export async function grantPluginTrust(machineId: string, pluginId: string): Promise<boolean> {
+  try {
+    const res = (await getRpcClient(machineId).callRpc(machineId, 'plugin-trust-grant', {
+      plugin_id: pluginId,
+    })) as { ok?: boolean; error?: string };
+    if (res.ok) {
+      pluginRegistry.setTrusted(machineId, pluginId, true);
+      return true;
+    }
+  } catch {
+    // fall through
+  }
+  return false;
+}

--- a/apps/web/lib/plugins/builtin-themes.ts
+++ b/apps/web/lib/plugins/builtin-themes.ts
@@ -1,0 +1,96 @@
+/**
+ * Built-in example theme plugins.
+ *
+ * These ship with the app so the theme picker demonstrates plugin themes with
+ * no daemon/backend involved (P0). They register under the synthetic
+ * `builtin` machine and are always trusted. Real user plugins arrive later via
+ * the `plugin-catalog` RPC and flow through the exact same code path.
+ *
+ * Tokens are bare HSL triplets consumed as `hsl(var(--token))`, matching
+ * `app/globals.css`. Only whitelisted tokens are honoured (see
+ * `THEME_TOKEN_WHITELIST`).
+ */
+
+import { type PluginManifest, PLUGIN_API_VERSION } from './types';
+
+const catppuccin: PluginManifest = {
+  id: 'catppuccin',
+  apiVersion: PLUGIN_API_VERSION,
+  name: 'Catppuccin',
+  description: 'Soothing pastel themes — the community Catppuccin palette.',
+  author: 'Vicoa (example)',
+  themes: [
+    {
+      id: 'mocha',
+      label: 'Catppuccin Mocha',
+      base: 'dark',
+      tokens: {
+        background: '240 21% 15%',
+        foreground: '226 64% 88%',
+        card: '240 21% 12%',
+        'card-foreground': '226 64% 88%',
+        popover: '240 21% 12%',
+        'popover-foreground': '226 64% 88%',
+        primary: '267 84% 81%',
+        'primary-foreground': '240 21% 15%',
+        secondary: '237 16% 23%',
+        'secondary-foreground': '226 64% 88%',
+        muted: '237 16% 23%',
+        'muted-foreground': '228 24% 72%',
+        accent: '237 16% 23%',
+        'accent-foreground': '226 64% 88%',
+        destructive: '343 81% 75%',
+        'destructive-foreground': '240 21% 15%',
+        border: '234 13% 31%',
+        input: '234 13% 31%',
+        ring: '267 84% 81%',
+        'sidebar-background': '240 23% 9%',
+        'sidebar-foreground': '226 64% 88%',
+        'sidebar-primary': '267 84% 81%',
+        'sidebar-primary-foreground': '240 21% 15%',
+        'sidebar-accent': '237 16% 23%',
+        'sidebar-accent-foreground': '226 64% 88%',
+        'sidebar-border': '234 13% 31%',
+        'sidebar-ring': '267 84% 81%',
+        'message-text': '226 64% 88%',
+      },
+    },
+    {
+      id: 'latte',
+      label: 'Catppuccin Latte',
+      base: 'light',
+      tokens: {
+        background: '220 23% 95%',
+        foreground: '234 16% 35%',
+        card: '220 22% 92%',
+        'card-foreground': '234 16% 35%',
+        popover: '220 22% 92%',
+        'popover-foreground': '234 16% 35%',
+        primary: '266 85% 58%',
+        'primary-foreground': '220 23% 95%',
+        secondary: '223 16% 83%',
+        'secondary-foreground': '234 16% 35%',
+        muted: '223 16% 83%',
+        'muted-foreground': '233 10% 47%',
+        accent: '223 16% 83%',
+        'accent-foreground': '234 16% 35%',
+        destructive: '347 87% 44%',
+        'destructive-foreground': '220 23% 95%',
+        border: '223 16% 83%',
+        input: '223 16% 83%',
+        ring: '266 85% 58%',
+        'sidebar-background': '223 16% 88%',
+        'sidebar-foreground': '234 16% 35%',
+        'sidebar-primary': '266 85% 58%',
+        'sidebar-primary-foreground': '220 23% 95%',
+        'sidebar-accent': '223 16% 83%',
+        'sidebar-accent-foreground': '234 16% 35%',
+        'sidebar-border': '223 16% 83%',
+        'sidebar-ring': '266 85% 58%',
+        'message-text': '234 16% 35%',
+      },
+    },
+  ],
+};
+
+export const BUILTIN_PLUGIN_MANIFESTS: PluginManifest[] = [catppuccin];

--- a/apps/web/lib/plugins/catalog.ts
+++ b/apps/web/lib/plugins/catalog.ts
@@ -1,0 +1,48 @@
+/**
+ * Wire shape of the daemon's `plugin-catalog` RPC and the mapper into the
+ * renderer's `RegisteredPlugin`. Mirrors `plugin_ops.plugin_catalog` in the
+ * backend.
+ */
+
+import type { PluginManifest } from './types';
+import type { RegisteredPlugin } from './registry';
+
+export interface CatalogPluginWire {
+  id: string;
+  /** On-disk directory name; the authoritative key for enable/trust/remove. */
+  dir: string;
+  manifest: PluginManifest;
+  enabled: boolean;
+  trusted: boolean;
+  server_available: boolean;
+  source?: string | null;
+  api_compatible: boolean;
+}
+
+export interface CatalogWire {
+  etag?: string;
+  plugins_enabled?: boolean;
+  plugins?: CatalogPluginWire[];
+  not_modified?: boolean;
+}
+
+/**
+ * Turn a catalog payload into registry entries. The global `plugins_enabled`
+ * master switch is folded into each plugin's effective `enabled` so a disabled
+ * master switch contributes nothing, while per-plugin state stays visible to the
+ * settings surface (which queries `plugin-list` directly).
+ */
+export function mapCatalog(machineId: string, res: CatalogWire): RegisteredPlugin[] {
+  const enabledGlobally = res.plugins_enabled !== false;
+  return (res.plugins ?? [])
+    .filter((p) => p.manifest && p.api_compatible)
+    .map((p) => ({
+      machineId,
+      pluginId: p.dir,
+      manifest: p.manifest,
+      enabled: enabledGlobally && p.enabled,
+      trusted: p.trusted,
+      serverAvailable: p.server_available,
+      builtin: false,
+    }));
+}

--- a/apps/web/lib/plugins/composer.ts
+++ b/apps/web/lib/plugins/composer.ts
@@ -1,0 +1,51 @@
+/**
+ * The narrowed handle a plugin gets into the composer. Deliberately small: it
+ * exposes intent-level operations (insert text, open an existing picker) rather
+ * than internal composer state, so a UI refactor can't break plugins and a
+ * plugin can't reach into the draft machinery. Tier 1 behaviors are applied
+ * through `applyComposerBehavior`.
+ */
+
+import { folderPathToMention } from '@/lib/chat-drop';
+import type { ComposerActionBehavior } from './types';
+
+/** Existing composer pickers a plugin action may open. */
+export type ComposerPanel = 'mention' | 'commands' | 'files' | 'folder';
+
+export interface ComposerContext {
+  instanceId: string | null;
+  machineId: string | null;
+  /** The session's working directory (project root), for path-relative mentions. */
+  cwd: string | null;
+  agentType: string;
+  /** Insert literal text at the cursor. */
+  insertText(text: string): void;
+  /** Open one of the built-in composer pickers. */
+  openPanel(panel: ComposerPanel): void;
+}
+
+/** Run a Tier 1 composer action against the live composer context. */
+export function applyComposerBehavior(
+  behavior: ComposerActionBehavior,
+  ctx: ComposerContext,
+): void {
+  switch (behavior.type) {
+    case 'insert-text':
+      ctx.insertText(behavior.text);
+      return;
+    case 'insert-path-ref':
+      ctx.insertText(`@${folderPathToMention(behavior.path, ctx.cwd)}`);
+      return;
+    case 'panel': {
+      const map: Record<string, ComposerPanel> = {
+        mention: 'mention',
+        commands: 'commands',
+        files: 'files',
+        folder: 'folder',
+      };
+      const panel = map[behavior.panelId];
+      if (panel) ctx.openPanel(panel);
+      return;
+    }
+  }
+}

--- a/apps/web/lib/plugins/hooks.ts
+++ b/apps/web/lib/plugins/hooks.ts
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * React bindings for the plugin registry. Components use these; the registry
+ * itself (`registry.ts`) stays framework-free so non-React callers (the WS
+ * layer, the theme provider) can read it too.
+ */
+
+import { useMemo, useSyncExternalStore } from 'react';
+import {
+  pluginRegistry,
+  getPluginThemesSnapshot,
+  getPluginSidebarItems,
+  getPluginComposerActions,
+  type RegisteredPlugin,
+  type ResolvedTheme,
+  type OwnedSidebarItem,
+  type OwnedComposerAction,
+} from './registry';
+
+/** All registered plugins (across every machine), re-rendering on change. */
+export function usePluginRegistry(): RegisteredPlugin[] {
+  return useSyncExternalStore(
+    pluginRegistry.subscribe,
+    pluginRegistry.getSnapshot,
+    pluginRegistry.getServerSnapshot,
+  );
+}
+
+/** Themes from all active (enabled + trusted) plugins. */
+export function usePluginThemes(): ResolvedTheme[] {
+  const all = usePluginRegistry();
+  return useMemo(() => getPluginThemesSnapshot(all), [all]);
+}
+
+/** Sidebar items contributed to a given slot. */
+export function usePluginSidebarItems(slot: 'nav' | 'footer'): OwnedSidebarItem[] {
+  const all = usePluginRegistry();
+  return useMemo(() => getPluginSidebarItems(slot, all), [all, slot]);
+}
+
+/** Composer actions contributed to a given placement. */
+export function usePluginComposerActions(
+  placement: 'menu' | 'toolbar',
+): OwnedComposerAction[] {
+  const all = usePluginRegistry();
+  return useMemo(() => getPluginComposerActions(placement, all), [all, placement]);
+}

--- a/apps/web/lib/plugins/registry.ts
+++ b/apps/web/lib/plugins/registry.ts
@@ -1,0 +1,242 @@
+/**
+ * Plugin registry — the renderer's single source of truth for installed
+ * plugins, aggregated across every connected machine.
+ *
+ * Data flows in from the daemon's `plugin-catalog` RPC (per machine) via
+ * `setMachinePlugins`, plus any built-in example plugins registered at startup.
+ * Components read it through `usePluginRegistry()` (a `useSyncExternalStore`
+ * hook with a stable snapshot) and derive their slice with `useMemo`.
+ * `theme-provider.tsx` also reads it synchronously through the non-hook
+ * `getPluginThemesSnapshot()` accessor.
+ *
+ * Only **Tier 1** (declarative manifest) data lives here. The store is a plain
+ * module singleton — no React, no context — so it is safe to touch from the WS
+ * layer and from the theme provider's effect alike.
+ */
+
+import {
+  type PluginManifest,
+  type PluginThemeContribution,
+  type PluginSidebarItem,
+  type PluginComposerAction,
+  PLUGIN_API_VERSION,
+} from './types';
+
+/** Synthetic machine id for built-in/example plugins that ship with the app. */
+export const BUILTIN_MACHINE_ID = 'builtin';
+
+export interface RegisteredPlugin {
+  machineId: string;
+  pluginId: string;
+  manifest: PluginManifest;
+  /** User toggle from the daemon config; disabled plugins contribute nothing. */
+  enabled: boolean;
+  /** Trust-gate state. Untrusted plugins contribute nothing until confirmed. */
+  trusted: boolean;
+  /** Whether the plugin's optional backend subprocess is reachable (Tier 2). */
+  serverAvailable: boolean;
+  /** Built-in example plugins are always trusted and need no daemon round-trip. */
+  builtin: boolean;
+}
+
+/** A theme resolved to its owning plugin, ready for the picker / injector. */
+export interface ResolvedTheme extends PluginThemeContribution {
+  pluginId: string;
+  machineId: string;
+  pluginName: string;
+}
+
+function pluginKey(machineId: string, pluginId: string): string {
+  return `${machineId}::${pluginId}`;
+}
+
+class PluginRegistry {
+  private byKey = new Map<string, RegisteredPlugin>();
+  private listeners = new Set<() => void>();
+  /** Cached array handed to React; rebuilt only when data changes. */
+  private snapshot: RegisteredPlugin[] = [];
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): RegisteredPlugin[] => this.snapshot;
+
+  /** SSR: no plugins. Stable empty array keeps hydration deterministic. */
+  getServerSnapshot = (): RegisteredPlugin[] => EMPTY;
+
+  private commit() {
+    this.snapshot = Array.from(this.byKey.values());
+    for (const l of this.listeners) l();
+  }
+
+  /**
+   * Replace the full set of plugins reported by one machine. Called after a
+   * `plugin-catalog` fetch. Built-in plugins live under BUILTIN_MACHINE_ID and
+   * are untouched by real-machine updates.
+   */
+  setMachinePlugins(machineId: string, plugins: RegisteredPlugin[]) {
+    let changed = false;
+    // Drop any existing plugins from this machine that are no longer present.
+    const incoming = new Set(plugins.map((p) => pluginKey(machineId, p.pluginId)));
+    for (const key of Array.from(this.byKey.keys())) {
+      const p = this.byKey.get(key)!;
+      if (p.machineId === machineId && !incoming.has(key)) {
+        this.byKey.delete(key);
+        changed = true;
+      }
+    }
+    for (const p of plugins) {
+      if (p.manifest.apiVersion > PLUGIN_API_VERSION) continue; // host too old
+      this.byKey.set(pluginKey(machineId, p.pluginId), p);
+      changed = true;
+    }
+    if (changed) this.commit();
+  }
+
+  /** Register built-in example plugins (idempotent). */
+  registerBuiltins(manifests: PluginManifest[]) {
+    let changed = false;
+    for (const manifest of manifests) {
+      const key = pluginKey(BUILTIN_MACHINE_ID, manifest.id);
+      if (this.byKey.has(key)) continue;
+      this.byKey.set(key, {
+        machineId: BUILTIN_MACHINE_ID,
+        pluginId: manifest.id,
+        manifest,
+        enabled: true,
+        trusted: true,
+        serverAvailable: false,
+        builtin: true,
+      });
+      changed = true;
+    }
+    if (changed) this.commit();
+  }
+
+  /** Flip a plugin's trust flag locally (after the user clears the trust gate). */
+  setTrusted(machineId: string, pluginId: string, trusted: boolean) {
+    const p = this.byKey.get(pluginKey(machineId, pluginId));
+    if (p && p.trusted !== trusted) {
+      this.byKey.set(pluginKey(machineId, pluginId), { ...p, trusted });
+      this.commit();
+    }
+  }
+
+  /** Optimistic local toggle; the daemon config is the durable source. */
+  setEnabled(machineId: string, pluginId: string, enabled: boolean) {
+    const p = this.byKey.get(pluginKey(machineId, pluginId));
+    if (p && p.enabled !== enabled) {
+      this.byKey.set(pluginKey(machineId, pluginId), { ...p, enabled });
+      this.commit();
+    }
+  }
+
+  /** Remove a single plugin (e.g. after an uninstall from settings). */
+  removePlugin(machineId: string, pluginId: string) {
+    if (this.byKey.delete(pluginKey(machineId, pluginId))) this.commit();
+  }
+
+  /** Remove every plugin belonging to a machine (e.g. on disconnect). */
+  clearMachine(machineId: string) {
+    let changed = false;
+    for (const key of Array.from(this.byKey.keys())) {
+      if (this.byKey.get(key)!.machineId === machineId) {
+        this.byKey.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) this.commit();
+  }
+}
+
+const EMPTY: RegisteredPlugin[] = [];
+
+/** Process-wide singleton. */
+export const pluginRegistry = new PluginRegistry();
+
+// ---------------------------------------------------------------------------
+// Non-hook selectors (safe to call outside React, e.g. the theme provider).
+// ---------------------------------------------------------------------------
+
+/** Plugins that actively contribute: enabled AND trusted. */
+export function activePlugins(all: RegisteredPlugin[] = pluginRegistry.getSnapshot()): RegisteredPlugin[] {
+  return all.filter((p) => p.enabled && p.trusted);
+}
+
+/** Every theme from every active plugin, flattened and resolved to its owner. */
+export function getPluginThemesSnapshot(
+  all: RegisteredPlugin[] = pluginRegistry.getSnapshot(),
+): ResolvedTheme[] {
+  const out: ResolvedTheme[] = [];
+  for (const p of activePlugins(all)) {
+    for (const theme of p.manifest.themes ?? []) {
+      out.push({
+        ...theme,
+        pluginId: p.pluginId,
+        machineId: p.machineId,
+        pluginName: p.manifest.name ?? p.pluginId,
+      });
+    }
+  }
+  return out;
+}
+
+/** Look up a single theme by `pluginId` + `themeId` across active plugins. */
+export function findPluginTheme(
+  pluginId: string,
+  themeId: string,
+  all: RegisteredPlugin[] = pluginRegistry.getSnapshot(),
+): ResolvedTheme | null {
+  for (const t of getPluginThemesSnapshot(all)) {
+    if (t.pluginId === pluginId && t.id === themeId) return t;
+  }
+  return null;
+}
+
+/** Sidebar items from active plugins for a given slot, tagged with owner. */
+export interface OwnedSidebarItem {
+  item: PluginSidebarItem;
+  pluginId: string;
+  machineId: string;
+}
+
+export function getPluginSidebarItems(
+  slot: 'nav' | 'footer',
+  all: RegisteredPlugin[] = pluginRegistry.getSnapshot(),
+): OwnedSidebarItem[] {
+  const out: OwnedSidebarItem[] = [];
+  for (const p of activePlugins(all)) {
+    for (const item of p.manifest.sidebarItems ?? []) {
+      if ((item.slot ?? 'nav') === slot) {
+        out.push({ item, pluginId: p.pluginId, machineId: p.machineId });
+      }
+    }
+  }
+  return out;
+}
+
+/** Composer actions from active plugins for a given placement, tagged with owner. */
+export interface OwnedComposerAction {
+  action: PluginComposerAction;
+  pluginId: string;
+  machineId: string;
+}
+
+export function getPluginComposerActions(
+  placement: 'menu' | 'toolbar',
+  all: RegisteredPlugin[] = pluginRegistry.getSnapshot(),
+): OwnedComposerAction[] {
+  const out: OwnedComposerAction[] = [];
+  for (const p of activePlugins(all)) {
+    for (const action of p.manifest.composerActions ?? []) {
+      if ((action.placement ?? 'menu') === placement) {
+        out.push({ action, pluginId: p.pluginId, machineId: p.machineId });
+      }
+    }
+  }
+  return out;
+}

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -1,0 +1,172 @@
+/**
+ * Plugin system — shared type surface (renderer side).
+ *
+ * These types describe the **Tier 1** (declarative, no code execution) plugin
+ * contract: a `plugin.json` manifest that the daemon reads off disk and returns
+ * verbatim through the `plugin-catalog` RPC. The renderer aggregates manifests
+ * from every connected machine in `registry.ts` and turns them into themes,
+ * sidebar entries, and composer actions.
+ *
+ * The Python side mirrors this schema in
+ * `backend/src/protocol/plugin_manifest.py` — keep the two in sync. Tier 2
+ * (code bundles) is layered on later and does not change this file.
+ */
+
+/** Manifests declaring a higher apiVersion than this are rejected by the host. */
+export const PLUGIN_API_VERSION = 1 as const;
+
+/**
+ * Theme tokens a plugin is allowed to override. Mirrors the shadcn custom
+ * properties defined in `app/globals.css` (`:root` / `.dark`). Anything a
+ * plugin sends outside this set is dropped, so a theme can never inject
+ * arbitrary CSS custom properties.
+ *
+ * `radius` is the only non-HSL token (a length like `0.5rem`); every other
+ * value is a bare HSL triplet ("240 21% 15%") consumed as `hsl(var(--token))`.
+ */
+export const THEME_TOKEN_WHITELIST = [
+  'background',
+  'foreground',
+  'card',
+  'card-foreground',
+  'popover',
+  'popover-foreground',
+  'primary',
+  'primary-foreground',
+  'secondary',
+  'secondary-foreground',
+  'muted',
+  'muted-foreground',
+  'accent',
+  'accent-foreground',
+  'destructive',
+  'destructive-foreground',
+  'border',
+  'input',
+  'ring',
+  'chart-1',
+  'chart-2',
+  'chart-3',
+  'chart-4',
+  'chart-5',
+  'sidebar-background',
+  'sidebar-foreground',
+  'sidebar-primary',
+  'sidebar-primary-foreground',
+  'sidebar-accent',
+  'sidebar-accent-foreground',
+  'sidebar-border',
+  'sidebar-ring',
+  'message-text',
+  'radius',
+] as const;
+
+export type ThemeToken = (typeof THEME_TOKEN_WHITELIST)[number];
+
+/** Fast membership test for the token whitelist. */
+const TOKEN_SET: ReadonlySet<string> = new Set(THEME_TOKEN_WHITELIST);
+
+export function isThemeToken(name: string): name is ThemeToken {
+  return TOKEN_SET.has(name);
+}
+
+/** Which of the two built-in base palettes a plugin theme builds upon. */
+export type ThemeBase = 'dark' | 'light';
+
+export interface PluginThemeContribution {
+  /** Unique within the plugin. */
+  id: string;
+  /** Human label shown in the theme picker. */
+  label: string;
+  /** Base palette the theme inherits; also the `.dark`/`.light` class applied. */
+  base: ThemeBase;
+  /** Token name (without the leading `--`) → value. Unknown tokens are dropped. */
+  tokens: Record<string, string>;
+}
+
+/** What a sidebar item does when clicked. */
+export type SidebarItemAction =
+  /** Open a URL (external link or in-app route). */
+  | { type: 'open-url'; url: string; external?: boolean }
+  /** Invoke a daemon RPC method on the plugin's machine (Tier 1: read-only-ish). */
+  | { type: 'rpc'; method: string; params?: Record<string, unknown> }
+  /** Navigate to a Tier 2 plugin surface (wired in P2; declared here for stability). */
+  | { type: 'surface'; surfaceId: string };
+
+export interface PluginSidebarItem {
+  id: string;
+  label: string;
+  /** Icon name from the controlled `<Icon>` whitelist; falls back to a default. */
+  icon?: string;
+  /** Where the row appears in the sidebar. Defaults to `nav`. */
+  slot?: 'nav' | 'footer';
+  action: SidebarItemAction;
+}
+
+/** What a composer action inserts/triggers. Tier 1 stays within safe primitives. */
+export type ComposerActionBehavior =
+  /** Insert literal text at the cursor. */
+  | { type: 'insert-text'; text: string }
+  /** Insert an `@`-mention reference to an absolute path. */
+  | { type: 'insert-path-ref'; path: string }
+  /** Trigger an existing composer panel by id (e.g. the file/command pickers). */
+  | { type: 'panel'; panelId: string };
+
+export interface PluginComposerAction {
+  id: string;
+  label: string;
+  icon?: string;
+  /** `menu` = a row in the "+" menu; `toolbar` = a standalone icon button. */
+  placement?: 'menu' | 'toolbar';
+  behavior: ComposerActionBehavior;
+}
+
+export interface PluginSlashCommand {
+  id: string;
+  /** The command trigger, e.g. "/review". */
+  command: string;
+  label?: string;
+  /** Text inserted into the composer when the command is chosen. */
+  insertText: string;
+}
+
+/** The full parsed contents of a plugin's `plugin.json`. */
+export interface PluginManifest {
+  id: string;
+  apiVersion: number;
+  name?: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  homepage?: string;
+  themes?: PluginThemeContribution[];
+  sidebarItems?: PluginSidebarItem[];
+  composerActions?: PluginComposerAction[];
+  slashCommands?: PluginSlashCommand[];
+  /**
+   * Whether the plugin ships a Tier 2 client bundle (`dist/client.js`). Wired in
+   * P2; present here so the catalog shape is stable. The renderer only evaluates
+   * bundles on the desktop runtime.
+   */
+  hasClientBundle?: boolean;
+}
+
+/** A theme value encoded for the ThemeProvider: `plugin:<pluginId>/<themeId>`. */
+export function pluginThemeValue(pluginId: string, themeId: string): string {
+  return `plugin:${pluginId}/${themeId}`;
+}
+
+/** Parse a `plugin:<pluginId>/<themeId>` value back into its parts, or null. */
+export function parsePluginThemeValue(
+  value: string,
+): { pluginId: string; themeId: string } | null {
+  if (!value.startsWith('plugin:')) return null;
+  const rest = value.slice('plugin:'.length);
+  const slash = rest.indexOf('/');
+  if (slash <= 0 || slash === rest.length - 1) return null;
+  return { pluginId: rest.slice(0, slash), themeId: rest.slice(slash + 1) };
+}
+
+export function isPluginThemeValue(value: string): boolean {
+  return value.startsWith('plugin:');
+}

--- a/backend/src/protocol/plugin_manifest.py
+++ b/backend/src/protocol/plugin_manifest.py
@@ -1,0 +1,373 @@
+"""Plugin manifest schema, validation, and catalog ETag.
+
+The wire contract for **Tier 1** (declarative, no code execution) plugins. A
+plugin ships a ``plugin.json`` that the daemon reads off disk, validates here,
+and returns through the ``plugin-catalog`` RPC. The renderer mirror of this
+schema lives in ``apps/web/lib/plugins/types.ts`` — keep the two in sync.
+
+Validation is *tolerant*: a malformed individual contribution (one bad theme,
+one bad sidebar item) is dropped with a recorded warning rather than failing the
+whole plugin, but a manifest missing a usable ``id`` / ``apiVersion`` is
+rejected outright. The daemon only ever hands the renderer the sanitized shape,
+so the client never sees a token or icon it isn't prepared for. The renderer
+additionally re-sanitizes theme token *values* before injecting them (defense in
+depth), but the authoritative allow-lists are here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, TypeGuard
+
+# Manifests declaring a higher apiVersion than this are surfaced but the host
+# renderer skips them (it cannot understand a newer contract).
+PLUGIN_API_VERSION = 1
+
+# Theme tokens a plugin may override — the shadcn custom properties from
+# apps/web/app/globals.css. Anything outside this set is dropped so a theme can
+# never inject an arbitrary CSS custom property.
+THEME_TOKEN_WHITELIST: frozenset[str] = frozenset(
+    {
+        "background",
+        "foreground",
+        "card",
+        "card-foreground",
+        "popover",
+        "popover-foreground",
+        "primary",
+        "primary-foreground",
+        "secondary",
+        "secondary-foreground",
+        "muted",
+        "muted-foreground",
+        "accent",
+        "accent-foreground",
+        "destructive",
+        "destructive-foreground",
+        "border",
+        "input",
+        "ring",
+        "chart-1",
+        "chart-2",
+        "chart-3",
+        "chart-4",
+        "chart-5",
+        "sidebar-background",
+        "sidebar-foreground",
+        "sidebar-primary",
+        "sidebar-primary-foreground",
+        "sidebar-accent",
+        "sidebar-accent-foreground",
+        "sidebar-border",
+        "sidebar-ring",
+        "message-text",
+        "radius",
+    }
+)
+
+# Controlled icon names a plugin may reference. The renderer's <Icon> maps these
+# to concrete lucide-react components (apps/web/components/plugins/plugin-icon.tsx);
+# an unknown name is dropped and the renderer falls back to a default glyph, so
+# the two lists must agree.
+ICON_WHITELIST: frozenset[str] = frozenset(
+    {
+        "book-open",
+        "list-todo",
+        "calendar-clock",
+        "layers",
+        "settings",
+        "terminal",
+        "sparkles",
+        "zap",
+        "star",
+        "link",
+        "external-link",
+        "folder",
+        "file",
+        "search",
+        "plus",
+        "play",
+        "refresh-cw",
+        "bell",
+        "bot",
+        "code",
+        "git-branch",
+        "message-square",
+        "bug",
+        "wrench",
+        "palette",
+        "puzzle",
+        "rocket",
+        "globe",
+        "database",
+        "cloud",
+        "key",
+        "lock",
+        "shield",
+        "check",
+        "clipboard",
+        "download",
+        "upload",
+        "command",
+        "panel-left",
+    }
+)
+
+# A plugin id doubles as its on-disk directory name, so keep it a strict slug.
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def is_valid_plugin_id(value: Any) -> bool:
+    """Whether ``value`` is a well-formed plugin id (a lowercase dir-safe slug)."""
+    return isinstance(value, str) and bool(_ID_RE.match(value))
+
+
+# Theme token value: digits, letters, whitespace, and the punctuation used in
+# HSL triplets / lengths / hex / rgb()/hsl(). Notably excludes ; { } < > " ' : @
+# so a value cannot close the declaration or start a new rule. Mirrors the
+# renderer's SAFE_VALUE.
+_TOKEN_VALUE_RE = re.compile(r"^[0-9a-zA-Z%.,()/#\s_-]{1,64}$")
+
+_MAX_STR = 200
+
+
+def _is_str(v: Any, *, max_len: int = _MAX_STR) -> TypeGuard[str]:
+    return isinstance(v, str) and 0 < len(v) <= max_len
+
+
+def _clean_icon(raw: Any) -> str | None:
+    return raw if isinstance(raw, str) and raw in ICON_WHITELIST else None
+
+
+def _clean_theme(raw: Any, errors: list[str]) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        errors.append("theme: not an object")
+        return None
+    tid = raw.get("id")
+    label = raw.get("label")
+    base = raw.get("base")
+    if not _is_str(tid) or not _is_str(label):
+        errors.append("theme: missing id/label")
+        return None
+    if base not in ("dark", "light"):
+        errors.append(f"theme {tid!r}: base must be 'dark' or 'light'")
+        return None
+    tokens_in = raw.get("tokens")
+    if not isinstance(tokens_in, dict):
+        errors.append(f"theme {tid!r}: tokens must be an object")
+        return None
+    tokens: dict[str, str] = {}
+    for name, value in tokens_in.items():
+        if name not in THEME_TOKEN_WHITELIST:
+            continue  # silently drop unknown tokens
+        if not isinstance(value, str):
+            continue
+        trimmed = value.strip()
+        low = trimmed.lower()
+        if not _TOKEN_VALUE_RE.match(trimmed) or "url(" in low or "expression" in low:
+            errors.append(f"theme {tid!r}: token {name!r} has an unsafe value")
+            continue
+        tokens[name] = trimmed
+    if not tokens:
+        errors.append(f"theme {tid!r}: no valid tokens")
+        return None
+    return {"id": tid, "label": label, "base": base, "tokens": tokens}
+
+
+def _clean_sidebar_action(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    kind = raw.get("type")
+    if kind == "open-url":
+        url = raw.get("url")
+        if not _is_str(url) or not (
+            url.startswith("https://")
+            or url.startswith("http://")
+            or url.startswith("/")
+        ):
+            return None
+        return {
+            "type": "open-url",
+            "url": url,
+            "external": bool(raw.get("external", False)),
+        }
+    if kind == "rpc":
+        method = raw.get("method")
+        if not _is_str(method):
+            return None
+        params = raw.get("params")
+        return {
+            "type": "rpc",
+            "method": method,
+            "params": params if isinstance(params, dict) else {},
+        }
+    if kind == "surface":
+        surface_id = raw.get("surfaceId")
+        if not _is_str(surface_id):
+            return None
+        return {"type": "surface", "surfaceId": surface_id}
+    return None
+
+
+def _clean_sidebar_item(raw: Any, errors: list[str]) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    iid = raw.get("id")
+    label = raw.get("label")
+    if not _is_str(iid) or not _is_str(label):
+        errors.append("sidebarItem: missing id/label")
+        return None
+    action = _clean_sidebar_action(raw.get("action"))
+    if action is None:
+        errors.append(f"sidebarItem {iid!r}: invalid action")
+        return None
+    slot = raw.get("slot")
+    out: dict[str, Any] = {
+        "id": iid,
+        "label": label,
+        "slot": slot if slot in ("nav", "footer") else "nav",
+        "action": action,
+    }
+    icon = _clean_icon(raw.get("icon"))
+    if icon:
+        out["icon"] = icon
+    return out
+
+
+def _clean_composer_behavior(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    kind = raw.get("type")
+    if kind == "insert-text":
+        text = raw.get("text")
+        return (
+            {"type": "insert-text", "text": text}
+            if _is_str(text, max_len=4000)
+            else None
+        )
+    if kind == "insert-path-ref":
+        path = raw.get("path")
+        return (
+            {"type": "insert-path-ref", "path": path}
+            if _is_str(path, max_len=4000)
+            else None
+        )
+    if kind == "panel":
+        panel_id = raw.get("panelId")
+        return {"type": "panel", "panelId": panel_id} if _is_str(panel_id) else None
+    return None
+
+
+def _clean_composer_action(raw: Any, errors: list[str]) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    aid = raw.get("id")
+    label = raw.get("label")
+    if not _is_str(aid) or not _is_str(label):
+        errors.append("composerAction: missing id/label")
+        return None
+    behavior = _clean_composer_behavior(raw.get("behavior"))
+    if behavior is None:
+        errors.append(f"composerAction {aid!r}: invalid behavior")
+        return None
+    placement = raw.get("placement")
+    out: dict[str, Any] = {
+        "id": aid,
+        "label": label,
+        "placement": placement if placement in ("menu", "toolbar") else "menu",
+        "behavior": behavior,
+    }
+    icon = _clean_icon(raw.get("icon"))
+    if icon:
+        out["icon"] = icon
+    return out
+
+
+def _clean_slash_command(raw: Any, errors: list[str]) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    cid = raw.get("id")
+    command = raw.get("command")
+    insert_text = raw.get("insertText")
+    if (
+        not _is_str(cid)
+        or not _is_str(command)
+        or not _is_str(insert_text, max_len=4000)
+    ):
+        errors.append("slashCommand: missing id/command/insertText")
+        return None
+    out: dict[str, Any] = {"id": cid, "command": command, "insertText": insert_text}
+    label = raw.get("label")
+    if _is_str(label):
+        out["label"] = label
+    return out
+
+
+def _clean_list(
+    raw: Any, cleaner: Any, errors: list[str], *, limit: int = 64
+) -> list[dict[str, Any]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        errors.append("contribution list is not an array")
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in raw[:limit]:
+        cleaned = cleaner(entry, errors)
+        if cleaned is not None:
+            out.append(cleaned)
+    return out
+
+
+def validate_manifest(raw: Any) -> tuple[dict[str, Any] | None, list[str]]:
+    """Validate and sanitize a parsed ``plugin.json``.
+
+    Returns ``(clean_manifest, errors)``. ``clean_manifest`` is ``None`` only
+    when the manifest lacks a usable ``id`` / ``apiVersion``; otherwise it is a
+    minimal, whitelisted dict safe to hand to the renderer. ``errors`` collects
+    non-fatal warnings about dropped contributions.
+    """
+    errors: list[str] = []
+    if not isinstance(raw, dict):
+        return None, ["manifest is not a JSON object"]
+
+    pid = raw.get("id")
+    if not isinstance(pid, str) or not _ID_RE.match(pid):
+        return None, ["manifest 'id' missing or not a lowercase slug"]
+
+    api = raw.get("apiVersion")
+    if not isinstance(api, int) or isinstance(api, bool) or api < 1:
+        return None, [f"plugin {pid!r}: 'apiVersion' must be a positive integer"]
+
+    clean: dict[str, Any] = {"id": pid, "apiVersion": api}
+    for key in ("name", "description", "version", "author", "homepage"):
+        val = raw.get(key)
+        if _is_str(val, max_len=500):
+            clean[key] = val
+
+    themes = _clean_list(raw.get("themes"), _clean_theme, errors)
+    if themes:
+        clean["themes"] = themes
+    sidebar = _clean_list(raw.get("sidebarItems"), _clean_sidebar_item, errors)
+    if sidebar:
+        clean["sidebarItems"] = sidebar
+    composer = _clean_list(raw.get("composerActions"), _clean_composer_action, errors)
+    if composer:
+        clean["composerActions"] = composer
+    slash = _clean_list(raw.get("slashCommands"), _clean_slash_command, errors)
+    if slash:
+        clean["slashCommands"] = slash
+
+    return clean, errors
+
+
+def compute_catalog_etag(payload: Any) -> str:
+    """SHA-256 of the canonical JSON for a catalog payload.
+
+    Includes the full catalog (manifests + enabled/trusted flags), so any
+    install / edit / enable-toggle changes the ETag and the renderer re-fetches.
+    """
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/backend/src/vicoa/cli.py
+++ b/backend/src/vicoa/cli.py
@@ -35,6 +35,7 @@ from .constants import DEFAULT_API_URL, DEFAULT_AUTH_URL
 from .file_sync import sync_project_files
 from .utils import get_project_path
 from .commands.automation import add_automation_subparser, run_automation_command
+from .commands.plugin import add_plugin_subparser, run_plugin_command
 from .commands.instance import run_session_command
 from .commands.ls import cmd_ls as _cmd_ls
 from .commands.stop import cmd_stop
@@ -1754,6 +1755,11 @@ Examples:
     # commands/automation.py).
     add_automation_subparser(subparsers)
 
+    # 'plugin' subcommand — manage machine-local plugins (themes, sidebar,
+    # composer). Registered from its command module (commands/plugin.py); these
+    # operate on ~/.vicoa/plugins directly, not over the network.
+    add_plugin_subparser(subparsers)
+
     # 'session' subcommand — inspect the user's agent sessions from the backend.
     # Distinct from `vicoa ls` (local processes only): this spans every machine
     # and finished sessions, and can print a session's message transcript.
@@ -2120,6 +2126,8 @@ Examples:
         sys.exit(run_automation_command(args))
     elif args.command == "session":
         sys.exit(run_session_command(args))
+    elif args.command == "plugin":
+        sys.exit(run_plugin_command(args))
     elif args.command in {"claude", "codex", "opencode"}:
         run_agent_default(args, unknown_args)
     else:

--- a/backend/src/vicoa/commands/plugin.py
+++ b/backend/src/vicoa/commands/plugin.py
@@ -1,0 +1,271 @@
+"""``vicoa plugin`` — manage locally-installed Vicoa plugins.
+
+Unlike most CLI subcommands (which hit the backend HTTP API), plugins are a
+*machine-local* resource — files under ``~/.vicoa/plugins/`` read by the daemon
+running on this same machine. So these handlers call ``vicoa.rpc.plugin_ops``
+directly rather than going over the network; they work with no login and no
+daemon connection.
+
+    vicoa plugin init ./my-plugin          scaffold a new plugin
+    vicoa plugin install ./my-plugin       install from a local directory
+    vicoa plugin add owner/repo --ref v1   install from a git repo (clone only)
+    vicoa plugin ls [--json]               list installed plugins
+    vicoa plugin enable|disable <id>       toggle a single plugin
+    vicoa plugin trust <id>                approve a plugin's current manifest
+    vicoa plugin remove <id>               uninstall a plugin
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys
+from pathlib import Path
+
+
+def _print_list(payload: dict) -> None:
+    plugins = payload.get("plugins", [])
+    if not plugins:
+        print("No plugins installed. Try `vicoa plugin init ./my-plugin`.")
+        return
+    if not payload.get("plugins_enabled", True):
+        print(
+            "(!) Plugins are globally disabled — enable them in Settings > Plugins.\n"
+        )
+    width = max((len(p.get("id", "")) for p in plugins), default=2)
+    for p in plugins:
+        flags = []
+        flags.append("on " if p.get("enabled") else "off")
+        if not p.get("valid", True):
+            flags.append("INVALID")
+        elif not p.get("trusted"):
+            flags.append("untrusted")
+        contrib = p.get("contributes") or {}
+        summary = ", ".join(f"{k}:{v}" for k, v in contrib.items() if v) or "-"
+        print(f"{p.get('id', ''):<{width}}  {'/'.join(flags):<18}  {summary}")
+        errors = p.get("errors") or []
+        for err in errors:
+            print(f"    ! {err}")
+
+
+_SCAFFOLD_MANIFEST = {
+    "id": "my-plugin",
+    "apiVersion": 1,
+    "name": "My Plugin",
+    "description": "A starter Vicoa plugin.",
+    "themes": [
+        {
+            "id": "example",
+            "label": "My Plugin — Example",
+            "base": "dark",
+            "tokens": {
+                "primary": "267 84% 81%",
+                "sidebar-primary": "267 84% 81%",
+            },
+        }
+    ],
+    "sidebarItems": [
+        {
+            "id": "docs",
+            "label": "Plugin Docs",
+            "icon": "book-open",
+            "action": {"type": "open-url", "url": "https://vicoa.ai", "external": True},
+        }
+    ],
+    "composerActions": [
+        {
+            "id": "insert-signature",
+            "label": "Insert signature",
+            "icon": "sparkles",
+            "placement": "menu",
+            "behavior": {"type": "insert-text", "text": "\n\n— sent via My Plugin"},
+        }
+    ],
+}
+
+
+def _cmd_init(args) -> int:
+    target = Path(args.path).expanduser()
+    if target.exists() and any(target.iterdir()):
+        print(f"error: {target} exists and is not empty", file=sys.stderr)
+        return 1
+    target.mkdir(parents=True, exist_ok=True)
+    manifest = dict(_SCAFFOLD_MANIFEST)
+    if args.id:
+        manifest["id"] = args.id
+    (target / "plugin.json").write_text(
+        _json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"Scaffolded plugin '{manifest['id']}' at {target}")
+    print(f"Install it with:  vicoa plugin install {target}")
+    return 0
+
+
+def _cmd_install(args) -> int:
+    from vicoa.rpc import plugin_ops
+
+    result = plugin_ops.install_plugin(source=args.source, overwrite=args.overwrite)
+    return _report_install(result, args)
+
+
+def _cmd_add(args) -> int:
+    from vicoa.rpc import plugin_ops
+
+    source = _expand_repo_shorthand(args.repo)
+    result = plugin_ops.install_plugin(
+        source=source, ref=args.ref, subdir=args.subdir, overwrite=args.overwrite
+    )
+    return _report_install(result, args)
+
+
+def _expand_repo_shorthand(repo: str) -> str:
+    """`owner/repo` -> a GitHub HTTPS URL; a full URL / local path is untouched."""
+    r = repo.strip()
+    if "://" in r or r.startswith("git@") or "/" not in r:
+        return r
+    # Treat a bare `owner/repo` (no scheme, exactly two segments) as GitHub.
+    parts = r.split("/")
+    if len(parts) == 2 and all(parts):
+        return f"https://github.com/{parts[0]}/{parts[1]}"
+    return r
+
+
+def _report_install(result: dict, args) -> int:
+    if getattr(args, "json", False):
+        print(_json.dumps(result, indent=2))
+        return 0 if "error" not in result else 1
+    if "error" in result:
+        detail = f": {result['detail']}" if result.get("detail") else ""
+        print(f"error: {result['error']}{detail}", file=sys.stderr)
+        return 1
+    print(f"Installed '{result['id']}' -> {result['path']}")
+    for w in result.get("warnings") or []:
+        print(f"  warning: {w}")
+    return 0
+
+
+def _cmd_ls(args) -> int:
+    from vicoa.rpc import plugin_ops
+
+    payload = plugin_ops.plugin_list()
+    if getattr(args, "json", False):
+        print(_json.dumps(payload, indent=2))
+    else:
+        _print_list(payload)
+    return 0
+
+
+def _cmd_enable(args) -> int:
+    return _toggle(args, True)
+
+
+def _cmd_disable(args) -> int:
+    return _toggle(args, False)
+
+
+def _toggle(args, enabled: bool) -> int:
+    from vicoa.rpc import plugin_ops
+
+    result = plugin_ops.set_plugin_enabled(plugin_id=args.id, enabled=enabled)
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+    print(f"{'Enabled' if enabled else 'Disabled'} '{args.id}'")
+    return 0
+
+
+def _cmd_trust(args) -> int:
+    from vicoa.rpc import plugin_ops
+
+    result = plugin_ops.grant_plugin_trust(plugin_id=args.id)
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+    print(f"Trusted '{args.id}' (current manifest).")
+    return 0
+
+
+def _cmd_remove(args) -> int:
+    from vicoa.rpc import plugin_ops
+
+    result = plugin_ops.remove_plugin(plugin_id=args.id)
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+    print(f"Removed '{args.id}'")
+    return 0
+
+
+_HANDLERS = {
+    "init": _cmd_init,
+    "install": _cmd_install,
+    "add": _cmd_add,
+    "ls": _cmd_ls,
+    "enable": _cmd_enable,
+    "disable": _cmd_disable,
+    "trust": _cmd_trust,
+    "remove": _cmd_remove,
+}
+
+
+def run_plugin_command(args) -> int:
+    """Entry point wired into ``cli.py``'s dispatch for ``vicoa plugin``."""
+    sub = getattr(args, "plugin_command", None)
+    handler = _HANDLERS.get(sub) if sub else None
+    if handler is None:
+        print(
+            "usage: vicoa plugin {init,install,add,ls,enable,disable,trust,remove} ...\n"
+            "Run `vicoa plugin --help` for details.",
+            file=sys.stderr,
+        )
+        return 2
+    return handler(args)
+
+
+def add_plugin_subparser(subparsers) -> None:
+    """Register the ``plugin`` subcommand tree on ``cli.py``'s subparsers."""
+    plugin_parser = subparsers.add_parser(
+        "plugin",
+        help="Install and manage local Vicoa plugins (themes, sidebar, composer)",
+    )
+    plugin_sub = plugin_parser.add_subparsers(dest="plugin_command")
+
+    p_init = plugin_sub.add_parser("init", help="Scaffold a new plugin directory")
+    p_init.add_argument("path", help="Directory to create the plugin in")
+    p_init.add_argument("--id", help="Plugin id (lowercase slug); default 'my-plugin'")
+
+    p_install = plugin_sub.add_parser(
+        "install", help="Install a plugin from a local directory"
+    )
+    p_install.add_argument("source", help="Path to a directory containing plugin.json")
+    p_install.add_argument(
+        "--overwrite", action="store_true", help="Replace if already installed"
+    )
+    p_install.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    p_add = plugin_sub.add_parser(
+        "add", help="Install a plugin from a git repo (clone only)"
+    )
+    p_add.add_argument("repo", help="owner/repo, a git URL, or a local path")
+    p_add.add_argument("--ref", help="Branch or tag to clone")
+    p_add.add_argument(
+        "--subdir", help="Subdirectory within the repo holding plugin.json"
+    )
+    p_add.add_argument(
+        "--overwrite", action="store_true", help="Replace if already installed"
+    )
+    p_add.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    p_ls = plugin_sub.add_parser("ls", help="List installed plugins")
+    p_ls.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    p_enable = plugin_sub.add_parser("enable", help="Enable a plugin")
+    p_enable.add_argument("id", help="Plugin id")
+
+    p_disable = plugin_sub.add_parser("disable", help="Disable a plugin")
+    p_disable.add_argument("id", help="Plugin id")
+
+    p_trust = plugin_sub.add_parser("trust", help="Approve a plugin's current manifest")
+    p_trust.add_argument("id", help="Plugin id")
+
+    p_remove = plugin_sub.add_parser("remove", help="Uninstall a plugin")
+    p_remove.add_argument("id", help="Plugin id")

--- a/backend/src/vicoa/machine_daemon.py
+++ b/backend/src/vicoa/machine_daemon.py
@@ -1805,6 +1805,34 @@ class MachineDaemon:
             from vicoa.rpc import skills_ops
 
             return skills_ops.uninstall_skill(**(frame.get("params") or {}))
+        if method == "plugin-catalog":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.plugin_catalog(**(frame.get("params") or {}))
+        if method == "plugin-list":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.plugin_list(**(frame.get("params") or {}))
+        if method == "plugin-install":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.install_plugin(**(frame.get("params") or {}))
+        if method == "plugin-remove":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.remove_plugin(**(frame.get("params") or {}))
+        if method == "plugin-enable":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.set_plugin_enabled(**(frame.get("params") or {}))
+        if method == "plugin-set-enabled":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.set_plugins_enabled(**(frame.get("params") or {}))
+        if method == "plugin-trust-grant":
+            from vicoa.rpc import plugin_ops
+
+            return plugin_ops.grant_plugin_trust(**(frame.get("params") or {}))
         if method == "git-status":
             from vicoa.rpc import git_ops
 
@@ -1890,6 +1918,13 @@ class MachineDaemon:
             "get-skill",
             "install-skill",
             "uninstall-skill",
+            "plugin-catalog",
+            "plugin-list",
+            "plugin-install",
+            "plugin-remove",
+            "plugin-enable",
+            "plugin-set-enabled",
+            "plugin-trust-grant",
             "git-status",
             "git-diff",
             "git-log",

--- a/backend/src/vicoa/rpc/plugin_ops.py
+++ b/backend/src/vicoa/rpc/plugin_ops.py
@@ -1,0 +1,503 @@
+"""Daemon RPC handlers for the plugin system: scan / catalog / install / remove
+/ enable / trust.
+
+Plugins live on disk under ``~/.vicoa/plugins/<id>/``, each a directory holding
+a ``plugin.json`` (Tier 1 manifest) and optionally a ``dist/`` bundle (Tier 2,
+read only on the desktop renderer — never executed here). This module owns the
+*management* surface; the renderer reads the result through ``plugin-catalog``.
+
+Mirrors the conventions of ``skills_ops`` (git clone / dir copy into place, a
+hidden ``.vicoa-plugins.json`` provenance manifest, size/count guardrails, and —
+crucially — **no install scripts are ever run**). Enable state lives in
+``~/.vicoa/config.json`` under a ``plugins`` section; per-plugin trust lives in
+``~/.vicoa/daemon_state.json`` keyed by the manifest's SHA-256, mirroring
+``worktree_trust`` (editing a plugin's manifest re-arms the trust prompt).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from protocol.plugin_manifest import (
+    PLUGIN_API_VERSION,
+    compute_catalog_etag,
+    is_valid_plugin_id,
+    validate_manifest,
+)
+from vicoa.machine_state import read_state_file, save_state_file
+from vicoa.rpc.paths import OutsideRoot, resolve_inside_root
+
+_MANIFEST_NAME = ".vicoa-plugins.json"
+_PLUGIN_JSON = "plugin.json"
+
+# Guardrails on an installed plugin tree (excluding .git). Mirrors skills_ops.
+_MAX_FILE_BYTES = 2 * 1024 * 1024
+_MAX_TOTAL_BYTES = 25 * 1024 * 1024
+_MAX_FILE_COUNT = 1024
+_CLONE_TIMEOUT_S = 25  # must fit the WS RPC budget (~30s)
+
+_GIT_URL_SCHEMES = ("https://", "http://", "git://", "ssh://", "file://", "git@")
+
+# daemon_state.json key: {plugin_id: manifest_sha256}. Trust is a property of the
+# machine, never synced to another device (same boundary as worktree_trust).
+_TRUST_KEY = "plugin_trust"
+
+# config.json section shape: {"enabled": bool, "states": {id: bool}}.
+_CONFIG_KEY = "plugins"
+
+
+# --------------------------------------------------------------------------- #
+# Paths (resolved at call time so a redirected HOME in tests is honored)
+# --------------------------------------------------------------------------- #
+def plugins_dir() -> Path:
+    return Path.home() / ".vicoa" / "plugins"
+
+
+def _state_path() -> Path:
+    return Path.home() / ".vicoa" / "daemon_state.json"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Provenance manifest (DB-less, hidden inside plugins_dir)
+# --------------------------------------------------------------------------- #
+def _manifest_path() -> Path:
+    return plugins_dir() / _MANIFEST_NAME
+
+
+def _read_provenance() -> dict[str, dict[str, Any]]:
+    try:
+        with open(_manifest_path(), "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".vicoa-tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _write_provenance_entry(plugin_id: str, entry: dict[str, Any]) -> None:
+    data = _read_provenance()
+    data[plugin_id] = entry
+    _atomic_write_json(_manifest_path(), data)
+
+
+def _drop_provenance_entry(plugin_id: str) -> None:
+    data = _read_provenance()
+    if plugin_id in data:
+        del data[plugin_id]
+        _atomic_write_json(_manifest_path(), data)
+
+
+# --------------------------------------------------------------------------- #
+# Config (enable state)
+# --------------------------------------------------------------------------- #
+def _read_config_section() -> dict[str, Any]:
+    # Lazy import to avoid an import cycle (cli -> commands.plugin -> plugin_ops).
+    from vicoa.cli import load_user_config
+
+    section = load_user_config().get(_CONFIG_KEY)
+    return section if isinstance(section, dict) else {}
+
+
+def _write_config_section(section: dict[str, Any]) -> None:
+    from vicoa.cli import save_user_config
+
+    save_user_config({_CONFIG_KEY: section})
+
+
+def _plugins_enabled(section: dict[str, Any] | None = None) -> bool:
+    sec = section if section is not None else _read_config_section()
+    val = sec.get("enabled", True)
+    return bool(val) if isinstance(val, bool) else True
+
+
+def _is_enabled(plugin_id: str, section: dict[str, Any] | None = None) -> bool:
+    sec = section if section is not None else _read_config_section()
+    states = sec.get("states")
+    if isinstance(states, dict) and plugin_id in states:
+        return bool(states[plugin_id])
+    return True  # installed plugins default to enabled
+
+
+# --------------------------------------------------------------------------- #
+# Trust (per manifest hash)
+# --------------------------------------------------------------------------- #
+def _manifest_hash(plugin_path: Path) -> str | None:
+    try:
+        raw = (plugin_path / _PLUGIN_JSON).read_bytes()
+    except OSError:
+        return None
+    return hashlib.sha256(raw).hexdigest()
+
+
+def is_plugin_trusted(
+    plugin_id: str, plugin_path: Path, state_path: Path | None = None
+) -> bool:
+    current = _manifest_hash(plugin_path)
+    if current is None:
+        return False
+    trust = read_state_file(state_path or _state_path()).get(_TRUST_KEY)
+    if not isinstance(trust, dict):
+        return False
+    return trust.get(plugin_id) == current
+
+
+def grant_plugin_trust(
+    plugin_id: str, state_path: Path | None = None
+) -> dict[str, Any]:
+    """Persist a trust grant for the plugin's *current* manifest hash."""
+    if not is_valid_plugin_id(plugin_id):
+        return {"error": "invalid_plugin_id"}
+    try:
+        dest = resolve_inside_root(plugins_dir(), plugin_id)
+    except OutsideRoot:
+        return {"error": "invalid_plugin_id"}
+    current = _manifest_hash(dest)
+    if current is None:
+        return {"error": "not_found"}
+    path = state_path or _state_path()
+    state = read_state_file(path)
+    trust = state.get(_TRUST_KEY)
+    if not isinstance(trust, dict):
+        trust = {}
+    trust[plugin_id] = current
+    state[_TRUST_KEY] = trust
+    save_state_file(state, path)
+    return {"ok": True}
+
+
+# --------------------------------------------------------------------------- #
+# Validation helpers
+# --------------------------------------------------------------------------- #
+def _valid_git_url(url: Any) -> bool:
+    return (
+        isinstance(url, str)
+        and bool(url.strip())
+        and url.strip().startswith(_GIT_URL_SCHEMES)
+    )
+
+
+def _within_caps(src: Path) -> tuple[bool, str]:
+    total = 0
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(src):
+        if ".git" in dirnames:
+            dirnames.remove(".git")
+        for filename in filenames:
+            try:
+                size = (Path(dirpath) / filename).stat().st_size
+            except OSError:
+                continue
+            if size > _MAX_FILE_BYTES:
+                return False, "file_too_large"
+            total += size
+            count += 1
+            if count > _MAX_FILE_COUNT:
+                return False, "too_many_files"
+            if total > _MAX_TOTAL_BYTES:
+                return False, "plugin_too_large"
+    return True, ""
+
+
+def _load_manifest(plugin_path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        raw = json.loads((plugin_path / _PLUGIN_JSON).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f"plugin.json unreadable: {exc}"]
+    return validate_manifest(raw)
+
+
+def _has_client_bundle(plugin_path: Path) -> bool:
+    return (plugin_path / "dist" / "client.js").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# Scanning
+# --------------------------------------------------------------------------- #
+def _scan() -> list[dict[str, Any]]:
+    """Every installed plugin, with its validated manifest and metadata.
+
+    Malformed plugins are included with ``manifest=None`` + ``errors`` so the
+    management UI can surface them; the catalog filters them out.
+    """
+    root = plugins_dir()
+    provenance = _read_provenance()
+    out: list[dict[str, Any]] = []
+    if not root.is_dir():
+        return out
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        manifest, errors = _load_manifest(child)
+        prov = provenance.get(child.name, {})
+        entry: dict[str, Any] = {
+            "dir": child.name,
+            "path": str(child),
+            "manifest": manifest,
+            "errors": errors,
+            "source": prov.get("source"),
+            "installed_at": prov.get("installed_at"),
+        }
+        if manifest is not None:
+            manifest["hasClientBundle"] = _has_client_bundle(child)
+        out.append(entry)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# RPC handlers
+# --------------------------------------------------------------------------- #
+def plugin_catalog(etag: str | None = None) -> dict[str, Any]:
+    """The renderer-facing catalog: valid, id-keyed plugins with enable/trust
+    flags. Returns ``{etag, not_modified: True}`` when the caller's ETag matches.
+    """
+    section = _read_config_section()
+    plugins_on = _plugins_enabled(section)
+    plugins: list[dict[str, Any]] = []
+    for entry in _scan():
+        manifest = entry["manifest"]
+        if manifest is None:
+            continue  # malformed — visible only via plugin-list
+        pid = manifest["id"]
+        # Guard against a dir named differently from the manifest id: the on-disk
+        # dir name is authoritative for trust/enable/remove.
+        dir_name = entry["dir"]
+        if not is_valid_plugin_id(dir_name):
+            continue
+        plugin_path = plugins_dir() / dir_name
+        plugins.append(
+            {
+                "id": pid,
+                "dir": dir_name,
+                "manifest": manifest,
+                "enabled": _is_enabled(dir_name, section),
+                "trusted": is_plugin_trusted(dir_name, plugin_path),
+                "server_available": False,  # Tier 2 subprocess arrives in P3
+                "source": entry["source"],
+                "api_compatible": manifest["apiVersion"] <= PLUGIN_API_VERSION,
+            }
+        )
+    payload: dict[str, Any] = {"plugins_enabled": plugins_on, "plugins": plugins}
+    computed = compute_catalog_etag(payload)
+    if etag is not None and etag == computed:
+        return {"etag": computed, "not_modified": True}
+    payload["etag"] = computed
+    return payload
+
+
+def plugin_list() -> dict[str, Any]:
+    """Fuller listing (including malformed plugins + errors) for CLI / settings."""
+    section = _read_config_section()
+    out: list[dict[str, Any]] = []
+    for entry in _scan():
+        manifest = entry["manifest"]
+        dir_name = entry["dir"]
+        plugin_path = plugins_dir() / dir_name
+        out.append(
+            {
+                "id": manifest["id"] if manifest else dir_name,
+                "dir": dir_name,
+                "name": (manifest.get("name") if manifest else None) or dir_name,
+                "valid": manifest is not None,
+                "errors": entry["errors"],
+                "enabled": _is_enabled(dir_name, section),
+                "trusted": is_plugin_trusted(dir_name, plugin_path)
+                if manifest
+                else False,
+                "source": entry["source"],
+                "installed_at": entry["installed_at"],
+                "path": entry["path"],
+                "contributes": _summarize(manifest) if manifest else {},
+            }
+        )
+    return {"plugins_enabled": _plugins_enabled(section), "plugins": out}
+
+
+def _summarize(manifest: dict[str, Any]) -> dict[str, int]:
+    return {
+        "themes": len(manifest.get("themes") or []),
+        "sidebarItems": len(manifest.get("sidebarItems") or []),
+        "composerActions": len(manifest.get("composerActions") or []),
+        "slashCommands": len(manifest.get("slashCommands") or []),
+    }
+
+
+def _acquire_source(
+    source: str, ref: str | None, tmp: str
+) -> tuple[Path | None, dict[str, Any] | None]:
+    """Materialize ``source`` into a temp dir. Returns (path, None) or (None, error)."""
+    if isinstance(source, str) and os.path.isdir(os.path.expanduser(source)):
+        src = Path(os.path.expanduser(source)).resolve()
+        return src, None
+    if not _valid_git_url(source):
+        return None, {"error": "invalid_source"}
+    clone_dir = os.path.join(tmp, "repo")
+    cmd = ["git", "clone", "--depth", "1", "--single-branch"]
+    if ref:
+        cmd += ["--branch", ref]
+    cmd += [source.strip(), clone_dir]
+    try:
+        subprocess.run(cmd, capture_output=True, timeout=_CLONE_TIMEOUT_S, check=True)
+    except subprocess.TimeoutExpired:
+        return None, {"error": "install_timeout"}
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or b"").decode("utf-8", "replace")[-400:].strip()
+        return None, {"error": "clone_failed", "detail": detail}
+    except FileNotFoundError:
+        return None, {"error": "git_not_available"}
+    return Path(clone_dir), None
+
+
+def install_plugin(
+    source: str,
+    ref: str | None = None,
+    subdir: str | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Install a plugin from a local directory or a git URL.
+
+    The source root (or ``subdir`` within it) must contain a ``plugin.json`` with
+    a valid ``id``; the plugin lands at ``~/.vicoa/plugins/<id>/``. NO scripts
+    from the source are ever executed (git clone + copy only). Returns the
+    installed summary or ``{"error": <code>}``.
+    """
+    tmp = tempfile.mkdtemp(prefix="vicoa-plugin-")
+    try:
+        src, err = _acquire_source(source, ref, tmp)
+        if err is not None:
+            return err
+        assert src is not None
+        if subdir:
+            cleaned = os.path.normpath(subdir.strip().strip("/"))
+            if cleaned.startswith("..") or os.path.isabs(cleaned):
+                return {"error": "invalid_subdir"}
+            src = src / cleaned
+
+        if not (src / _PLUGIN_JSON).is_file():
+            return {"error": "manifest_not_found"}
+
+        manifest, errors = _load_manifest(src)
+        if manifest is None:
+            return {"error": "invalid_manifest", "detail": "; ".join(errors)[:400]}
+        pid = manifest["id"]
+
+        ok, cap_error = _within_caps(src)
+        if not ok:
+            return {"error": cap_error}
+
+        root = plugins_dir()
+        try:
+            dest = resolve_inside_root(root, pid)
+        except OutsideRoot:
+            return {"error": "invalid_plugin_id"}
+
+        if dest.exists():
+            if not overwrite:
+                return {"error": "plugin_exists"}
+            shutil.rmtree(dest)
+
+        root.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dest, ignore=shutil.ignore_patterns(".git"))
+
+        installed_at = _utcnow_iso()
+        _write_provenance_entry(
+            pid,
+            {
+                "source": source.strip() if isinstance(source, str) else "",
+                "ref": ref or "",
+                "subdir": subdir or "",
+                "installed_at": installed_at,
+            },
+        )
+        return {
+            "id": pid,
+            "name": manifest.get("name") or pid,
+            "path": str(dest),
+            "installed_at": installed_at,
+            "warnings": errors,
+        }
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def remove_plugin(plugin_id: str) -> dict[str, Any]:
+    """Delete an installed plugin and forget its enable/trust/provenance state."""
+    if not is_valid_plugin_id(plugin_id):
+        return {"error": "invalid_plugin_id"}
+    try:
+        dest = resolve_inside_root(plugins_dir(), plugin_id)
+    except OutsideRoot:
+        return {"error": "invalid_plugin_id"}
+    if not dest.is_dir():
+        return {"error": "not_found"}
+    shutil.rmtree(dest, ignore_errors=True)
+    _drop_provenance_entry(plugin_id)
+
+    # Forget enable state.
+    section = _read_config_section()
+    states = section.get("states")
+    if isinstance(states, dict) and plugin_id in states:
+        del states[plugin_id]
+        section["states"] = states
+        _write_config_section(section)
+
+    # Forget trust.
+    path = _state_path()
+    state = read_state_file(path)
+    trust = state.get(_TRUST_KEY)
+    if isinstance(trust, dict) and plugin_id in trust:
+        del trust[plugin_id]
+        state[_TRUST_KEY] = trust
+        save_state_file(state, path)
+    return {"ok": True}
+
+
+def set_plugin_enabled(plugin_id: str, enabled: bool) -> dict[str, Any]:
+    if not is_valid_plugin_id(plugin_id):
+        return {"error": "invalid_plugin_id"}
+    try:
+        dest = resolve_inside_root(plugins_dir(), plugin_id)
+    except OutsideRoot:
+        return {"error": "invalid_plugin_id"}
+    if not dest.is_dir():
+        return {"error": "not_found"}
+    section = _read_config_section()
+    states = section.get("states")
+    if not isinstance(states, dict):
+        states = {}
+    states[plugin_id] = bool(enabled)
+    section["states"] = states
+    _write_config_section(section)
+    return {"ok": True, "enabled": bool(enabled)}
+
+
+def set_plugins_enabled(enabled: bool) -> dict[str, Any]:
+    """Flip the global master switch for all plugins."""
+    section = _read_config_section()
+    section["enabled"] = bool(enabled)
+    _write_config_section(section)
+    return {"ok": True, "plugins_enabled": bool(enabled)}

--- a/backend/tests/test_plugin_manifest.py
+++ b/backend/tests/test_plugin_manifest.py
@@ -1,0 +1,195 @@
+"""Tests for plugin manifest validation + catalog ETag (protocol.plugin_manifest)."""
+
+from protocol.plugin_manifest import (
+    compute_catalog_etag,
+    is_valid_plugin_id,
+    validate_manifest,
+)
+
+
+def _base(**over):
+    m = {"id": "demo", "apiVersion": 1}
+    m.update(over)
+    return m
+
+
+def test_minimal_valid_manifest():
+    clean, errors = validate_manifest(_base())
+    assert clean is not None
+    assert clean["id"] == "demo"
+    assert clean["apiVersion"] == 1
+    assert errors == []
+
+
+def test_bad_id_rejected():
+    clean, errors = validate_manifest(_base(id="Has Spaces"))
+    assert clean is None
+    assert errors
+
+
+def test_non_dict_rejected():
+    clean, _ = validate_manifest("nope")
+    assert clean is None
+
+
+def test_apiversion_must_be_int():
+    clean, _ = validate_manifest({"id": "demo", "apiVersion": "1"})
+    assert clean is None
+    clean2, _ = validate_manifest({"id": "demo", "apiVersion": True})
+    assert clean2 is None
+
+
+def test_theme_unknown_tokens_dropped_known_kept():
+    clean, _ = validate_manifest(
+        _base(
+            themes=[
+                {
+                    "id": "t",
+                    "label": "T",
+                    "base": "dark",
+                    "tokens": {"primary": "267 84% 81%", "evil-token": "10px"},
+                }
+            ]
+        )
+    )
+    assert clean is not None
+    tokens = clean["themes"][0]["tokens"]
+    assert tokens == {"primary": "267 84% 81%"}
+
+
+def test_theme_unsafe_value_rejected():
+    clean, errors = validate_manifest(
+        _base(
+            themes=[
+                {
+                    "id": "t",
+                    "label": "T",
+                    "base": "dark",
+                    "tokens": {"primary": "10px; } body { display:none"},
+                }
+            ]
+        )
+    )
+    # The only token was unsafe -> theme dropped entirely, and no themes remain.
+    assert clean is not None
+    assert "themes" not in clean
+    assert any("unsafe" in e for e in errors)
+
+
+def test_theme_url_value_rejected():
+    clean, _ = validate_manifest(
+        _base(
+            themes=[
+                {
+                    "id": "t",
+                    "label": "T",
+                    "base": "dark",
+                    "tokens": {"background": "url(https://evil)"},
+                }
+            ]
+        )
+    )
+    assert clean is not None
+    assert "themes" not in clean
+
+
+def test_theme_bad_base_dropped():
+    clean, _ = validate_manifest(
+        _base(
+            themes=[
+                {
+                    "id": "t",
+                    "label": "T",
+                    "base": "neon",
+                    "tokens": {"primary": "1 2% 3%"},
+                }
+            ]
+        )
+    )
+    assert "themes" not in (clean or {})
+
+
+def test_sidebar_actions_validated():
+    clean, _ = validate_manifest(
+        _base(
+            sidebarItems=[
+                {
+                    "id": "a",
+                    "label": "A",
+                    "action": {"type": "open-url", "url": "https://x.com"},
+                },
+                {
+                    "id": "b",
+                    "label": "B",
+                    "action": {"type": "open-url", "url": "javascript:evil"},
+                },
+                {
+                    "id": "c",
+                    "label": "C",
+                    "action": {"type": "rpc", "method": "git-status"},
+                },
+                {"id": "d", "label": "D", "action": {"type": "bogus"}},
+            ]
+        )
+    )
+    assert clean is not None
+    ids = {i["id"] for i in clean["sidebarItems"]}
+    # javascript: url and bogus action dropped; https + rpc kept.
+    assert ids == {"a", "c"}
+
+
+def test_icon_whitelist_enforced():
+    clean, _ = validate_manifest(
+        _base(
+            sidebarItems=[
+                {
+                    "id": "a",
+                    "label": "A",
+                    "icon": "not-a-real-icon",
+                    "action": {"type": "open-url", "url": "/dashboard"},
+                },
+                {
+                    "id": "b",
+                    "label": "B",
+                    "icon": "book-open",
+                    "action": {"type": "open-url", "url": "/dashboard"},
+                },
+            ]
+        )
+    )
+    assert clean is not None
+    by_id = {i["id"]: i for i in clean["sidebarItems"]}
+    assert "icon" not in by_id["a"]  # unknown icon dropped
+    assert by_id["b"]["icon"] == "book-open"
+
+
+def test_composer_action_defaults_placement():
+    clean, _ = validate_manifest(
+        _base(
+            composerActions=[
+                {
+                    "id": "x",
+                    "label": "X",
+                    "behavior": {"type": "insert-text", "text": "hi"},
+                }
+            ]
+        )
+    )
+    assert clean is not None
+    assert clean["composerActions"][0]["placement"] == "menu"
+
+
+def test_is_valid_plugin_id():
+    assert is_valid_plugin_id("catppuccin")
+    assert is_valid_plugin_id("my-plugin_1")
+    assert not is_valid_plugin_id("Bad")
+    assert not is_valid_plugin_id("../escape")
+    assert not is_valid_plugin_id(123)
+
+
+def test_etag_stable_and_sensitive():
+    a = compute_catalog_etag({"plugins": [{"id": "x", "enabled": True}]})
+    b = compute_catalog_etag({"plugins": [{"id": "x", "enabled": True}]})
+    c = compute_catalog_etag({"plugins": [{"id": "x", "enabled": False}]})
+    assert a == b
+    assert a != c

--- a/backend/tests/test_rpc_plugin_ops.py
+++ b/backend/tests/test_rpc_plugin_ops.py
@@ -1,0 +1,156 @@
+"""Tests for the plugin RPC handlers (install / catalog / enable / trust / remove)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vicoa.rpc import plugin_ops
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    return fake_home
+
+
+def _make_plugin_dir(tmp_path: Path, plugin_id: str, **manifest_over) -> Path:
+    src = tmp_path / f"src-{plugin_id}"
+    src.mkdir()
+    manifest = {
+        "id": plugin_id,
+        "apiVersion": 1,
+        "name": plugin_id.title(),
+        "themes": [
+            {
+                "id": "t",
+                "label": "T",
+                "base": "dark",
+                "tokens": {"primary": "267 84% 81%"},
+            }
+        ],
+    }
+    manifest.update(manifest_over)
+    (src / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return src
+
+
+def test_install_from_directory(home: Path, tmp_path: Path):
+    src = _make_plugin_dir(tmp_path, "demo")
+    result = plugin_ops.install_plugin(source=str(src))
+    assert result.get("id") == "demo"
+    dest = home / ".vicoa" / "plugins" / "demo"
+    assert (dest / "plugin.json").is_file()
+    # Provenance recorded.
+    prov = json.loads((home / ".vicoa" / "plugins" / ".vicoa-plugins.json").read_text())
+    assert prov["demo"]["source"] == str(src)
+
+
+def test_install_rejects_invalid_manifest(home: Path, tmp_path: Path):
+    src = tmp_path / "bad"
+    src.mkdir()
+    (src / "plugin.json").write_text(
+        json.dumps({"apiVersion": 1}), encoding="utf-8"
+    )  # no id
+    result = plugin_ops.install_plugin(source=str(src))
+    assert result.get("error") == "invalid_manifest"
+
+
+def test_install_missing_manifest(home: Path, tmp_path: Path):
+    src = tmp_path / "empty"
+    src.mkdir()
+    result = plugin_ops.install_plugin(source=str(src))
+    assert result.get("error") == "manifest_not_found"
+
+
+def test_install_exists_without_overwrite(home: Path, tmp_path: Path):
+    src = _make_plugin_dir(tmp_path, "demo")
+    assert plugin_ops.install_plugin(source=str(src)).get("id") == "demo"
+    again = plugin_ops.install_plugin(source=str(src))
+    assert again.get("error") == "plugin_exists"
+    assert (
+        plugin_ops.install_plugin(source=str(src), overwrite=True).get("id") == "demo"
+    )
+
+
+def test_catalog_enable_and_trust_flow(home: Path, tmp_path: Path):
+    src = _make_plugin_dir(tmp_path, "demo")
+    plugin_ops.install_plugin(source=str(src))
+
+    cat = plugin_ops.plugin_catalog()
+    assert "etag" in cat
+    entry = next(p for p in cat["plugins"] if p["id"] == "demo")
+    assert entry["enabled"] is True
+    assert entry["trusted"] is False
+    assert entry["server_available"] is False
+
+    # ETag conditional GET.
+    assert plugin_ops.plugin_catalog(etag=cat["etag"]).get("not_modified") is True
+
+    # Grant trust -> reflected, and ETag changes.
+    assert plugin_ops.grant_plugin_trust("demo") == {"ok": True}
+    cat2 = plugin_ops.plugin_catalog()
+    assert next(p for p in cat2["plugins"] if p["id"] == "demo")["trusted"] is True
+    assert cat2["etag"] != cat["etag"]
+
+    # Editing the manifest re-arms trust (hash changes).
+    dest = home / ".vicoa" / "plugins" / "demo"
+    manifest = json.loads((dest / "plugin.json").read_text())
+    manifest["name"] = "Renamed"
+    (dest / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+    assert plugin_ops.is_plugin_trusted("demo", dest) is False
+
+
+def test_disable_and_global_switch(home: Path, tmp_path: Path):
+    plugin_ops.install_plugin(source=str(_make_plugin_dir(tmp_path, "demo")))
+
+    assert plugin_ops.set_plugin_enabled("demo", False)["enabled"] is False
+    assert (
+        next(p for p in plugin_ops.plugin_catalog()["plugins"] if p["id"] == "demo")[
+            "enabled"
+        ]
+        is False
+    )
+
+    assert plugin_ops.set_plugins_enabled(False)["plugins_enabled"] is False
+    assert plugin_ops.plugin_catalog()["plugins_enabled"] is False
+
+
+def test_remove_clears_state(home: Path, tmp_path: Path):
+    plugin_ops.install_plugin(source=str(_make_plugin_dir(tmp_path, "demo")))
+    plugin_ops.grant_plugin_trust("demo")
+    plugin_ops.set_plugin_enabled("demo", False)
+
+    assert plugin_ops.remove_plugin("demo") == {"ok": True}
+    assert not (home / ".vicoa" / "plugins" / "demo").exists()
+    assert plugin_ops.plugin_catalog()["plugins"] == []
+    # Trust + provenance forgotten.
+    assert (
+        plugin_ops.is_plugin_trusted("demo", home / ".vicoa" / "plugins" / "demo")
+        is False
+    )
+    prov = json.loads((home / ".vicoa" / "plugins" / ".vicoa-plugins.json").read_text())
+    assert "demo" not in prov
+
+
+def test_remove_invalid_id(home: Path):
+    assert plugin_ops.remove_plugin("../etc")["error"] == "invalid_plugin_id"
+    assert plugin_ops.remove_plugin("ghost")["error"] == "not_found"
+
+
+def test_malformed_plugin_visible_in_list_not_catalog(home: Path, tmp_path: Path):
+    # Install a good one, then drop a broken plugin dir alongside it.
+    plugin_ops.install_plugin(source=str(_make_plugin_dir(tmp_path, "good")))
+    broken = home / ".vicoa" / "plugins" / "broken"
+    broken.mkdir(parents=True)
+    (broken / "plugin.json").write_text("{ not json", encoding="utf-8")
+
+    listing = plugin_ops.plugin_list()
+    ids = {p["id"]: p for p in listing["plugins"]}
+    assert ids["broken"]["valid"] is False
+    assert ids["broken"]["errors"]
+
+    catalog_ids = {p["id"] for p in plugin_ops.plugin_catalog()["plugins"]}
+    assert catalog_ids == {"good"}

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,41 @@
+# Example Vicoa plugins
+
+Declarative **Tier 1** plugins — a single `plugin.json`, no code, cross-platform.
+They customize the app through three contribution types:
+
+- **`themes`** — remap shadcn color tokens (HSL triplets); shown in the theme picker.
+- **`sidebarItems`** — a labeled row in the dashboard sidebar (`open-url` / `rpc`).
+- **`composerActions`** — a "+" menu row (`placement: "menu"`) or a toolbar icon
+  button (`placement: "toolbar"`) that inserts text / opens a picker.
+
+Icon names and theme token names are allow-listed
+(`backend/src/protocol/plugin_manifest.py`); anything else is dropped.
+
+## Try it
+
+```bash
+# Install this example (copies it into ~/.vicoa/plugins/<id>/ — runs no scripts)
+vicoa plugin install examples/plugins/hello-vicoa
+
+# Approve it (or accept the trust prompt the app shows on first sight)
+vicoa plugin trust hello-vicoa
+
+vicoa plugin ls           # see it + what it contributes
+vicoa plugin disable hello-vicoa
+vicoa plugin remove hello-vicoa
+```
+
+Then, in the app: pick **Hello Vicoa — Emerald** in the theme picker, see the
+**Vicoa Docs** row in the sidebar, and the two composer actions (a row in the
+"+" menu and a toolbar button). Manage everything in **Settings → Plugins**.
+
+> The daemon serving the app must be built from a branch that has the plugin
+> RPCs (P1). Themes registered as built-in examples show up client-side without
+> any daemon.
+
+## Make your own
+
+```bash
+vicoa plugin init ./my-plugin --id my-plugin   # scaffolds a full example
+vicoa plugin install ./my-plugin
+```

--- a/examples/plugins/hello-vicoa/plugin.json
+++ b/examples/plugins/hello-vicoa/plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "hello-vicoa",
+  "apiVersion": 1,
+  "name": "Hello Vicoa",
+  "description": "A tiny example plugin: a theme, a sidebar link, and two composer actions.",
+  "author": "Vicoa",
+  "homepage": "https://vicoa.ai",
+  "themes": [
+    {
+      "id": "emerald",
+      "label": "Hello Vicoa — Emerald",
+      "base": "dark",
+      "tokens": {
+        "primary": "160 84% 39%",
+        "primary-foreground": "0 0% 100%",
+        "ring": "160 84% 39%",
+        "sidebar-primary": "160 84% 39%",
+        "sidebar-primary-foreground": "0 0% 100%",
+        "accent": "160 40% 18%",
+        "accent-foreground": "160 60% 88%"
+      }
+    }
+  ],
+  "sidebarItems": [
+    {
+      "id": "docs",
+      "label": "Vicoa Docs",
+      "icon": "book-open",
+      "slot": "nav",
+      "action": { "type": "open-url", "url": "https://vicoa.ai/docs", "external": true }
+    }
+  ],
+  "composerActions": [
+    {
+      "id": "pr-template",
+      "label": "Insert PR description template",
+      "icon": "clipboard",
+      "placement": "menu",
+      "behavior": {
+        "type": "insert-text",
+        "text": "## Summary\n\n## Testing\n\n## Screenshots\n"
+      }
+    },
+    {
+      "id": "signoff",
+      "label": "Insert sign-off",
+      "icon": "sparkles",
+      "placement": "toolbar",
+      "behavior": { "type": "insert-text", "text": "\n\n— via Hello Vicoa" }
+    }
+  ]
+}


### PR DESCRIPTION
## Vicoa plugin system — P0 + P1 (declarative Tier 1)

Implements the declarative tier of the plugin system per
`plans/todos/plugin-system.md`: users can customize themes, sidebar entries, and
composer actions from a machine-local `plugin.json` — no code execution.

### Backend (Python daemon)
- `protocol/plugin_manifest.py` — manifest schema/validation (tolerant: bad
  contributions dropped, bad id/apiVersion rejected) + token/icon allow-lists +
  `compute_catalog_etag`.
- `vicoa/rpc/plugin_ops.py` — scan / catalog / list / install / remove / enable /
  trust. Installs from a local dir **or** git clone, and **runs no scripts**
  (mirrors `skills_ops`). Enable state → `config.json`; per-plugin trust (by
  manifest SHA256) → `daemon_state.json` (editing a manifest re-arms trust,
  mirrors `worktree_trust`). Plugins live at `~/.vicoa/plugins/<id>/`.
- `vicoa/commands/plugin.py` — `vicoa plugin init|install|add|ls|enable|disable|trust|remove`.
- `machine_daemon.py` — 7 `plugin-*` RPCs registered in both the dispatch ladder
  and the advertised list.

### Web (Next.js renderer)
- `lib/plugins/` — registry (`useSyncExternalStore`, stable snapshot), manifest
  types (mirror of the Python schema), catalog mapper, composer/actions helpers,
  built-in Catppuccin example themes.
- Themes: `PluginThemeStyle` injects sanitized `:root` token overrides;
  `theme-provider` `Theme` extended to `plugin:<id>/<theme>`; a theme picker
  (Settings → General → Appearance for now).
- Sidebar items in both sidebars; composer toolbar buttons + "+" menu extras;
  per-machine catalog sync (ETag-gated, incl. desktop-local); first-load trust
  gate; a **Settings → Plugins** management tab.
- `examples/plugins/hello-vicoa/` — a runnable example (theme + sidebar link +
  two composer actions) + README.

### Verification
- Web: `next build` green, `tsc --noEmit` clean (no ESLint config in `apps/web`;
  tsc is the gate).
- Backend: `make lint` green (ruff + pyright 0 errors + WS freeze check) + **22
  new tests** (`test_plugin_manifest.py`, `test_rpc_plugin_ops.py`).

### Notes / scope
- **Deviation:** did not extract a shared `SidebarNavRow`; `<PluginSidebarItems>`
  is self-contained and inserted into both sidebars (lower risk, same result).
- **Deferred (separate work):** P2 (SDK npm pkg + Tier 2 bundle eval, desktop
  runtime only) and P3 (Node subprocess plugin backends).
- **Related, not in this PR:** full theming / light-mode / Appearance-tab work is
  a cross-cutting tokenization refactor — briefed in
  `plans/todos/theming-tokenization.md` (umbrella repo).
