### PR TITLE
fix(desktop): render project icons in settings nav + add sidebar settings gear

### DIFF
--- a/apps/web/components/dashboard/desktop-settings-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-settings-sidebar.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { Suspense, useCallback, useMemo } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Bot, Folder, Keyboard, Monitor, Palette, Puzzle, Settings, User } from 'lucide-react';
+import { ArrowLeft, Bot, Keyboard, Monitor, Palette, Puzzle, Settings, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
 import { DesktopTitlebarLead } from '@/components/desktop/window-chrome';
 import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
 import { projectSettingsTargets } from '@/components/dashboard/session-grouping';
+import { ProjectIcon } from '@/components/dashboard/task-ui';
+import { getBackendAPI, type ProjectResponse } from '@/lib/backend-api';
 
 /**
  * Left panel while the desktop app is on /dashboard/settings: replaces the
@@ -63,6 +65,30 @@ function DesktopSettingsSidebarInner() {
   const activeDir = searchParams.get('dir') ?? '';
   const { recentInstances } = useAgentDashboard();
   const projectTargets = useMemo(() => projectSettingsTargets(recentInstances), [recentInstances]);
+
+  // The DB projects, by id — the source of truth for each row's icon/image/emoji
+  // (identity-unification §5d), mirroring the app sidebar. A target's `key` is
+  // the linked `project_id` (see projectGroupKey), so this map resolves it; an
+  // unlinked/loading target falls back to a generated initial-square. Refetched
+  // when navigating between panes and on window focus, so an icon edited in the
+  // middle pane shows here (the <img> is cache-busted by updated_at).
+  const [projectsById, setProjectsById] = useState<Map<string, ProjectResponse>>(
+    () => new Map(),
+  );
+  const searchKey = searchParams.toString();
+  useEffect(() => {
+    const load = () => {
+      getBackendAPI(true)
+        .listProjects(true)
+        .then((list) => setProjectsById(new Map(list.map((p) => [p.id, p]))))
+        .catch(() => {
+          /* best-effort: rows fall back to a generated icon until it loads */
+        });
+    };
+    load();
+    window.addEventListener('focus', load);
+    return () => window.removeEventListener('focus', load);
+  }, [searchKey]);
 
   const backToApp = useCallback(() => {
     let target: string | null = null;
@@ -148,7 +174,15 @@ function DesktopSettingsSidebarInner() {
                       : 'text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground',
                   )}
                 >
-                  <Folder className="h-3.5 w-3.5 shrink-0" />
+                  <ProjectIcon
+                    project={
+                      projectsById.get(target.key) ?? {
+                        id: target.key,
+                        name: target.label,
+                        is_inbox: false,
+                      }
+                    }
+                  />
                   <span className="truncate">{target.label}</span>
                 </button>
               );

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -412,13 +412,14 @@ function CloudAccountArea() {
 
   return (
     <>
+    <div className="flex items-center gap-0.5">
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
           title="Account"
           aria-label="Account menu"
-          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10"
         >
           <User className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="flex-1 min-w-0 truncate text-xs text-muted-foreground" title={email ?? undefined}>
@@ -467,6 +468,17 @@ function CloudAccountArea() {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    {/* Quick settings shortcut beside the account row (parity with the web
+        sidebar's gear); the account dropdown keeps its own Settings item. */}
+    <Link
+      href="/dashboard/settings"
+      title="Settings"
+      aria-label="Settings"
+      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
+    >
+      <Cog className="h-4 w-4" />
+    </Link>
+    </div>
     {/* Sibling of the menu, not a child: the dialog must outlive the dropdown
         unmounting on select. */}
     <ReportIssueDialog


### PR DESCRIPTION
## What

Two **desktop-only** gaps left over from the project-identity unification (c56079c / #15), which wired the emoji/image project icons into the **web** settings page and the app sidebar but never reached the **desktop** settings surface (a separate component tree, `desktop-settings-sidebar.tsx` + `desktop-sidebar.tsx`).

### 1. Settings nav showed a generic folder for every project
`desktop-settings-sidebar.tsx` hardcoded a `<Folder>` glyph on each project row, so the configured emoji/image never appeared there. Now each row resolves its target (`key` == linked `project_id`, see `projectGroupKey`) against the DB projects and renders the shared `<ProjectIcon>` — **image → emoji → generated initial-square** — matching the app sidebar and the web settings nav. The map is refetched on pane navigation and on window focus, so an icon edited in the middle pane shows here (the `<img>` is cache-busted by `updated_at`).

### 2. No visible settings entry in the desktop sidebar
In cloud (logged-in) mode `CloudAccountArea` only exposed **Settings** inside the account dropdown — there was no standalone gear like the web sidebar has. Added a `Cog` shortcut beside the account row (the dropdown keeps its own Settings item too).

## Notes
- Renderer-only change → needs a new desktop build/release to reach installed apps; **no backend change**.
- Emoji works off the pre-existing `projects.icon` column; the **image** variant additionally needs migration `f4a7c2e9b1d3` applied + S3 configured on the backend (already part of #15).
- Based on latest `main` (kept the token-driven theming classes from #18); diff is only these two files.

## Test plan
- [ ] Desktop settings left nav shows each project's real emoji/image (or colored initial-square when unset), not a folder.
- [ ] Editing a project's icon in the middle pane updates the left-nav thumbnail (on focus / re-nav).
- [ ] Desktop sidebar shows a gear beside the account row → opens `/dashboard/settings`; account dropdown still lists Settings.
- [ ] `pnpm build` (apps/web) passes.