### PR TITLE
feat(theming): real light theme + systematic token-driven theming

### DIFF
--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -2179,7 +2179,7 @@ function AgentInstanceContent() {
           <div>
             <span className="font-medium">Status: </span>
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-              <span className="w-2 h-2 rounded-full bg-gray-400 mr-1.5" />
+              <span className="w-2 h-2 rounded-full bg-muted-foreground mr-1.5" />
               {instance.status}
             </span>
           </div>

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -1589,7 +1589,7 @@ function NewSessionContent() {
       </div>
 
       {/* Chat-style input pinned to bottom */}
-      <div className="flex-shrink-0 bg-muted/10 p-4">
+      <div className="flex-shrink-0 p-4">
         <div className="max-w-4xl mx-auto">
           {/* Setup chips: machine · working dir · worktree (when supported) */}
           <div className="mb-2 flex flex-wrap items-center gap-1.5">
@@ -1729,7 +1729,7 @@ function NewSessionContent() {
             </TaskPickerPopover>
           </div>
 
-          <div ref={promptContainerRef} className="w-full bg-transparent border border-border/50 rounded-3xl px-4 py-3 relative font-mono flex gap-3">
+          <div ref={promptContainerRef} className="w-full bg-composer border border-border/50 rounded-3xl px-4 py-3 relative font-mono flex gap-3 shadow-sm">
             {/* Slash command suggestions */}
             {showSlashCommands && (
               <SlashCommandSuggestions

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -172,7 +172,7 @@ const LIFTED_DROPDOWN_SIDE_OFFSET = 8;
     Same surface as the prompt box; hover ≈ the dropdown-item highlight
     composited over it. */
 const SETUP_CHIP_CLASS =
-  'flex h-7 min-w-0 items-center gap-1.5 rounded-lg bg-[#2D2D2D] px-2.5 text-xs font-mono text-foreground/90 transition-colors hover:bg-[#3B3B3A] disabled:cursor-not-allowed disabled:opacity-50';
+  'flex h-7 min-w-0 items-center gap-1.5 rounded-lg bg-menu px-2.5 text-xs font-mono text-foreground/90 transition-colors hover:bg-menu-elevated disabled:cursor-not-allowed disabled:opacity-50';
 
 /**
  * Compose the initial prompt seeded from a task (plan §6): the task title +
@@ -1729,7 +1729,7 @@ function NewSessionContent() {
             </TaskPickerPopover>
           </div>
 
-          <div ref={promptContainerRef} className="w-full bg-[#2D2D2D] rounded-3xl px-4 py-3 relative font-mono flex gap-3">
+          <div ref={promptContainerRef} className="w-full bg-menu rounded-3xl px-4 py-3 relative font-mono flex gap-3">
             {/* Slash command suggestions */}
             {showSlashCommands && (
               <SlashCommandSuggestions

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -172,7 +172,7 @@ const LIFTED_DROPDOWN_SIDE_OFFSET = 8;
     Same surface as the prompt box; hover ≈ the dropdown-item highlight
     composited over it. */
 const SETUP_CHIP_CLASS =
-  'flex h-7 min-w-0 items-center gap-1.5 rounded-lg bg-menu px-2.5 text-xs font-mono text-foreground/90 transition-colors hover:bg-menu-elevated disabled:cursor-not-allowed disabled:opacity-50';
+  'flex h-7 min-w-0 items-center gap-1.5 rounded-lg bg-background dark:bg-menu px-2.5 text-xs font-mono text-foreground/90 transition-colors hover:bg-menu-elevated disabled:cursor-not-allowed disabled:opacity-50';
 
 /**
  * Compose the initial prompt seeded from a task (plan §6): the task title +
@@ -1729,7 +1729,7 @@ function NewSessionContent() {
             </TaskPickerPopover>
           </div>
 
-          <div ref={promptContainerRef} className="w-full bg-composer border border-border rounded-3xl px-4 py-3 relative font-mono flex gap-3 shadow-sm">
+          <div ref={promptContainerRef} className="w-full bg-composer border border-border/50 rounded-3xl px-4 py-3 relative font-mono flex gap-3 shadow-sm">
             {/* Slash command suggestions */}
             {showSlashCommands && (
               <SlashCommandSuggestions

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -1729,7 +1729,7 @@ function NewSessionContent() {
             </TaskPickerPopover>
           </div>
 
-          <div ref={promptContainerRef} className="w-full bg-menu rounded-3xl px-4 py-3 relative font-mono flex gap-3">
+          <div ref={promptContainerRef} className="w-full bg-composer border border-border rounded-3xl px-4 py-3 relative font-mono flex gap-3 shadow-sm">
             {/* Slash command suggestions */}
             {showSlashCommands && (
               <SlashCommandSuggestions

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -1729,7 +1729,7 @@ function NewSessionContent() {
             </TaskPickerPopover>
           </div>
 
-          <div ref={promptContainerRef} className="w-full bg-composer border border-border/50 rounded-3xl px-4 py-3 relative font-mono flex gap-3 shadow-sm">
+          <div ref={promptContainerRef} className="w-full bg-transparent border border-border/50 rounded-3xl px-4 py-3 relative font-mono flex gap-3">
             {/* Slash command suggestions */}
             {showSlashCommands && (
               <SlashCommandSuggestions

--- a/apps/web/app/dashboard/automation/components/automation-list.tsx
+++ b/apps/web/app/dashboard/automation/components/automation-list.tsx
@@ -143,7 +143,7 @@ export function AutomationList({
                         <button
                           type="button"
                           onClick={(e) => e.stopPropagation()}
-                          className="flex-shrink-0 rounded-md p-1 text-muted-foreground opacity-0 hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 data-[state=open]:opacity-100"
+                          className="flex-shrink-0 rounded-md p-1 text-muted-foreground opacity-0 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground group-hover:opacity-100 data-[state=open]:opacity-100"
                           title="Actions"
                         >
                           <MoreHorizontal className="h-4 w-4" />

--- a/apps/web/app/dashboard/automation/components/controls.tsx
+++ b/apps/web/app/dashboard/automation/components/controls.tsx
@@ -11,7 +11,7 @@ import {
 import { DAY_LABELS } from '../lib/frequency';
 
 export const ROW_TRIGGER =
-  'flex h-7 max-w-full items-center gap-1.5 rounded-lg px-2 text-sm text-foreground/90 transition-colors hover:bg-foreground/10 disabled:opacity-50';
+  'flex h-7 max-w-full items-center gap-1.5 rounded-lg px-2 text-sm text-foreground/90 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 disabled:opacity-50';
 
 /** A right-aligned enum picker rendered as a "value ⌄" dropdown. */
 export function ValueDropdown<T extends string>({
@@ -129,7 +129,7 @@ export function WeekdayPicker({
                 'h-7 w-9 rounded-md text-xs font-medium transition-colors',
                 value.includes(d)
                   ? 'bg-foreground text-background'
-                  : 'bg-muted/40 text-muted-foreground hover:bg-foreground/10',
+                  : 'bg-muted/40 text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10',
               )}
             >
               {dayLabel}
@@ -174,7 +174,7 @@ export function MonthdayPicker({
                 'h-7 rounded-md text-xs transition-colors',
                 value.includes(d)
                   ? 'bg-foreground text-background'
-                  : 'bg-muted/40 text-muted-foreground hover:bg-foreground/10',
+                  : 'bg-muted/40 text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10',
               )}
             >
               {d}

--- a/apps/web/app/dashboard/automation/components/datetime-fields.tsx
+++ b/apps/web/app/dashboard/automation/components/datetime-fields.tsx
@@ -111,7 +111,7 @@ function TimeColumn({
             'block w-full rounded-md px-2 py-1 text-center text-sm transition-colors',
             n === selected
               ? 'bg-foreground text-background'
-              : 'text-foreground/80 hover:bg-foreground/10',
+              : 'text-foreground/80 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10',
           )}
         >
           {pad2(n)}

--- a/apps/web/app/dashboard/automation/components/details-section.tsx
+++ b/apps/web/app/dashboard/automation/components/details-section.tsx
@@ -27,7 +27,7 @@ export interface WorktreeDraft {
 }
 
 const VALUE_TRIGGER =
-  'flex h-7 max-w-full items-center gap-1.5 rounded-lg px-2 text-sm text-foreground/90 transition-colors hover:bg-foreground/10 disabled:opacity-50';
+  'flex h-7 max-w-full items-center gap-1.5 rounded-lg px-2 text-sm text-foreground/90 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 disabled:opacity-50';
 
 function machineLabel(m: MachineSummary): string {
   return m.display_name || m.hostname || `Machine ${m.machine_id.slice(0, 6)}`;

--- a/apps/web/app/dashboard/automation/components/run-history-section.tsx
+++ b/apps/web/app/dashboard/automation/components/run-history-section.tsx
@@ -23,7 +23,7 @@ const STATUS_META: Record<
   { icon: LucideIcon; color: string; label: string }
 > = {
   fired: { icon: CheckCircle2, color: 'text-green-500', label: 'Ran' },
-  missed_offline: { icon: CircleAlert, color: 'text-amber-500', label: 'Missed — offline' },
+  missed_offline: { icon: CircleAlert, color: 'text-warning', label: 'Missed — offline' },
   failed: { icon: XCircle, color: 'text-red-500', label: 'Failed' },
   skipped: { icon: MinusCircle, color: 'text-muted-foreground', label: 'Skipped' },
 };

--- a/apps/web/app/dashboard/dashboard-layout.tsx
+++ b/apps/web/app/dashboard/dashboard-layout.tsx
@@ -332,7 +332,7 @@ function DashboardSidebar({
   return (
     <aside
       ref={sidebarRef}
-      className={`fixed inset-y-0 left-0 z-50 bg-[#272726] border-r border-border flex flex-col xl:relative xl:translate-x-0 transform transition-[transform] duration-300 ease-in-out font-mono text-sm ${
+      className={`fixed inset-y-0 left-0 z-50 bg-surface-nav border-r border-border flex flex-col xl:relative xl:translate-x-0 transform transition-[transform] duration-300 ease-in-out font-mono text-sm ${
         isMobileOpen ? 'translate-x-0' : '-translate-x-full'
       } xl:block`}
       style={{ width: showSideBar ? sidebarWidth : 56 }}
@@ -346,7 +346,7 @@ function DashboardSidebar({
       )}
 
       {/* Sidebar content */}
-      <div className="relative z-50 flex flex-col h-full bg-[#272726]">
+      <div className="relative z-50 flex flex-col h-full bg-surface-nav">
         {/* Logo Header */}
         <div className={cn("flex items-center", showSideBar ? "justify-between pl-5 pr-3 pt-2 pb-3" : "justify-center px-2 py-3")}>
           {!showSideBar ? (
@@ -908,7 +908,7 @@ function DashboardShell({
           />
         )}
 
-        <div className={cn('flex-1 flex flex-col min-w-0 xl:ml-0 overflow-hidden', IS_DESKTOP && 'relative bg-[#171717]')}>
+        <div className={cn('flex-1 flex flex-col min-w-0 xl:ml-0 overflow-hidden', IS_DESKTOP && 'relative bg-surface-canvas')}>
           {!isInstancePage && !IS_DESKTOP && <div className="xl:hidden h-16"></div>}
           {/* Windows: every non-instance page reserves a real titlebar-height
               strip (in flow, so content sits below it) so nothing is overlapped

--- a/apps/web/app/dashboard/settings/billing-settings-section.tsx
+++ b/apps/web/app/dashboard/settings/billing-settings-section.tsx
@@ -119,7 +119,7 @@ export function BillingSettingsSection({
             <ul className="mt-6 space-y-3">
               {freePlanFeatures.map((feature) => (
                 <li key={feature} className="flex items-start gap-3">
-                  <Check className="mt-0.5 h-5 w-5 flex-shrink-0 text-slate-600 dark:text-slate-400" />
+                  <Check className="mt-0.5 h-5 w-5 flex-shrink-0 text-muted-foreground" />
                   <span className="text-sm text-foreground/80">{feature}</span>
                 </li>
               ))}

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -30,6 +30,7 @@ import { OnboardingModal, ONBOARDING_KEY } from '@/components/dashboard/onboardi
 import { DesktopSettings } from '@/components/dashboard/desktop-settings';
 import { ProvidersSettingsSection } from '@/components/dashboard/providers-settings-section';
 import { MachinesSettingsSection } from '@/components/dashboard/machines-settings-section';
+import { ThemeSelect } from '@/components/plugins/theme-select';
 
 // Desktop builds swap the whole settings surface: the shell renders the
 // settings nav in the left panel and this page renders only the tab content.
@@ -53,6 +54,7 @@ type SupabaseUser = {
 
 const tabs = [
   { id: 'profile', label: 'Profile' },
+  { id: 'appearance', label: 'Appearance' },
   { id: 'providers', label: 'Providers' },
   { id: 'machines', label: 'Machines' },
   { id: 'billing', label: 'Billing' },
@@ -246,6 +248,25 @@ function SettingsContent() {
                       Profile information is unavailable.
                     </div>
                   )}
+                </CardContent>
+              </Card>
+            )}
+
+            {activeTab === 'appearance' && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Appearance</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                    <div className="space-y-1">
+                      <p className="text-sm text-foreground">Theme</p>
+                      <p className="text-xs text-muted-foreground">
+                        Base mode, or a theme installed from a plugin
+                      </p>
+                    </div>
+                    <ThemeSelect />
+                  </div>
                 </CardContent>
               </Card>
             )}
@@ -546,7 +567,7 @@ function SupabaseProfileForm({ user, onRefresh }: SupabaseProfileFormProps) {
         </div>
       </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
-      {success && <p className="text-sm text-emerald-500">{success}</p>}
+      {success && <p className="text-sm text-success">{success}</p>}
       <Button type="submit" disabled={isSaving}>
         {isSaving ? (
           <>

--- a/apps/web/app/dashboard/tasks/task-display-menu.tsx
+++ b/apps/web/app/dashboard/tasks/task-display-menu.tsx
@@ -57,8 +57,8 @@ export function TaskDisplayMenu({
         </Button>
       </PopoverTrigger>
       {/* Match the neighbouring header dropdowns (project filter, view) which
-          use bg-[#2D2D2D] rather than the lighter bg-popover. */}
-      <PopoverContent align="end" className="w-64 bg-[#2D2D2D] p-0 text-sm">
+          use bg-menu rather than the lighter bg-popover. */}
+      <PopoverContent align="end" className="w-64 bg-menu p-0 text-sm">
         <label className="flex cursor-pointer items-center justify-between border-b px-3 py-2.5">
           <span>Show sub-tasks</span>
           <Switch checked={showSubTasks} onCheckedChange={onShowSubTasksChange} />

--- a/apps/web/app/dashboard/tasks/task-views-bar.tsx
+++ b/apps/web/app/dashboard/tasks/task-views-bar.tsx
@@ -100,7 +100,7 @@ export function TaskViewsBar({
                   type="button"
                   aria-label="View options"
                   className={cn(
-                    'mr-0.5 flex size-5 items-center justify-center rounded-sm opacity-0 transition-opacity hover:bg-foreground/10 group-hover/tab:opacity-100 data-[state=open]:opacity-100',
+                    'mr-0.5 flex size-5 items-center justify-center rounded-sm opacity-0 transition-opacity hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 group-hover/tab:opacity-100 data-[state=open]:opacity-100',
                     active && 'opacity-70',
                   )}
                   onClick={(e) => e.stopPropagation()}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -74,6 +74,12 @@
   --color-warning: hsl(var(--warning));
   --color-info: hsl(var(--info));
 
+  /* Chat surfaces: the user message bubble and the composer container. Own
+     tokens so light can be tuned (reduced bubble, distinguishable composer)
+     without disturbing dark. */
+  --color-user-bubble: hsl(var(--user-bubble));
+  --color-composer: hsl(var(--composer));
+
   /* Font sweep: see the `.font-mono` override below. We do NOT repoint the
      Tailwind `--font-mono` @theme token — fumadocs also defines it and wins in
      the production bundle, and a `var()` value isn't valid in @theme anyway. */
@@ -157,14 +163,21 @@
     --menu-border: 214.3 31.8% 91.4%;
     --menu-elevated: 0 0% 97%;
 
-    /* Desktop app-shell surfaces (light). */
-    --surface-nav: 0 0% 98%;
+    /* Desktop app-shell surfaces (light). Nav is a subtle cool gray so it reads
+       as clearly distinct from the white content canvas (not just a hair off). */
+    --surface-nav: 220 20% 96.5%;
     --surface-canvas: 0 0% 100%;
 
     /* Semantic status colours (light — one step darker for contrast on white). */
     --success: 160 84% 34%;
     --warning: 32 95% 44%;
     --info: 221 83% 53%;
+
+    /* Chat surfaces (light). User bubble is a gentle, reduced tint (not the
+       heavier --muted); composer is a soft off-white so it separates from the
+       white page even before its border/shadow. */
+    --user-bubble: 214 32% 97%;
+    --composer: 210 40% 97.5%;
 
     /* Git commit-graph lane colors (used raw as var(--…), not HSL-wrapped).
        Rendered only on the always-dark files/git panel, so one definition. */
@@ -228,6 +241,11 @@
     --success: 160 84% 39%;
     --warning: 38 92% 50%;
     --info: 213 94% 68%;
+
+    /* Chat surfaces (dark) — unchanged from before: user bubble = --muted
+       (#212B36), composer = --menu (#2D2D2D). Pinned here so dark is identical. */
+    --user-bubble: 205 23% 12.9%;
+    --composer: 0 0% 18%;
   }
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -54,7 +54,7 @@
   --color-sidebar-border: hsl(var(--sidebar-border));
   --color-sidebar-ring: hsl(var(--sidebar-ring));
 
-  --color-inline-code: #ABB0F4;
+  --color-inline-code: hsl(var(--inline-code));
   --color-message-text: hsl(var(--message-text));
 
   /* Menu / overlay surfaces — grayer than --popover, used by dropdowns,
@@ -163,9 +163,10 @@
     --menu-border: 214.3 31.8% 91.4%;
     --menu-elevated: 0 0% 97%;
 
-    /* Desktop app-shell surfaces (light). Nav + canvas match the page bg
-       (#FDFCFC); separation comes from borders + the pure-white composer/cards. */
-    --surface-nav: 0 20% 99%; /* #FDFCFC */
+    /* Desktop app-shell surfaces (light). Nav is a hair grayer than the page bg
+       so the left column reads as distinct; canvas matches the page bg so the
+       pure-white composer/cards pop. */
+    --surface-nav: 300 8% 97.5%; /* #F9F8F9 */
     --surface-canvas: 0 20% 99%; /* #FDFCFC */
 
     /* Semantic status colours (light — one step darker for contrast on white). */
@@ -178,6 +179,8 @@
        canvas (helped by its border + shadow). */
     --user-bubble: 214 32% 97%;
     --composer: 0 0% 100%; /* pure white */
+    --inline-code: 243 70% 56%; /* readable indigo on white (dark uses the pale
+      #ABB0F4, which is far too light against a light surface) */
 
     /* Git commit-graph lane colors (used raw as var(--…), not HSL-wrapped).
        Rendered only on the always-dark files/git panel, so one definition. */
@@ -246,6 +249,7 @@
        (#212B36), composer = --menu (#2D2D2D). Pinned here so dark is identical. */
     --user-bubble: 205 23% 12.9%;
     --composer: 0 0% 18%;
+    --inline-code: 236 77% 81.5%; /* #ABB0F4 — unchanged from before */
   }
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -120,7 +120,7 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 0 20% 99%; /* #FDFCFC — soft off-white page background */
     --foreground: 222.2 84% 4.9%;
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
@@ -163,10 +163,10 @@
     --menu-border: 214.3 31.8% 91.4%;
     --menu-elevated: 0 0% 97%;
 
-    /* Desktop app-shell surfaces (light). Nav is a subtle cool gray so it reads
-       as clearly distinct from the white content canvas (not just a hair off). */
-    --surface-nav: 220 20% 96.5%;
-    --surface-canvas: 0 0% 100%;
+    /* Desktop app-shell surfaces (light). Nav + canvas match the page bg
+       (#FDFCFC); separation comes from borders + the pure-white composer/cards. */
+    --surface-nav: 0 20% 99%; /* #FDFCFC */
+    --surface-canvas: 0 20% 99%; /* #FDFCFC */
 
     /* Semantic status colours (light — one step darker for contrast on white). */
     --success: 160 84% 34%;
@@ -174,10 +174,10 @@
     --info: 221 83% 53%;
 
     /* Chat surfaces (light). User bubble is a gentle, reduced tint (not the
-       heavier --muted); composer is a soft off-white so it separates from the
-       white page even before its border/shadow. */
+       heavier --muted); composer is pure white so it pops off the #FDFCFC
+       canvas (helped by its border + shadow). */
     --user-bubble: 214 32% 97%;
-    --composer: 210 40% 97.5%;
+    --composer: 0 0% 100%; /* pure white */
 
     /* Git commit-graph lane colors (used raw as var(--…), not HSL-wrapped).
        Rendered only on the always-dark files/git panel, so one definition. */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -57,6 +57,23 @@
   --color-inline-code: #ABB0F4;
   --color-message-text: hsl(var(--message-text));
 
+  /* Menu / overlay surfaces — grayer than --popover, used by dropdowns,
+     context menus, selects, pickers, and the composer. A distinct semantic
+     role, so its own token (see globals.css :root/.dark for values). */
+  --color-menu: hsl(var(--menu));
+  --color-menu-foreground: hsl(var(--menu-foreground));
+  --color-menu-border: hsl(var(--menu-border));
+  --color-menu-elevated: hsl(var(--menu-elevated));
+
+  /* Desktop app-shell surfaces (the Electron renderer chrome). */
+  --color-surface-nav: hsl(var(--surface-nav));
+  --color-surface-canvas: hsl(var(--surface-canvas));
+
+  /* Semantic status colours (previously ad-hoc emerald/amber utilities). */
+  --color-success: hsl(var(--success));
+  --color-warning: hsl(var(--warning));
+  --color-info: hsl(var(--info));
+
   /* Font sweep: see the `.font-mono` override below. We do NOT repoint the
      Tailwind `--font-mono` @theme token — fumadocs also defines it and wins in
      the production bundle, and a `var()` value isn't valid in @theme anyway. */
@@ -108,7 +125,8 @@
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 68%;
+    --muted-foreground: 215.4 16.3% 40%; /* Readable secondary text on white
+      (was 68% — near-invisible; used for nearly all muted text app-wide). */
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
     --destructive: 0 70% 55%;
@@ -131,6 +149,22 @@
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
     --message-text: 0 0% 40%; /* Darker gray for light mode */
+
+    /* Menu / overlay surfaces (light). Menus render as white cards with a
+       hairline border + shadow, distinct from the page card. */
+    --menu: 0 0% 100%;
+    --menu-foreground: 222.2 84% 4.9%;
+    --menu-border: 214.3 31.8% 91.4%;
+    --menu-elevated: 0 0% 97%;
+
+    /* Desktop app-shell surfaces (light). */
+    --surface-nav: 0 0% 98%;
+    --surface-canvas: 0 0% 100%;
+
+    /* Semantic status colours (light — one step darker for contrast on white). */
+    --success: 160 84% 34%;
+    --warning: 32 95% 44%;
+    --info: 221 83% 53%;
 
     /* Git commit-graph lane colors (used raw as var(--…), not HSL-wrapped).
        Rendered only on the always-dark files/git panel, so one definition. */
@@ -177,6 +211,23 @@
     --sidebar-border: 205 20% 20%;
     --sidebar-ring: 217.2 91.2% 59.8%;
     --message-text: 0 0% 98.4%; /* #fbfbfb - Custom color for message text */
+
+    /* Menu / overlay surfaces (dark). Values equal the previously-hardcoded
+       hexes so dark mode is pixel-identical to before tokenization:
+       --menu #2D2D2D, --menu-elevated #333331, --menu-border ≈ white/10. */
+    --menu: 0 0% 18%;
+    --menu-foreground: 210 40% 98%;
+    --menu-border: 0 0% 27%;
+    --menu-elevated: 60 2% 20%;
+
+    /* Desktop app-shell surfaces (dark): --surface-nav #272726, canvas #171717. */
+    --surface-nav: 60 1% 15%;
+    --surface-canvas: 0 0% 9%;
+
+    /* Semantic status colours (dark): emerald-500 / amber-500 / blue-400. */
+    --success: 160 84% 39%;
+    --warning: 38 92% 50%;
+    --info: 213 94% 68%;
   }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -140,6 +140,18 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
+        {/* Pre-hydration theme class. `<html>` ships with `dark` as the no-JS
+            default; this blocking script runs before first paint and swaps in
+            the user's stored choice so light-mode users never see a dark flash.
+            Mirrors theme-provider.tsx: storageKey `ui-theme`, `system` resolves
+            via matchMedia, and `plugin:` themes fall back to their dark base
+            until the provider resolves the real base post-mount. Must stay a
+            raw <script> (not next/script, which defers). */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('ui-theme')||'dark';var c='dark';if(t==='light')c='light';else if(t==='system')c=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';else if(t.indexOf('plugin:')===0)c='dark';var e=document.documentElement;e.classList.remove('light','dark');e.classList.add(c);}catch(e){}})();`,
+          }}
+        />
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-EWZH9BN2RK"
           strategy="lazyOnload"

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -694,7 +694,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
       )}
       <div
         ref={containerRef}
-        className="w-full bg-menu rounded-3xl px-4 py-3 relative font-mono"
+        className="w-full bg-composer border border-border rounded-3xl px-4 py-3 relative font-mono shadow-sm"
       >
       {/* Slash command suggestions */}
       {showSlashCommands && (

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -694,7 +694,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
       )}
       <div
         ref={containerRef}
-        className="w-full bg-composer border border-border rounded-3xl px-4 py-3 relative font-mono shadow-sm"
+        className="w-full bg-composer border border-border/50 rounded-3xl px-4 py-3 relative font-mono shadow-sm"
       >
       {/* Slash command suggestions */}
       {showSlashCommands && (

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -694,7 +694,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
       )}
       <div
         ref={containerRef}
-        className="w-full bg-[#2D2D2D] rounded-3xl px-4 py-3 relative font-mono"
+        className="w-full bg-menu rounded-3xl px-4 py-3 relative font-mono"
       >
       {/* Slash command suggestions */}
       {showSlashCommands && (

--- a/apps/web/components/chat-usage-indicator.tsx
+++ b/apps/web/components/chat-usage-indicator.tsx
@@ -172,7 +172,7 @@ export function ChatUsageIndicator({
       <PopoverContent
         align="start"
         side="top"
-        className="w-72 space-y-3 p-3 font-mono text-xs bg-[#2D2D2D] border-foreground/15 shadow-xl rounded-xl"
+        className="w-72 space-y-3 p-3 font-mono text-xs bg-menu border-foreground/15 shadow-xl rounded-xl"
       >
         <div className="flex items-baseline justify-between gap-2 text-xs text-muted-foreground/60">
           <span>Usage</span>

--- a/apps/web/components/dashboard/agent-type-icon.tsx
+++ b/apps/web/components/dashboard/agent-type-icon.tsx
@@ -3,22 +3,36 @@ import { MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CLOSED_STATUSES } from '@/components/dashboard/session-grouping';
 
-// `isOpenAI` really means "monochrome dark glyph that needs inverting on dark
-// surfaces" — the monochrome brand marks reuse it alongside openai.svg.
-// `boxedWhite` is the alternative for a dark glyph we'd rather not invert:
-// on a dark surface it renders as-is on a white rounded chip (keeps detail).
-const AGENT_LOGOS: { match: string; src: string; alt: string; isOpenAI?: boolean; boxedWhite?: boolean }[] = [
+// Brand-mark treatment, per logo. The marks were authored for the old
+// always-dark UI, so several need theme-aware handling now that a light theme
+// exists (all applied only when `whiteForOpenAI`, i.e. on the themed surfaces):
+//   • `isOpenAI` — a monochrome dark glyph (currentColor → black). Inverts to
+//     white on a DARK theme; stays dark (legible) on light. (Codex, Cursor, Copilot)
+//   • `invertForLight` — a two-tone mark built for dark (near-white outer): invert
+//     it on LIGHT so the outer goes dark, leave it untouched on dark. (OpenCode)
+//   • `darkPlate` — a white-on-transparent mark that vanishes on light: sit it on a
+//     dark rounded plate (only where needed; transparent on dark). (Kimi)
+//   • `boxedWhite` — a dark glyph we'd rather not invert: a white rounded chip. (Hermes)
+const AGENT_LOGOS: {
+  match: string;
+  src: string;
+  alt: string;
+  isOpenAI?: boolean;
+  invertForLight?: boolean;
+  darkPlate?: boolean;
+  boxedWhite?: boolean;
+}[] = [
   { match: 'claude',    src: '/images/integrations/claude-color.svg',  alt: 'Claude' },
   { match: 'codex',     src: '/images/integrations/openai.svg',        alt: 'Codex', isOpenAI: true },
-  { match: 'opencode',  src: '/images/integrations/opencode.svg',      alt: 'OpenCode' },
+  { match: 'opencode',  src: '/images/integrations/opencode.svg',      alt: 'OpenCode', invertForLight: true },
   { match: 'cursor',    src: '/images/integrations/cursor.svg',        alt: 'Cursor', isOpenAI: true },
   { match: 'gemini',    src: '/images/integrations/gemini-color.svg',  alt: 'Gemini' },
   { match: 'copilot',   src: '/images/integrations/githubcopilot.svg', alt: 'Copilot', isOpenAI: true },
-  { match: 'kimi',      src: '/images/integrations/kimi-color.svg',    alt: 'Kimi' },
+  { match: 'kimi',      src: '/images/integrations/kimi-color.svg',    alt: 'Kimi', darkPlate: true },
   { match: 'hermes',    src: '/images/integrations/hermes.svg',        alt: 'Hermes', boxedWhite: true },
 ];
 
-export function getAgentLogoSrc(agentTypeName: string | null | undefined): { src: string; alt: string; isOpenAI?: boolean; boxedWhite?: boolean } | null {
+export function getAgentLogoSrc(agentTypeName: string | null | undefined): { src: string; alt: string; isOpenAI?: boolean; invertForLight?: boolean; darkPlate?: boolean; boxedWhite?: boolean } | null {
   if (!agentTypeName) return null;
   const name = agentTypeName.toLowerCase();
   return AGENT_LOGOS.find(({ match }) => name.includes(match)) ?? null;
@@ -65,6 +79,32 @@ export function AgentTypeIcon({
     );
   }
 
+  // Kimi (white-on-transparent): invisible on a light surface. Sit it on a dark
+  // rounded plate in light (bg-foreground = near-black), transparent in dark
+  // where the surface already supplies the contrast.
+  if (whiteForOpenAI && logo.darkPlate) {
+    const glyph = Math.round(size * 0.82);
+    return (
+      <span
+        className={cn(
+          'flex-shrink-0 inline-flex items-center justify-center bg-foreground dark:bg-transparent',
+          className,
+        )}
+        style={{ width: size, height: size, borderRadius: size * 0.24 }}
+      >
+        <Image
+          src={logo.src}
+          alt={logo.alt}
+          width={glyph}
+          height={glyph}
+          unoptimized
+          className={cn(spinning && 'animate-logo-fade')}
+          style={{ width: glyph, height: glyph }}
+        />
+      </span>
+    );
+  }
+
   return (
     <Image
       src={logo.src}
@@ -75,7 +115,10 @@ export function AgentTypeIcon({
       className={cn(
         'flex-shrink-0',
         spinning && 'animate-logo-fade',
-        whiteForOpenAI && logo.isOpenAI && 'invert',
+        // Monochrome dark glyphs go white only on a dark theme; dark & legible on light.
+        whiteForOpenAI && logo.isOpenAI && 'dark:invert',
+        // Two-tone marks built for dark invert on light, natural on dark.
+        whiteForOpenAI && logo.invertForLight && 'invert dark:invert-0',
         className
       )}
       style={{ width: size, height: size }}

--- a/apps/web/components/dashboard/ask-user-question-panel.tsx
+++ b/apps/web/components/dashboard/ask-user-question-panel.tsx
@@ -417,7 +417,7 @@ export function AskUserQuestionPanel({ message, onSubmit, onCancel }: AskUserQue
                 });
               }}
               rows={3}
-              className="custom-scrollbar w-full resize-y rounded-md bg-black/25 px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+              className="custom-scrollbar w-full resize-y rounded-md bg-foreground/5 px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
               placeholder="Type your answer"
             />
           )}

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -87,7 +87,6 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
                  message.sender_type === 'USER' ||
                  message.sender_type === 'HUMAN';
 
-  const requiresAction = message.requires_user_input;
   const agentType = resolveAgentType(agentTypeName);
   const askUserQuestion = parseAskUserQuestionPayload(message);
   const attachments = extractChatAttachments(message.message_metadata);
@@ -124,13 +123,11 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
 
   // Shared bubble chrome, now applied to the image bubble and the text bubble
   // independently (they used to be one element).
-  const bubbleShell = `rounded-xl ${
-    compact && !isUser ? '' : 'px-4 py-2 shadow-sm'
-  } ${
+  // Agent messages are flat (no bg / border / shadow) so they read as plain
+  // prose; only the user bubble carries a (reduced) fill + hairline border.
+  const bubbleShell = `rounded-xl ${compact && !isUser ? '' : 'px-4 py-2'} ${
     isUser
-      ? 'bg-muted border border-border text-foreground rounded-tr-sm'
-      : requiresAction
-      ? 'text-foreground rounded-tl-sm'
+      ? 'bg-user-bubble border border-border text-foreground rounded-tr-sm shadow-sm'
       : 'text-foreground rounded-tl-sm'
   }`;
   // An image-only user message has no text body — skip the empty text bubble.

--- a/apps/web/components/dashboard/desktop-connection-banner.tsx
+++ b/apps/web/components/dashboard/desktop-connection-banner.tsx
@@ -54,7 +54,7 @@ export function DesktopConnectionBanner() {
   if (!show) return null;
 
   return (
-    <div className="flex items-center justify-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-mono text-amber-600 dark:text-amber-500">
+    <div className="flex items-center justify-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-mono text-amber-600 dark:text-warning">
       <Loader2 className="h-3 w-3 animate-spin" />
       Local daemon disconnected — reconnecting…
     </div>

--- a/apps/web/components/dashboard/desktop-notification-nudge.tsx
+++ b/apps/web/components/dashboard/desktop-notification-nudge.tsx
@@ -65,7 +65,7 @@ export function DesktopNotificationNudge() {
         type="button"
         aria-label="Dismiss"
         onClick={() => dismissNotificationNudge()}
-        className="ml-1 flex h-4 w-4 cursor-pointer items-center justify-center rounded hover:bg-foreground/10 hover:text-foreground"
+        className="ml-1 flex h-4 w-4 cursor-pointer items-center justify-center rounded hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
       >
         <X className="h-3 w-3" />
       </button>

--- a/apps/web/components/dashboard/desktop-settings-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-settings-sidebar.tsx
@@ -89,7 +89,7 @@ function DesktopSettingsSidebarInner() {
           type="button"
           onClick={backToApp}
           style={NO_DRAG}
-          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
         >
           <ArrowLeft className="h-3.5 w-3.5" />
           Back to app
@@ -112,7 +112,7 @@ function DesktopSettingsSidebarInner() {
               'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
               tab === id
                 ? 'bg-foreground/10 text-foreground'
-                : 'text-muted-foreground hover:bg-foreground/10 hover:text-foreground',
+                : 'text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground',
             )}
           >
             <Icon className="h-3.5 w-3.5 shrink-0" />
@@ -145,7 +145,7 @@ function DesktopSettingsSidebarInner() {
                     'flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors',
                     active
                       ? 'bg-foreground/10 text-foreground'
-                      : 'text-muted-foreground hover:bg-foreground/10 hover:text-foreground',
+                      : 'text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground',
                   )}
                 >
                   <Folder className="h-3.5 w-3.5 shrink-0" />

--- a/apps/web/components/dashboard/desktop-settings-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-settings-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useCallback, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Bot, Folder, Keyboard, Monitor, Puzzle, Settings, User } from 'lucide-react';
+import { ArrowLeft, Bot, Folder, Keyboard, Monitor, Palette, Puzzle, Settings, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
 import { DesktopTitlebarLead } from '@/components/desktop/window-chrome';
@@ -22,6 +22,7 @@ export const DESKTOP_LAST_APP_PATH_KEY = 'desktop-last-app-path';
 
 export const DESKTOP_SETTINGS_TABS = [
   { id: 'general', label: 'General', Icon: Settings },
+  { id: 'appearance', label: 'Appearance', Icon: Palette },
   { id: 'profile', label: 'Profile', Icon: User },
   { id: 'providers', label: 'Providers', Icon: Bot },
   { id: 'machines', label: 'Machines', Icon: Monitor },
@@ -47,7 +48,7 @@ export function DesktopSettingsSidebar() {
     // useSearchParams needs a Suspense boundary during prerender; the fallback
     // keeps the panel's frame so the layout doesn't jump.
     <Suspense
-      fallback={<aside className="w-64 shrink-0 border-r border-border bg-[#272726]" aria-hidden />}
+      fallback={<aside className="w-64 shrink-0 border-r border-border bg-surface-nav" aria-hidden />}
     >
       <DesktopSettingsSidebarInner />
     </Suspense>
@@ -74,7 +75,7 @@ function DesktopSettingsSidebarInner() {
   }, [router]);
 
   return (
-    <aside className="relative z-10 flex h-full w-64 shrink-0 flex-col border-r border-border bg-[#272726] font-mono text-sm">
+    <aside className="relative z-10 flex h-full w-64 shrink-0 flex-col border-r border-border bg-surface-nav font-mono text-sm">
       {/* Titlebar strip (window drag region), reserving the traffic lights. */}
       <div
         style={DRAG_REGION}

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -91,6 +91,8 @@ export function DesktopSettings() {
         <div className="mx-auto w-full max-w-3xl px-8 pb-12">
           {tab === 'shortcuts' ? (
             <ShortcutsSection />
+          ) : tab === 'appearance' ? (
+            <AppearanceSection />
           ) : tab === 'profile' ? (
             <ProfileSection />
           ) : tab === 'providers' ? (
@@ -316,8 +318,8 @@ const AUTHORIZATION_LABELS: Record<NotificationAuthorizationStatus, string> = {
 };
 
 const AUTHORIZATION_COLORS: Record<NotificationAuthorizationStatus, string> = {
-  authorized: 'text-emerald-500',
-  denied: 'text-amber-500',
+  authorized: 'text-success',
+  denied: 'text-warning',
   'not-determined': 'text-muted-foreground',
   unknown: 'text-muted-foreground',
 };
@@ -356,6 +358,27 @@ const NOTIFICATION_MODE_LABELS: Record<NotificationMode, string> = {
   unfocused: 'Only when unfocused',
   always: 'Always',
 };
+
+/** Appearance tab: theme selection (base modes + plugin themes). Its own tab so
+ *  it has room to grow (e.g. accent tint, density) beyond the single Theme row. */
+function AppearanceSection() {
+  return (
+    <section>
+      <SectionTitle>Appearance</SectionTitle>
+      <div className="mt-8">
+        <h2 className="mb-3 text-sm text-foreground/90">Theme</h2>
+        <SettingsCard>
+          <SettingsRow
+            title="Theme"
+            description="Base mode, or a theme installed from a plugin"
+          >
+            <ThemeSelect />
+          </SettingsRow>
+        </SettingsCard>
+      </div>
+    </section>
+  );
+}
 
 function GeneralSection() {
   const [mounted, setMounted] = useState(false);
@@ -423,17 +446,6 @@ function GeneralSection() {
     <section>
       <SectionTitle>General</SectionTitle>
       <div className="mt-8">
-        <h2 className="mb-3 text-sm text-foreground/90">Appearance</h2>
-        <SettingsCard>
-          <SettingsRow
-            title="Theme"
-            description="Base mode, or a theme installed from a plugin"
-          >
-            <ThemeSelect />
-          </SettingsRow>
-        </SettingsCard>
-      </div>
-      <div className="mt-8">
         <h2 className="mb-3 text-sm text-foreground/90">Notifications</h2>
         <SettingsCard>
           <SettingsRow
@@ -448,9 +460,9 @@ function GeneralSection() {
                 <SelectValue>{NOTIFICATION_MODE_LABELS[mode]}</SelectValue>
               </SelectTrigger>
               {/* Match DropdownMenuContent (e.g. the chat page's ··· menu):
-                  same #2D2D2D surface + foreground/10 hover instead of the
+                  same --menu surface + foreground/10 hover instead of the
                   select's default popover/accent pair. */}
-              <SelectContent align="end" className="bg-[#2D2D2D] font-mono">
+              <SelectContent align="end" className="bg-menu font-mono">
                 {(Object.keys(NOTIFICATION_MODE_LABELS) as NotificationMode[]).map((value) => (
                   <SelectItem
                     key={value}
@@ -475,7 +487,7 @@ function GeneralSection() {
                 >
                   <SelectValue>{silencePhone ? 'Silence while focused' : 'Always send'}</SelectValue>
                 </SelectTrigger>
-                <SelectContent align="end" className="bg-[#2D2D2D] font-mono">
+                <SelectContent align="end" className="bg-menu font-mono">
                   <SelectItem
                     value="silence"
                     className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground"
@@ -539,7 +551,7 @@ function GeneralSection() {
               >
                 <SelectValue>{mobileHidden ? 'Hidden' : 'Shown'}</SelectValue>
               </SelectTrigger>
-              <SelectContent align="end" className="bg-[#2D2D2D] font-mono">
+              <SelectContent align="end" className="bg-menu font-mono">
                 <SelectItem value="shown" className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground">
                   Shown
                 </SelectItem>
@@ -603,7 +615,7 @@ function CliCommandCard() {
         </SettingsRow>
         {result && (
           <div className="px-4 py-3 text-xs">
-            <div className={result.ok ? 'text-emerald-500' : 'text-amber-500'}>{result.message}</div>
+            <div className={result.ok ? 'text-success' : 'text-warning'}>{result.message}</div>
             {result.detail && (
               <div className="mt-1 whitespace-pre-wrap text-muted-foreground">{result.detail}</div>
             )}
@@ -865,7 +877,7 @@ function ShortcutRow({ label, children }: { label: string; children: React.React
 
 function Keycap({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="flex h-5 min-w-5 items-center justify-center rounded border border-border/70 bg-[#2D2D2D] px-1 font-mono text-[10px] text-muted-foreground">
+    <kbd className="flex h-5 min-w-5 items-center justify-center rounded border border-border/70 bg-menu px-1 font-mono text-[10px] text-muted-foreground">
       {children}
     </kbd>
   );

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -467,7 +467,7 @@ function GeneralSection() {
                   <SelectItem
                     key={value}
                     value={value}
-                    className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground"
+                    className="cursor-pointer text-xs focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground"
                   >
                     {NOTIFICATION_MODE_LABELS[value]}
                   </SelectItem>
@@ -490,13 +490,13 @@ function GeneralSection() {
                 <SelectContent align="end" className="bg-menu font-mono">
                   <SelectItem
                     value="silence"
-                    className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground"
+                    className="cursor-pointer text-xs focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground"
                   >
                     Silence while focused
                   </SelectItem>
                   <SelectItem
                     value="always"
-                    className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground"
+                    className="cursor-pointer text-xs focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground"
                   >
                     Always send
                   </SelectItem>
@@ -552,10 +552,10 @@ function GeneralSection() {
                 <SelectValue>{mobileHidden ? 'Hidden' : 'Shown'}</SelectValue>
               </SelectTrigger>
               <SelectContent align="end" className="bg-menu font-mono">
-                <SelectItem value="shown" className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground">
+                <SelectItem value="shown" className="cursor-pointer text-xs focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground">
                   Shown
                 </SelectItem>
-                <SelectItem value="hidden" className="cursor-pointer text-xs focus:bg-foreground/10 focus:text-foreground">
+                <SelectItem value="hidden" className="cursor-pointer text-xs focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground">
                   Hidden
                 </SelectItem>
               </SelectContent>

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -172,7 +172,7 @@ export function DesktopSidebar({
     <aside
       ref={asideRef}
       style={{ width }}
-      className="relative z-10 flex h-full shrink-0 flex-col border-r border-border bg-[#272726] font-mono text-sm"
+      className="relative z-10 flex h-full shrink-0 flex-col border-r border-border bg-surface-nav font-mono text-sm"
     >
       {/* Titlebar header (drag region). Reserves space for the macOS traffic
           lights, shows the brand, and collapses the panel. */}

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -188,7 +188,7 @@ export function DesktopSidebar({
           style={NO_DRAG}
           title="Collapse sidebar"
           aria-label="Collapse sidebar"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
         >
           <PanelLeft className="h-4 w-4" />
         </button>
@@ -352,7 +352,7 @@ function LocalAccountArea() {
           title="Settings"
           aria-label="Settings"
           onClick={() => router.push('/dashboard/settings')}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
         >
           <Cog className="h-4 w-4" />
         </button>
@@ -418,7 +418,7 @@ function CloudAccountArea() {
           type="button"
           title="Account"
           aria-label="Account menu"
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-muted/60"
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/10"
         >
           <User className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="flex-1 min-w-0 truncate text-xs text-muted-foreground" title={email ?? undefined}>

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -30,7 +30,7 @@ import { SetupChecklist } from '@/components/dashboard/setup-checklist';
 import { useTerminalSessions } from '@/components/terminal-pane/terminal-sessions';
 
 // Selected-row highlight for the nav buttons (New Session / Mobile / Tasks).
-const ITEM_SELECTED = 'bg-foreground/10 text-foreground';
+const ITEM_SELECTED = 'bg-foreground/[0.08] dark:bg-foreground/10 text-foreground';
 
 // Desktop sidebar is user-resizable; width persists across reloads. Clamp keeps
 // the session list usable without letting it eat the chat/files panels.
@@ -188,7 +188,7 @@ export function DesktopSidebar({
           style={NO_DRAG}
           title="Collapse sidebar"
           aria-label="Collapse sidebar"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
         >
           <PanelLeft className="h-4 w-4" />
         </button>
@@ -352,7 +352,7 @@ function LocalAccountArea() {
           title="Settings"
           aria-label="Settings"
           onClick={() => router.push('/dashboard/settings')}
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
         >
           <Cog className="h-4 w-4" />
         </button>
@@ -418,7 +418,7 @@ function CloudAccountArea() {
           type="button"
           title="Account"
           aria-label="Account menu"
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/10"
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10"
         >
           <User className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="flex-1 min-w-0 truncate text-xs text-muted-foreground" title={email ?? undefined}>

--- a/apps/web/components/dashboard/directory-picker-popover.tsx
+++ b/apps/web/components/dashboard/directory-picker-popover.tsx
@@ -62,7 +62,7 @@ export function DirectoryPickerPopover({
         // editor, AND lift it visually (thicker bordered, stronger shadow)
         // so it clearly sits apart from the trigger card rather than blending
         // in. Opens downward, flipping up on collision (Radix avoidCollisions).
-        className="w-[max(var(--radix-popover-trigger-width),18rem)] rounded-xl p-3 space-y-3 border border-foreground/15 bg-[#2D2D2D] shadow-xl"
+        className="w-[max(var(--radix-popover-trigger-width),18rem)] rounded-xl p-3 space-y-3 border border-foreground/15 bg-menu shadow-xl"
         // Radix's default auto-focus triggers the browser's "select-all"
         // behavior on inputs containing existing text. Prevent it and place
         // the cursor at the end instead — the user is almost always editing,
@@ -97,8 +97,8 @@ export function DirectoryPickerPopover({
               }
             }}
             // Borderless: the field reads as editable through its darker
-            // inset surface against the #2D2D2D popover instead of a border.
-            className="font-mono text-xs md:text-xs h-8 rounded-md border-0 bg-black/25 dark:bg-black/25 shadow-none focus-visible:ring-0 focus-visible:border-0"
+            // inset surface against the --menu popover instead of a border.
+            className="font-mono text-xs md:text-xs h-8 rounded-md border-0 bg-foreground/5 shadow-none focus-visible:ring-0 focus-visible:border-0"
           />
         </div>
 

--- a/apps/web/components/dashboard/directory-picker-popover.tsx
+++ b/apps/web/components/dashboard/directory-picker-popover.tsx
@@ -114,12 +114,12 @@ export function DirectoryPickerPopover({
                   type="button"
                   onClick={() => commit(path)}
                   // Match shadcn DropdownMenuItem's *actual* hover token —
-                  // `focus:bg-foreground/10` (Radix promotes hover into
+                  // `focus:bg-foreground/[0.06] dark:focus:bg-foreground/10` (Radix promotes hover into
                   // focus on the menu items). On a plain <button> the
-                  // equivalent is `hover:bg-foreground/10` (+ focus-visible
+                  // equivalent is `hover:bg-foreground/[0.06] dark:hover:bg-foreground/10` (+ focus-visible
                   // for keyboard nav). bg-accent looked identical to the
                   // popover BG in this theme, so the hover wasn't visible.
-                  className="flex w-full items-center gap-1.5 rounded-sm px-2.5 py-1 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:outline-none cursor-pointer"
+                  className="flex w-full items-center gap-1.5 rounded-sm px-2.5 py-1 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:outline-none cursor-pointer"
                   title={path}
                 >
                   <Folder className="h-3 w-3 flex-shrink-0" />
@@ -143,7 +143,7 @@ export function DirectoryPickerPopover({
                   if (path) commit(path);
                 });
               }}
-              className="flex w-full items-center gap-1.5 rounded-sm px-2.5 py-1.5 text-[11px] font-mono text-popover-foreground transition-colors hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:outline-none cursor-pointer"
+              className="flex w-full items-center gap-1.5 rounded-sm px-2.5 py-1.5 text-[11px] font-mono text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:outline-none cursor-pointer"
             >
               <FolderOpen className="h-3 w-3 flex-shrink-0" />
               Open folder…

--- a/apps/web/components/dashboard/machines-settings-section.tsx
+++ b/apps/web/components/dashboard/machines-settings-section.tsx
@@ -214,7 +214,7 @@ export function MachinesSettingsSection() {
           )}
         </SectionCard>
         {loadError && (
-          <p className="mt-2 text-xs text-amber-500">
+          <p className="mt-2 text-xs text-warning">
             Couldn’t reach the server — this list may be out of date.
           </p>
         )}

--- a/apps/web/components/dashboard/plugins-settings-section.tsx
+++ b/apps/web/components/dashboard/plugins-settings-section.tsx
@@ -200,7 +200,7 @@ export function PluginsSettingsSection() {
                           </span>
                         )}
                         {p.valid && !p.trusted && (
-                          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-500">
+                          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-warning">
                             untrusted
                           </span>
                         )}

--- a/apps/web/components/dashboard/providers-settings-section.tsx
+++ b/apps/web/components/dashboard/providers-settings-section.tsx
@@ -319,7 +319,7 @@ export function ProvidersSettingsSection() {
           )}
         </SectionCard>
         {loadError && (
-          <p className="mt-2 text-xs text-amber-500">
+          <p className="mt-2 text-xs text-warning">
             Couldn’t reach the server — this list may be out of date.
           </p>
         )}

--- a/apps/web/components/dashboard/queue-status.tsx
+++ b/apps/web/components/dashboard/queue-status.tsx
@@ -109,7 +109,7 @@ function QueuedMessageRow({
               aria-label="Bring queued message back to input"
               className={cn(
                 'mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full p-0.5 text-muted-foreground/60',
-                'hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
+                'hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
               )}
             >
               <Undo2 className="h-3.5 w-3.5" />
@@ -129,7 +129,7 @@ function QueuedMessageRow({
             aria-label="Remove queued message"
             className={cn(
               'mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full p-0.5 text-muted-foreground/60',
-              'hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
+              'hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
             )}
           >
             {isCancelling ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}

--- a/apps/web/components/dashboard/queue-status.tsx
+++ b/apps/web/components/dashboard/queue-status.tsx
@@ -109,7 +109,7 @@ function QueuedMessageRow({
               aria-label="Bring queued message back to input"
               className={cn(
                 'mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full p-0.5 text-muted-foreground/60',
-                'hover:bg-white/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
+                'hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
               )}
             >
               <Undo2 className="h-3.5 w-3.5" />
@@ -129,7 +129,7 @@ function QueuedMessageRow({
             aria-label="Remove queued message"
             className={cn(
               'mt-0.5 inline-flex shrink-0 items-center justify-center rounded-full p-0.5 text-muted-foreground/60',
-              'hover:bg-white/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
+              'hover:bg-foreground/10 hover:text-foreground disabled:opacity-50 disabled:pointer-events-none',
             )}
           >
             {isCancelling ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}
@@ -162,7 +162,7 @@ export function QueuedMessagesBar({
   if (items.length === 0) return null;
 
   return (
-    <div className="mx-auto w-[90%] rounded-t-3xl bg-[#2D2D2D] px-3 pt-2 pb-1.5 border-b border-white/5">
+    <div className="mx-auto w-[90%] rounded-t-3xl bg-menu px-3 pt-2 pb-1.5 border-b border-menu-border">
       <TooltipProvider delayDuration={300}>
         <div className="flex max-h-40 flex-col gap-1 overflow-y-auto">
           {items.map((item) => (

--- a/apps/web/components/dashboard/search-palette.tsx
+++ b/apps/web/components/dashboard/search-palette.tsx
@@ -703,7 +703,7 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
           <span>↑↓ navigate</span>
           <span>↵ open</span>
           {serverUnavailable && trimmedQuery ? (
-            <span className="ml-auto text-amber-600 dark:text-amber-500">
+            <span className="ml-auto text-amber-600 dark:text-warning">
               Server search unavailable — sessions only
             </span>
           ) : null}

--- a/apps/web/components/dashboard/session-actions-menu.tsx
+++ b/apps/web/components/dashboard/session-actions-menu.tsx
@@ -94,7 +94,7 @@ export function buildSessionActions({
     actions.push({
       key: 'copy-id',
       icon: copied ? Check : Copy,
-      iconClassName: copied ? 'text-emerald-500' : undefined,
+      iconClassName: copied ? 'text-success' : undefined,
       label: copied ? 'Copied ID' : 'Copy ID',
       onSelect: onCopyId,
     });

--- a/apps/web/components/dashboard/session-config-dropdown.tsx
+++ b/apps/web/components/dashboard/session-config-dropdown.tsx
@@ -162,7 +162,7 @@ export function ChipDropdown({
       >
         {/* Dimmed panel label, pinned while the list scrolls. Left padding
             matches the items' px-3 so it lines up with their content column. */}
-        <div className="sticky top-0 z-10 bg-[#2D2D2D] px-3 pb-1.5 pt-1 text-xs text-muted-foreground/60">
+        <div className="sticky top-0 z-10 bg-menu px-3 pb-1.5 pt-1 text-xs text-muted-foreground/60">
           {title}
         </div>
         {children(() => setOpen(false))}

--- a/apps/web/components/dashboard/session-config-dropdown.tsx
+++ b/apps/web/components/dashboard/session-config-dropdown.tsx
@@ -74,7 +74,7 @@ export function ModeIcon({ value, className }: { value: string; className?: stri
 }
 
 const CHIP_CLASS =
-  'flex h-6 max-w-44 min-w-0 shrink items-center gap-1.5 rounded-lg px-2 text-xs text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50';
+  'flex h-6 max-w-44 min-w-0 shrink items-center gap-1.5 rounded-lg px-2 text-xs text-muted-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50';
 
 export function TickItem({
   label,
@@ -99,7 +99,7 @@ export function TickItem({
       title={label}
       disabled={disabled}
       onClick={onClick}
-      className="group/item relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm border-0 px-3 py-1.5 text-xs outline-none transition-colors duration-100 hover:bg-foreground/10 hover:text-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+      className="group/item relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm border-0 px-3 py-1.5 text-xs outline-none transition-colors duration-100 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
     >
       {leading}
       <span className="min-w-0 flex-1 truncate text-left">{label}</span>

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -908,7 +908,7 @@ export function SidebarSessions({
                 e.preventDefault();
                 void handleArchive(instance);
               }}
-              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
             >
               <Archive className="h-3 w-3" />
             </button>
@@ -962,7 +962,7 @@ export function SidebarSessions({
               aria-label="Kanban"
               onClick={() => router.push('/dashboard/kanban')}
               className={cn(
-                'flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground',
+                'flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground',
                 pathname === '/dashboard/kanban' && ITEM_SELECTED,
               )}
             >
@@ -974,7 +974,7 @@ export function SidebarSessions({
                   type="button"
                   title="View options"
                   aria-label="View options"
-                  className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted/60 hover:text-foreground"
+                  className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
                 >
                   <ListFilter className="h-3.5 w-3.5" />
                 </button>

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -981,7 +981,7 @@ export function SidebarSessions({
               </DropdownMenuTrigger>
               <DropdownMenuContent
                 align="end"
-                className="w-48 border-white/10 bg-[#333331] font-mono text-[11px]"
+                className="w-48 border-menu-border bg-menu-elevated font-mono text-[11px]"
               >
                 {/* Nested filter menu: each row is a dimension with its current
                     value; the options live in a submenu. Single-choice picks
@@ -1318,7 +1318,7 @@ function FilterSubRow({
         <span className="flex-1 text-foreground/90">{label}</span>
         <span className="max-w-24 truncate font-normal text-muted-foreground">{value}</span>
       </DropdownMenuSubTrigger>
-      <DropdownMenuSubContent className="w-40 border-white/10 bg-[#333331] font-mono text-[11px]">
+      <DropdownMenuSubContent className="w-40 border-menu-border bg-menu-elevated font-mono text-[11px]">
         {children}
       </DropdownMenuSubContent>
     </DropdownMenuSub>

--- a/apps/web/components/dashboard/sidebar-sessions.tsx
+++ b/apps/web/components/dashboard/sidebar-sessions.tsx
@@ -89,7 +89,7 @@ import {
 } from '@/components/files-git-panel/rpc';
 
 // Selected-row highlight, shared between session rows and the view-options menu.
-const ITEM_SELECTED = 'bg-foreground/10 text-foreground';
+const ITEM_SELECTED = 'bg-foreground/[0.08] dark:bg-foreground/10 text-foreground';
 
 // Group-by options. Order + labels mirror the web sidebar.
 const GROUP_BY_OPTIONS: { value: GroupBy; label: string }[] = [
@@ -908,7 +908,7 @@ export function SidebarSessions({
                 e.preventDefault();
                 void handleArchive(instance);
               }}
-              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
             >
               <Archive className="h-3 w-3" />
             </button>
@@ -962,7 +962,7 @@ export function SidebarSessions({
               aria-label="Kanban"
               onClick={() => router.push('/dashboard/kanban')}
               className={cn(
-                'flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground',
+                'flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground',
                 pathname === '/dashboard/kanban' && ITEM_SELECTED,
               )}
             >
@@ -974,7 +974,7 @@ export function SidebarSessions({
                   type="button"
                   title="View options"
                   aria-label="View options"
-                  className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
+                  className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
                 >
                   <ListFilter className="h-3.5 w-3.5" />
                 </button>

--- a/apps/web/components/dashboard/sidebar-update-callout.tsx
+++ b/apps/web/components/dashboard/sidebar-update-callout.tsx
@@ -102,7 +102,7 @@ export function SidebarUpdateCallout() {
             type="button"
             aria-label="Dismiss"
             onClick={handleDismiss}
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
+            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
           >
             <X className="h-3 w-3" />
           </button>

--- a/apps/web/components/dashboard/sidebar-update-callout.tsx
+++ b/apps/web/components/dashboard/sidebar-update-callout.tsx
@@ -152,7 +152,7 @@ function CalloutIcon({ kind }: { kind: UpdateBannerView['kind'] }) {
     case 'downloaded':
       return <RotateCw className={cn(className, 'text-foreground')} />;
     case 'error':
-      return <TriangleAlert className={cn(className, 'text-amber-500')} />;
+      return <TriangleAlert className={cn(className, 'text-warning')} />;
     default:
       return <Gift className={cn(className, 'text-foreground')} />;
   }

--- a/apps/web/components/dashboard/task-picker-popover.tsx
+++ b/apps/web/components/dashboard/task-picker-popover.tsx
@@ -116,7 +116,7 @@ export function TaskPickerPopover({
         align="start"
         side="top"
         sideOffset={8}
-        className="w-[max(var(--radix-popover-trigger-width),20rem)] p-3 space-y-2 border border-foreground/15 bg-[#2D2D2D] shadow-xl"
+        className="w-[max(var(--radix-popover-trigger-width),20rem)] p-3 space-y-2 border border-foreground/15 bg-menu shadow-xl"
       >
         <div className="text-[11px] text-muted-foreground font-mono">Task</div>
 

--- a/apps/web/components/dashboard/task-picker-popover.tsx
+++ b/apps/web/components/dashboard/task-picker-popover.tsx
@@ -123,7 +123,7 @@ export function TaskPickerPopover({
         <button
           type="button"
           onClick={() => select(null)}
-          className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/10 cursor-pointer"
+          className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 cursor-pointer"
         >
           <CircleSlash className="h-3 w-3 flex-shrink-0" />
           <span className="flex-1 text-left">No task</span>
@@ -164,7 +164,7 @@ export function TaskPickerPopover({
                     key={task.id}
                     type="button"
                     onClick={() => select(task)}
-                    className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/10 cursor-pointer"
+                    className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 cursor-pointer"
                     title={task.title}
                   >
                     <StatusIcon status={task.status} className="h-3 w-3" />

--- a/apps/web/components/dashboard/tool-use-display.tsx
+++ b/apps/web/components/dashboard/tool-use-display.tsx
@@ -50,7 +50,7 @@ function DiffStat({ stat }: { stat: string }) {
   const [plus, minus] = stat.split(/\s+/);
   return (
     <span className="flex shrink-0 items-center gap-1 text-xs">
-      {plus && <span className="text-emerald-500">{plus}</span>}
+      {plus && <span className="text-success">{plus}</span>}
       {minus && <span className="text-red-400">{minus}</span>}
     </span>
   );

--- a/apps/web/components/dashboard/worktree-picker-popover.tsx
+++ b/apps/web/components/dashboard/worktree-picker-popover.tsx
@@ -99,7 +99,7 @@ export function WorktreePickerPopover({
         <button
           type="button"
           onClick={() => select("none", null)}
-          className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/10 cursor-pointer"
+          className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 cursor-pointer"
         >
           <GitBranch className="h-3 w-3 flex-shrink-0" />
           <span className="flex-1 text-left">Current branch</span>
@@ -110,7 +110,7 @@ export function WorktreePickerPopover({
           <button
             type="button"
             onClick={() => select("new", null)}
-            className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/10 cursor-pointer"
+            className="flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[11px] text-popover-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 cursor-pointer"
           >
             <Plus className="h-3 w-3 flex-shrink-0" />
             <span className="flex-1 text-left">New worktree</span>
@@ -148,7 +148,7 @@ export function WorktreePickerPopover({
                 return (
                   <div
                     key={wt.path}
-                    className="flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-[11px] hover:bg-foreground/10"
+                    className="flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-[11px] hover:bg-foreground/[0.06] dark:hover:bg-foreground/10"
                   >
                     <button
                       type="button"

--- a/apps/web/components/dashboard/worktree-picker-popover.tsx
+++ b/apps/web/components/dashboard/worktree-picker-popover.tsx
@@ -90,7 +90,7 @@ export function WorktreePickerPopover({
         align="start"
         side={side}
         sideOffset={8}
-        className="w-[max(var(--radix-popover-trigger-width),18rem)] rounded-xl p-3 space-y-2 border border-foreground/15 bg-[#2D2D2D] shadow-xl"
+        className="w-[max(var(--radix-popover-trigger-width),18rem)] rounded-xl p-3 space-y-2 border border-foreground/15 bg-menu shadow-xl"
       >
         <div className="text-[11px] text-muted-foreground font-mono">
           Worktree

--- a/apps/web/components/desktop/window-chrome.tsx
+++ b/apps/web/components/desktop/window-chrome.tsx
@@ -100,7 +100,7 @@ export function DesktopWindowControls() {
         onClick={() => bridge?.minimize()}
         aria-label="Minimize"
         title="Minimize"
-        className={`${CONTROL_BTN} hover:bg-foreground/10 hover:text-foreground`}
+        className={`${CONTROL_BTN} hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground`}
       >
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">
           <path d="M0 5 H10" />
@@ -111,7 +111,7 @@ export function DesktopWindowControls() {
         onClick={() => bridge?.toggleMaximize()}
         aria-label={maximized ? 'Restore' : 'Maximize'}
         title={maximized ? 'Restore' : 'Maximize'}
-        className={`${CONTROL_BTN} hover:bg-foreground/10 hover:text-foreground`}
+        className={`${CONTROL_BTN} hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground`}
       >
         {maximized ? (
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1">

--- a/apps/web/components/plugins/theme-select.tsx
+++ b/apps/web/components/plugins/theme-select.tsx
@@ -65,7 +65,7 @@ export function ThemeSelect() {
       >
         <SelectValue>{currentLabel}</SelectValue>
       </SelectTrigger>
-      <SelectContent align="end" className="bg-[#2D2D2D] font-mono">
+      <SelectContent align="end" className="bg-menu font-mono">
         <SelectGroup>
           {Object.entries(BASE_LABELS).map(([value, label]) => (
             <SelectItem key={value} value={value} className="text-xs">

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         subtle:
-          "hover:bg-foreground/10 hover:text-foreground",
+          "hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline"
       },
       size: {

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -37,7 +37,7 @@ function ContextMenuItem({
     <ContextMenuPrimitive.Item
       data-slot="context-menu-item"
       className={cn(
-        "focus:bg-foreground/10 focus:text-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -55,7 +55,7 @@ function ContextMenuSubTrigger({
     <ContextMenuPrimitive.SubTrigger
       data-slot="context-menu-sub-trigger"
       className={cn(
-        "focus:bg-foreground/10 focus:text-foreground data-[state=open]:bg-foreground/10 relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground data-[state=open]:bg-foreground/[0.06] dark:data-[state=open]:bg-foreground/10 relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/apps/web/components/ui/context-menu.tsx
+++ b/apps/web/components/ui/context-menu.tsx
@@ -6,7 +6,7 @@ import { ContextMenu as ContextMenuPrimitive } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 /** Minimal shadcn-style wrapper over Radix ContextMenu, styled to match
-    DropdownMenuContent (#2D2D2D surface, same item hover tokens). */
+    DropdownMenuContent (--menu surface, same item hover tokens). */
 
 const ContextMenu = ContextMenuPrimitive.Root;
 const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
@@ -20,7 +20,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          'bg-[#2D2D2D] text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
+          'bg-menu text-menu-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
           className,
         )}
         {...props}
@@ -72,7 +72,7 @@ function ContextMenuSubContent({
       <ContextMenuPrimitive.SubContent
         data-slot="context-menu-sub-content"
         className={cn(
-          'bg-[#2D2D2D] text-popover-foreground z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
+          'bg-menu text-menu-foreground z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
           className,
         )}
         {...props}

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-[#2D2D2D] text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-menu text-menu-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className
         )}
         {...props}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-[#2D2D2D] text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-menu text-menu-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className
       )}
       {...props}

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-foreground/10 focus:text-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-foreground/[0.06] dark:focus:bg-foreground/10 focus:text-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -58,6 +58,15 @@ export const THEME_TOKEN_WHITELIST = [
   'sidebar-border',
   'sidebar-ring',
   'message-text',
+  'menu',
+  'menu-foreground',
+  'menu-border',
+  'menu-elevated',
+  'surface-nav',
+  'surface-canvas',
+  'success',
+  'warning',
+  'info',
   'radius',
 ] as const;
 

--- a/apps/web/lib/plugins/types.ts
+++ b/apps/web/lib/plugins/types.ts
@@ -67,6 +67,8 @@ export const THEME_TOKEN_WHITELIST = [
   'success',
   'warning',
   'info',
+  'user-bubble',
+  'composer',
   'radius',
 ] as const;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,9 @@
     "build": "next build",
     "start": "next start",
     "blog:cover": "tsx scripts/generate-blog-cover.ts",
+    "check:theme": "node scripts/check-theme-colors.mjs",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit && node scripts/check-theme-colors.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/web/scripts/check-theme-colors.mjs
+++ b/apps/web/scripts/check-theme-colors.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Theme-color guard.
+ *
+ * Fails if a themeable app-chrome file reintroduces a hardcoded hex color in a
+ * Tailwind arbitrary-value utility (e.g. `bg-[#2D2D2D]`, `text-[#161C24]`).
+ * Chrome must read semantic tokens (`bg-menu`, `text-muted-foreground`, …) so
+ * it flips with the light/dark/plugin theme. See app/globals.css for the token
+ * set and plans/todos/theming-tokenization.md for the rationale.
+ *
+ * Deliberately NOT matched: inline-style hex in JS objects (e.g. label-swatch
+ * data) — this only flags the `-[#…]` Tailwind class form. Exempt paths below
+ * are either intentionally-fixed-dark panels (VS-Code-style editor + terminal),
+ * marketing pages with their own styling, or platform conventions.
+ *
+ * Run: `node scripts/check-theme-colors.mjs` (wired into `pnpm lint`).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Directories to scan for themeable chrome.
+const SCAN_DIRS = ['components', 'app'];
+
+// Prefixes (relative to apps/web/) that are exempt from the rule.
+const EXEMPT_PREFIXES = [
+  // Plane B — intentionally fixed-dark surfaces (editor + terminal), always
+  // dark in every theme by design.
+  'components/files-git-panel/',
+  'components/terminal-pane/',
+  // Marketing / public pages: own always-on styling, not app chrome.
+  'components/landing/',
+  'components/vs/',
+  'app/(marketing)/',
+];
+
+// Individual files that are exempt (platform conventions / decorative).
+const EXEMPT_FILES = new Set([
+  'components/desktop/window-chrome.tsx', // Windows close-button system red (#c42b1c)
+  'components/onboarding/intro-slides.tsx', // decorative onboarding gradient
+]);
+
+// Tailwind color utilities that take an arbitrary hex value.
+const HARDCODED_HEX =
+  /\b(?:bg|text|border|ring|fill|stroke|from|via|to|shadow|decoration|outline|caret|accent|divide|placeholder)-\[#[0-9a-fA-F]{3,8}\b/;
+
+/** @param {string} abs @returns {string[]} */
+function walk(abs) {
+  const out = [];
+  for (const entry of readdirSync(abs)) {
+    if (entry === 'node_modules' || entry === '.next') continue;
+    const full = join(abs, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (/\.(tsx?|jsx?)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function isExempt(rel) {
+  if (EXEMPT_FILES.has(rel)) return true;
+  return EXEMPT_PREFIXES.some((p) => rel.startsWith(p));
+}
+
+const violations = [];
+for (const dir of SCAN_DIRS) {
+  const abs = join(WEB_ROOT, dir);
+  let files;
+  try {
+    files = walk(abs);
+  } catch {
+    continue; // dir absent — skip
+  }
+  for (const file of files) {
+    const rel = relative(WEB_ROOT, file);
+    if (isExempt(rel)) continue;
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      const m = line.match(HARDCODED_HEX);
+      if (m) violations.push(`${rel}:${i + 1}  ${m[0]}`);
+    });
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    `\n✖ Hardcoded theme colors found in app chrome (use a semantic token from globals.css instead):\n`,
+  );
+  for (const v of violations) console.error(`  ${v}`);
+  console.error(
+    `\n  If a surface is intentionally fixed (e.g. an always-dark editor panel),` +
+      ` add its path to EXEMPT_PREFIXES/EXEMPT_FILES in scripts/check-theme-colors.mjs.\n`,
+  );
+  process.exit(1);
+}
+
+console.log('✓ No hardcoded theme colors in app chrome.');

--- a/backend/src/protocol/plugin_manifest.py
+++ b/backend/src/protocol/plugin_manifest.py
@@ -63,6 +63,15 @@ THEME_TOKEN_WHITELIST: frozenset[str] = frozenset(
         "sidebar-border",
         "sidebar-ring",
         "message-text",
+        "menu",
+        "menu-foreground",
+        "menu-border",
+        "menu-elevated",
+        "surface-nav",
+        "surface-canvas",
+        "success",
+        "warning",
+        "info",
         "radius",
     }
 )

--- a/backend/src/protocol/plugin_manifest.py
+++ b/backend/src/protocol/plugin_manifest.py
@@ -72,6 +72,8 @@ THEME_TOKEN_WHITELIST: frozenset[str] = frozenset(
         "success",
         "warning",
         "info",
+        "user-bubble",
+        "composer",
         "radius",
     }
 )


### PR DESCRIPTION
## What & why

The dashboard (`apps/web`, also the desktop renderer) only ever ran **dark**. The
shadcn token layer existed but the app wasn't actually token-driven, so switching
to light broke many surfaces. This makes the app genuinely theme-able: a real
**light** theme, a clean path for alternate/plugin themes, a dedicated
**Appearance** tab (desktop + web), and a guard so light can't silently re-break.

**Dark is pixel-identical** — every new token's dark value equals the hex it
replaced. Default theme stays **dark**.

## Approach — three colour planes
- **Themed chrome (flips):** background, card, popover, **menu**, sidebar,
  foreground, muted, accent, border, primary, destructive, **success/warning/info**,
  chart-*. Components read only these tokens.
- **Fixed-dark panels (never flip):** the files/git editor + terminal
  (`files-git-panel/*`, `terminal-pane/*`) stay dark in every theme, VS-Code style.
- **Status colours:** success/warning/info tokenized (were ad-hoc emerald/amber).

## Key changes
- **New semantic tokens** in `app/globals.css` (`:root` + `.dark` + `@theme`):
  `--menu/-foreground/-border/-elevated` (the dropdown/context-menu/select/picker
  surface, was a hardcoded `#2D2D2D` baked into the shadcn primitives),
  `--surface-nav`/`--surface-canvas` (app shell), `--success/--warning/--info`,
  `--user-bubble`, `--composer`, and a theme-aware `--inline-code`.
- **FOUC fix:** `<html>` keeps `dark` as the no-JS default + a blocking
  pre-hydration script applies the stored theme before first paint, so light-mode
  users never flash dark.
- **Tokenized the shared menu primitives** (`ui/dropdown-menu`, `ui/context-menu`)
  and ~20 chrome files (sidebars, pickers, composer, status text).
- **Appearance settings tab** on desktop (moved out of General) and web (theme
  switching now works in the browser, not just desktop).
- **Light-theme polish:** page bg `#FDFCFC`, left column `#F9F8F9`, pure-white
  composer that pops, flat agent messages + reduced user bubble, softer
  hover/selected overlays (light ~6% vs dark 10%), theme-aware agent logos
  (Codex/Copilot/Cursor invert only on dark; OpenCode inverts on light; Kimi on a
  dark plate), new-session setup bar matches the page background.
- **Guard:** `apps/web/scripts/check-theme-colors.mjs` (wired into `pnpm lint`)
  fails on hardcoded `-[#hex]` in chrome; exempts the intentionally-dark panels.
- Plugin theme whitelist extended in **both** `lib/plugins/types.ts` and
  `backend/src/protocol/plugin_manifest.py` (kept in sync).

## Verification
`pnpm --dir apps/web lint` (tsc + guard) ✓ · `pnpm --dir apps/web build` (94/94) ✓ ·
704 vitest ✓ · backend `make lint` (ruff + pyright 0 errors + freeze) ✓ ·
`test_plugin_manifest.py` ✓. Walked light + dark + Catppuccin across the dashboard.

Plan/rationale: `plans/todos/theming-tokenization.md` (umbrella repo).