### PR TITLE
fix(sessions): auto-clear awaiting-input dot when leaving a viewed session

### DIFF
--- a/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
+++ b/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
@@ -295,7 +295,14 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
     }
   }
 
-  Future<void> _maybeAutoReviewSessionOnOpen() async {
+  /// Clear the "awaiting input" blue dot once the user has seen the last
+  /// message — either by opening the session, or by leaving it (see
+  /// [didPop]/[didPushNext]). A session can flip to AWAITING_INPUT *while it's
+  /// on screen* (the agent finishes its turn as you watch), so relying on open
+  /// alone left the dot stuck until you re-entered the session; marking it on
+  /// leave means switching away is enough. Skipped when the last message is a
+  /// real question (ask-user-question / options block) — those still need input.
+  Future<void> _maybeAutoReviewSession() async {
     final currentStatus =
         (_model.instanceData?['status'] ?? widget.instanceData?['status'])
             ?.toString()
@@ -401,7 +408,7 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
         _model.restoreLastSeenMessage();
 
         await _model.loadMessages(hasCachedData: hasCachedData);
-        await _maybeAutoReviewSessionOnOpen();
+        await _maybeAutoReviewSession();
         _lastKnownMessageCount = _model.messages.length;
 
         // Build initial message metadata cache
@@ -511,6 +518,9 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
     // Save draft message and last seen message when navigating back
     _model.saveDraftMessage();
     _model.saveLastSeenMessage();
+    // Leaving the session counts as having seen the last message — clear the
+    // awaiting-input blue dot instead of forcing a re-open. Fire-and-forget.
+    _maybeAutoReviewSession();
   }
 
   @override
@@ -519,6 +529,8 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
     // Save draft message and last seen message when pushing new route
     _model.saveDraftMessage();
     _model.saveLastSeenMessage();
+    // Switching away from the session counts as seen — clear the blue dot.
+    _maybeAutoReviewSession();
   }
 
   @override

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -478,6 +478,42 @@ function AgentInstanceContent() {
     updateInstanceStatus(instanceId, status);
   }, [instanceId, updateInstanceStatus]);
 
+  // Auto-mark REVIEWED when the user switches away from a session they were
+  // viewing. The sidebar only marks a session reviewed on *open*, so a session
+  // that flips to AWAITING_INPUT *while it's already on screen* (agent finished
+  // its turn as you watched) keeps its blue dot until you re-open it. Since you
+  // were looking at it, leaving = you've seen the last message — so clear it.
+  // Skipped when the last message is a real question (ask-user-question /
+  // options block): those genuinely still need your input, so the dot stays.
+  const markReviewedOnLeave = useCallback((leavingId: string) => {
+    const snapshot = getMessageStore().getSnapshot(leavingId);
+    if (snapshot?.instance?.status !== 'AWAITING_INPUT') return;
+    const messages = snapshot?.messages ?? [];
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage) {
+      const hasAskUserQuestion = Boolean(parseAskUserQuestionPayload(lastMessage));
+      const hasOptions = extractMessageOptions(lastMessage.content || '').options.length > 0;
+      if (hasAskUserQuestion || hasOptions) return;
+    }
+    // Optimistic local flip (sidebar row + cached message-store snapshot), then
+    // persist. Fire-and-forget: the page is unmounting, nothing awaits it.
+    updateInstanceStatus(leavingId, 'REVIEWED');
+    getMessageStore().patchInstance(leavingId, { status: 'REVIEWED' });
+    if (dashboardContext.api) {
+      void dashboardContext.api
+        .updateAgentStatus(leavingId, { status: 'REVIEWED' })
+        .catch((err) => console.error('Failed to auto-mark session reviewed on leave:', err));
+    }
+  }, [dashboardContext, updateInstanceStatus]);
+  // Read the latest callback through a ref so the leave effect can depend on
+  // instanceId alone — otherwise a new `api`/callback identity would re-run the
+  // effect and fire its cleanup while the session is still on screen.
+  const markReviewedOnLeaveRef = useRef(markReviewedOnLeave);
+  markReviewedOnLeaveRef.current = markReviewedOnLeave;
+  useEffect(() => () => {
+    markReviewedOnLeaveRef.current(instanceId);
+  }, [instanceId]);
+
   // Live usage (context window + rate limits) rides instance_metadata on every
   // instance-update; merge it into the store so the composer meter repaints.
   const handleInstanceMetadata = useCallback((metadata: Record<string, unknown> | null) => {


### PR DESCRIPTION
## Problem

The blue **awaiting-input** dot on a session was auto-cleared (status → `REVIEWED`) **only when the session was opened**. But a session can flip to `AWAITING_INPUT` *while it's already on screen* — the agent finishes its turn as you watch. In that case the dot appeared and stayed stuck until you left **and re-opened** the session. Switching away from a session you were actively viewing should count as "seen."

## Fix

Leaving / switching away from the currently-viewed session now runs the same auto-review logic that opening it already did. The existing guard is preserved on both platforms: if the last message is a genuine question (an ask-user-question payload or an `[OPTIONS]` block), the dot is **kept** — those still need your input.

### Web — `apps/web/app/dashboard/agents/[instanceId]/page.tsx`
The instance page is shared by the web dashboard **and** the desktop renderer, so a single hook covers both. Added a cleanup effect keyed on `instanceId` that fires when you switch to another session (route param changes) or navigate away (unmount). It reads the session's status + last message from the message store and, if `AWAITING_INPUT` and not a pending question, optimistically flips the sidebar row + cached snapshot to `REVIEWED` and persists via `updateAgentStatus`. The callback is read through a ref so the effect depends on `instanceId` alone (otherwise a changing `api`/context identity would fire the review while the session is still on screen).

### Mobile — `apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart`
The chat widget is already `RouteAware`. Generalized `_maybeAutoReviewSessionOnOpen()` → `_maybeAutoReviewSession()` (the logic is identical — you've seen the last message either way) and call it from:
- `didPop()` — popping back to the session list (the main "switch sessions" path)
- `didPushNext()` — pushing another route on top

in addition to on-open. It optimistically writes `REVIEWED` into `FFAppState.cachedAgentInstances` (so the home list's dot clears immediately), persists, and rolls back on failure.

## Testing
- Web: `pnpm lint` (tsc `--noEmit` + theme check) passes clean.
- Mobile: `flutter analyze` on the changed file reports only pre-existing warnings — none from these edits.

## Note / out of scope
Opening a session by **direct URL / notification click** (bypassing the sidebar) still doesn't mark-on-open — a separate pre-existing gap surfaced during exploration, not part of this change.