### PR TITLE
fix(web): theme the files/git panel + stop its separator covering dialogs

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -69,6 +69,9 @@
   --color-surface-nav: hsl(var(--surface-nav));
   --color-surface-canvas: hsl(var(--surface-canvas));
 
+  /* The files/git panel surface (the right rail's editor-like pane). */
+  --color-panel: hsl(var(--panel));
+
   /* Semantic status colours (previously ad-hoc emerald/amber utilities). */
   --color-success: hsl(var(--success));
   --color-warning: hsl(var(--warning));
@@ -169,6 +172,11 @@
     --surface-nav: 300 8% 97.5%; /* #F9F8F9 */
     --surface-canvas: 0 20% 99%; /* #FDFCFC */
 
+    /* Files/git panel surface (light): pure white, so the code pane reads like
+       an editor and separates from the #FDFCFC chat canvas beside it. Its own
+       token (not --surface-canvas) so the two can be tuned independently. */
+    --panel: 0 0% 100%;
+
     /* Semantic status colours (light — one step darker for contrast on white). */
     --success: 160 84% 34%;
     --warning: 32 95% 44%;
@@ -183,14 +191,15 @@
       #ABB0F4, which is far too light against a light surface) */
 
     /* Git commit-graph lane colors (used raw as var(--…), not HSL-wrapped).
-       Rendered only on the always-dark files/git panel, so one definition. */
-    --git-graph-ref: #3794ff;
-    --git-graph-remote-ref: #b66dff;
-    --git-graph-lane-1: #ffb000;
-    --git-graph-lane-2: #dc267f;
-    --git-graph-lane-3: #ce9178;
-    --git-graph-lane-4: #40b0a6;
-    --git-graph-lane-5: #b66dff;
+       Light: darkened so 1px lanes and ref pills stay legible on the white
+       panel; the dark block below keeps the original values. */
+    --git-graph-ref: #0b5cd5;
+    --git-graph-remote-ref: #7c3aed;
+    --git-graph-lane-1: #b45309;
+    --git-graph-lane-2: #be185d;
+    --git-graph-lane-3: #9a5b3d;
+    --git-graph-lane-4: #0f766e;
+    --git-graph-lane-5: #7c3aed;
   }
 
   .dark {
@@ -240,6 +249,10 @@
     --surface-nav: 60 1% 15%;
     --surface-canvas: 0 0% 9%;
 
+    /* Files/git panel surface (dark) — #171717, the value the panel used to
+       hard-code, so dark is pixel-identical to before it was tokenized. */
+    --panel: 0 0% 9%;
+
     /* Semantic status colours (dark): emerald-500 / amber-500 / blue-400. */
     --success: 160 84% 39%;
     --warning: 38 92% 50%;
@@ -250,6 +263,15 @@
     --user-bubble: 205 23% 12.9%;
     --composer: 0 0% 18%;
     --inline-code: 236 77% 81.5%; /* #ABB0F4 — unchanged from before */
+
+    /* Git commit-graph lane colors (dark) — the original panel palette. */
+    --git-graph-ref: #3794ff;
+    --git-graph-remote-ref: #b66dff;
+    --git-graph-lane-1: #ffb000;
+    --git-graph-lane-2: #dc267f;
+    --git-graph-lane-3: #ce9178;
+    --git-graph-lane-4: #40b0a6;
+    --git-graph-lane-5: #b66dff;
   }
 }
 
@@ -333,13 +355,76 @@
      competes. Amber wash for every hit, orange for the focused one — matching
      the chat find. See components/files-git-panel/use-cm-find.ts. */
   .cm-editor .cm-vicoa-find {
-    background-color: rgb(250 204 21 / 0.35);
+    background-color: #fde68a; /* amber-200, as in the chat find */
     border-radius: 2px;
+  }
+  .dark .cm-editor .cm-vicoa-find {
+    background-color: rgb(250 204 21 / 0.35);
   }
   .cm-editor .cm-vicoa-find-active {
     background-color: #f97316;
     color: #1a1205;
     border-radius: 2px;
+  }
+
+  /* highlight.js palette for the files/git panel in LIGHT mode. The app imports
+     atom-one-dark globally (chat + panel share it), which is unreadable once
+     the panel surface turns white, so re-tint just the panel's code with
+     atom-one-light. Scoped to [data-files-panel] so the chat renderer keeps the
+     dark palette it was designed against; `.dark` keeps atom-one-dark. */
+  html:not(.dark) [data-files-panel] .hljs {
+    color: #383a42;
+    background: transparent;
+  }
+  html:not(.dark) [data-files-panel] .hljs-comment,
+  html:not(.dark) [data-files-panel] .hljs-quote {
+    color: #a0a1a7;
+    font-style: italic;
+  }
+  html:not(.dark) [data-files-panel] .hljs-doctag,
+  html:not(.dark) [data-files-panel] .hljs-keyword,
+  html:not(.dark) [data-files-panel] .hljs-formula {
+    color: #a626a4;
+  }
+  html:not(.dark) [data-files-panel] .hljs-section,
+  html:not(.dark) [data-files-panel] .hljs-name,
+  html:not(.dark) [data-files-panel] .hljs-selector-tag,
+  html:not(.dark) [data-files-panel] .hljs-deletion,
+  html:not(.dark) [data-files-panel] .hljs-subst {
+    color: #e45649;
+  }
+  html:not(.dark) [data-files-panel] .hljs-literal {
+    color: #0184bb;
+  }
+  html:not(.dark) [data-files-panel] .hljs-string,
+  html:not(.dark) [data-files-panel] .hljs-regexp,
+  html:not(.dark) [data-files-panel] .hljs-addition,
+  html:not(.dark) [data-files-panel] .hljs-attribute,
+  html:not(.dark) [data-files-panel] .hljs-meta .hljs-string {
+    color: #50a14f;
+  }
+  html:not(.dark) [data-files-panel] .hljs-attr,
+  html:not(.dark) [data-files-panel] .hljs-variable,
+  html:not(.dark) [data-files-panel] .hljs-template-variable,
+  html:not(.dark) [data-files-panel] .hljs-type,
+  html:not(.dark) [data-files-panel] .hljs-selector-class,
+  html:not(.dark) [data-files-panel] .hljs-selector-attr,
+  html:not(.dark) [data-files-panel] .hljs-selector-pseudo,
+  html:not(.dark) [data-files-panel] .hljs-number {
+    color: #986801;
+  }
+  html:not(.dark) [data-files-panel] .hljs-symbol,
+  html:not(.dark) [data-files-panel] .hljs-bullet,
+  html:not(.dark) [data-files-panel] .hljs-link,
+  html:not(.dark) [data-files-panel] .hljs-meta,
+  html:not(.dark) [data-files-panel] .hljs-selector-id,
+  html:not(.dark) [data-files-panel] .hljs-title {
+    color: #4078f2;
+  }
+  html:not(.dark) [data-files-panel] .hljs-built_in,
+  html:not(.dark) [data-files-panel] .hljs-title.class_,
+  html:not(.dark) [data-files-panel] .hljs-class .hljs-title {
+    color: #c18401;
   }
 
   /* Blog prose code blocks: style the block, not each line */

--- a/apps/web/components/files-git-panel/cm-markdown-live.ts
+++ b/apps/web/components/files-git-panel/cm-markdown-live.ts
@@ -319,8 +319,11 @@ const tableField = StateField.define<DecorationSet>({
 // ── Theme ────────────────────────────────────────────────────────────────────
 
 const markdownLiveTheme = EditorView.theme({
-  // Headings: distinguished by size + weight only. The `span` rules override
-  // oneDark's coral heading color so heading text reads as normal body color.
+  // Headings: distinguished by size + weight only. The `span` rules override the
+  // syntax theme's heading color so heading text reads as normal body color.
+  //
+  // Every surface below is keyed off `--foreground` rather than a literal white
+  // so the rendered document follows the site theme along with the panel.
   '.cm-md-h1': { fontSize: '1.3em', fontWeight: '700', lineHeight: '1.35' },
   '.cm-md-h2': { fontSize: '1.18em', fontWeight: '700', lineHeight: '1.35' },
   '.cm-md-h3': { fontSize: '1.08em', fontWeight: '600', lineHeight: '1.35' },
@@ -334,31 +337,31 @@ const markdownLiveTheme = EditorView.theme({
   '.cm-md-strike': { textDecoration: 'line-through', opacity: '0.7' },
   '.cm-md-code': {
     fontFamily: 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
-    backgroundColor: 'rgba(255,255,255,0.08)',
+    backgroundColor: 'hsl(var(--foreground) / 0.08)',
     borderRadius: '3px',
     padding: '0.05em 0.3em',
     fontSize: '0.9em',
   },
-  '.cm-md-link': { color: '#60a5fa', textDecoration: 'underline', textUnderlineOffset: '2px' },
+  '.cm-md-link': { color: 'hsl(var(--info))', textDecoration: 'underline', textUnderlineOffset: '2px' },
   '.cm-md-quote': {
-    borderLeft: '3px solid rgba(255,255,255,0.2)',
+    borderLeft: '3px solid hsl(var(--foreground) / 0.2)',
     paddingLeft: '0.75em',
-    color: 'rgba(255,255,255,0.7)',
+    color: 'hsl(var(--foreground) / 0.7)',
   },
   '.cm-md-hr': {
     display: 'inline-block',
     width: '100%',
-    borderTop: '1px solid rgba(255,255,255,0.25)',
+    borderTop: '1px solid hsl(var(--foreground) / 0.25)',
     verticalAlign: 'middle',
   },
   '.cm-md-table-wrap': { padding: '6px 0', overflowX: 'auto' },
   '.cm-md-table': { borderCollapse: 'collapse', fontSize: '0.9em', lineHeight: '1.4' },
   '.cm-md-table th, .cm-md-table td': {
-    border: '1px solid rgba(255,255,255,0.15)',
+    border: '1px solid hsl(var(--foreground) / 0.15)',
     padding: '4px 10px',
     textAlign: 'left',
   },
-  '.cm-md-table th': { fontWeight: '600', backgroundColor: 'rgba(255,255,255,0.06)' },
+  '.cm-md-table th': { fontWeight: '600', backgroundColor: 'hsl(var(--foreground) / 0.06)' },
 });
 
 /** The live-preview layer: pair with the GFM `markdownLanguage` base in an

--- a/apps/web/components/files-git-panel/commit-files.tsx
+++ b/apps/web/components/files-git-panel/commit-files.tsx
@@ -35,7 +35,7 @@ export function CommitFiles({
   onToggleFile: (commitId: string, path: string) => void;
 }) {
   return (
-    <div className="border-t border-border/50 bg-black/20">
+    <div className="border-t border-border/50 bg-foreground/[0.04] dark:bg-black/20">
       {!files || files.loading ? (
         <div className="px-3 py-2 text-xs text-muted-foreground font-mono">Loading…</div>
       ) : files.error ? (
@@ -68,8 +68,8 @@ export function CommitFiles({
                   </span>
                 )}
                 <span className="text-[10px] font-mono">
-                  <span className="text-emerald-400">+{f.additions}</span>
-                  <span className="ml-1 text-red-400">-{f.deletions}</span>
+                  <span className="text-emerald-600 dark:text-emerald-400">+{f.additions}</span>
+                  <span className="ml-1 text-red-600 dark:text-red-400">-{f.deletions}</span>
                 </span>
               </button>
               {open && (

--- a/apps/web/components/files-git-panel/commit-graph-svg.tsx
+++ b/apps/web/components/files-git-panel/commit-graph-svg.tsx
@@ -2,10 +2,10 @@
 
 import { useMemo } from 'react';
 import { buildGraphRow, ROW_H, type CommitViewModel, type GraphColorId } from './commit-graph';
+import { PANEL_BG } from './styles';
 
-/** The panel is a fixed dark surface; ring "holes" fill with its background. */
-const PANEL_BG = '#171717';
-
+/** Ring "holes" fill with the panel's own surface, so they stay invisible in
+ *  either theme; lane ids resolve to the themed `--git-graph-*` vars. */
 function color(id: GraphColorId | 'bg'): string {
   return id === 'bg' ? PANEL_BG : `var(--${id})`;
 }

--- a/apps/web/components/files-git-panel/commit-row.tsx
+++ b/apps/web/components/files-git-panel/commit-row.tsx
@@ -56,7 +56,7 @@ export function CommitRow({
           <TooltipContent
             side="bottom"
             sideOffset={6}
-            className="max-w-96 border-0 bg-[#2D2D2D] text-foreground shadow-md"
+            className="max-w-96 border-0 bg-menu text-menu-foreground shadow-md"
           >
             <div className="flex flex-col gap-1.5 py-0.5 font-mono">
               <div className="whitespace-pre-wrap text-xs font-medium leading-snug text-foreground">
@@ -67,7 +67,7 @@ export function CommitRow({
                   {item.body}
                 </div>
               )}
-              <div className="mt-0.5 flex flex-col gap-0.5 border-t border-white/10 pt-1 text-[11px] text-muted-foreground">
+              <div className="mt-0.5 flex flex-col gap-0.5 border-t border-foreground/10 pt-1 text-[11px] text-muted-foreground">
                 <div className="truncate">{`${item.author_name} <${item.author_email}>`}</div>
                 <div>
                   {formatDate(item.timestamp)} ·{' '}

--- a/apps/web/components/files-git-panel/diff-editor.tsx
+++ b/apps/web/components/files-git-panel/diff-editor.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
-import { EditorState, Annotation, type Extension, type StateCommand } from '@codemirror/state';
+import {
+  EditorState,
+  Annotation,
+  Compartment,
+  type Extension,
+  type StateCommand,
+} from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import { indentWithTab } from '@codemirror/commands';
 import { basicSetup } from 'codemirror';
@@ -15,7 +21,8 @@ import {
 } from '@codemirror/merge';
 import { languageExtensionForPath } from './cm-languages';
 import { SCROLL_PERSIST_MS, scrollToAnchor, topAnchor } from './cm-scroll';
-import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT } from './styles';
+import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT, PANEL_BG } from './styles';
+import { resolvedThemeNow, useIsDarkTheme } from '@/lib/hooks/use-resolved-theme';
 
 /**
  * The editable diff surface, isolated behind the same swappable contract as
@@ -66,9 +73,6 @@ export interface DiffEditorProps {
   onDiffNav?: (nav: DiffNav | null) => void;
 }
 
-/** Matches the panel's fixed dark surface (independent of the theme token). */
-const PANEL_BG = '#171717';
-
 /** Marks a programmatic doc replacement (external reload) so the change
  * listener doesn't echo it back to the parent as if the user typed it. */
 const External = Annotation.define<boolean>();
@@ -86,12 +90,11 @@ const baseTheme = EditorView.theme({
   ...CM_SCROLLBAR_WEBKIT,
 });
 
-// Overrides @codemirror/merge's built-in diff decorations, which are tuned for a
-// light theme: faint muddy `rgba(...,.08)` line tints and — worst — a 2px
-// underline gradient on changed words that reads as ugly noise on the #171717
-// surface. We retint to a GitHub-dark-style palette (green #3fb950 for adds, red
-// #f85149 for deletes) and swap the word underline for a soft solid box. The
-// 3px change-gutter bar is removed separately (gutter:false in the view config).
+// Overrides @codemirror/merge's built-in diff decorations, whose faint muddy
+// `rgba(...,.08)` line tints and 2px underline gradient on changed words read as
+// noise on either surface. We retint to a GitHub-style palette (green for adds,
+// red for deletes) and swap the word underline for a soft solid box. The 3px
+// change-gutter bar is removed separately (gutter:false in the view config).
 // `!important` beats @codemirror/merge's base theme, whose `&dark.cm-merge-*`
 // selectors would otherwise win on specificity.
 //
@@ -100,29 +103,56 @@ const baseTheme = EditorView.theme({
 // span → the inline `<del class=cm-deletedText>`); pure add/delete lines carry
 // just the line background. So the two word rules below intentionally style only
 // that case — the redundant full-line box on pure inserts/deletes is gone.
-const mergeTheme = EditorView.theme(
-  {
-    // Whole changed lines: additions (the editable/b side + the unified inline
-    // changed line) green; the original/a side + deleted chunks red.
-    '&.cm-merge-b .cm-changedLine, & .cm-inlineChangedLine': {
-      backgroundColor: 'rgba(63,185,80,0.13) !important',
+function makeMergeTheme(add: string, addWord: string, del: string, delWord: string, dark: boolean) {
+  return EditorView.theme(
+    {
+      // Whole changed lines: additions (the editable/b side + the unified inline
+      // changed line) green; the original/a side + deleted chunks red.
+      '&.cm-merge-b .cm-changedLine, & .cm-inlineChangedLine': {
+        backgroundColor: `${add} !important`,
+      },
+      '&.cm-merge-a .cm-changedLine, & .cm-deletedChunk': {
+        backgroundColor: `${del} !important`,
+      },
+      // Word-level emphasis on same-line edits only: a soft solid box, not the
+      // default underline. Added span green; inline removed span red.
+      '&.cm-merge-b .cm-changedText': {
+        background: `${addWord} !important`,
+        borderRadius: '2px',
+      },
+      '&.cm-merge-b .cm-deletedText': {
+        background: `${delWord} !important`,
+        borderRadius: '2px',
+      },
     },
-    '&.cm-merge-a .cm-changedLine, & .cm-deletedChunk': {
-      backgroundColor: 'rgba(248,81,73,0.13) !important',
-    },
-    // Word-level emphasis on same-line edits only: a soft solid box, not the
-    // default underline. Added span green; inline removed span red.
-    '&.cm-merge-b .cm-changedText': {
-      background: 'rgba(63,185,80,0.30) !important',
-      borderRadius: '2px',
-    },
-    '&.cm-merge-b .cm-deletedText': {
-      background: 'rgba(248,81,73,0.30) !important',
-      borderRadius: '2px',
-    },
-  },
-  { dark: true },
+    { dark },
+  );
+}
+
+// GitHub-dark tints (green #3fb950 / red #f85149) on the dark panel; slightly
+// stronger GitHub-light tints (#2ea043 / #f85149) so they read on white.
+const mergeThemeDark = makeMergeTheme(
+  'rgba(63,185,80,0.13)',
+  'rgba(63,185,80,0.30)',
+  'rgba(248,81,73,0.13)',
+  'rgba(248,81,73,0.30)',
+  true,
 );
+const mergeThemeLight = makeMergeTheme(
+  'rgba(46,160,67,0.15)',
+  'rgba(46,160,67,0.35)',
+  'rgba(248,81,73,0.15)',
+  'rgba(248,81,73,0.35)',
+  false,
+);
+
+// The full theme swap: syntax colors + diff tints. In light, oneDark is dropped
+// so `basicSetup`'s bundled `defaultHighlightStyle` (a light palette) shows
+// through. The `{dark}` flag on the merge theme matters beyond the tints — it
+// is what tells CodeMirror which base palette to use for selection etc., so it
+// must never claim `dark: true` while the site is light.
+const themeExtensions = (dark: boolean): Extension =>
+  dark ? [oneDark, mergeThemeDark] : [mergeThemeLight];
 
 export function DiffEditor({
   path,
@@ -160,6 +190,14 @@ export function DiffEditor({
   // the number of chunks doesn't re-render the panel. Reset to -1 per surface
   // (in the effect) so the first publish always fires.
   const lastNavCountRef = useRef(-1);
+  // The surface is built once per (path, layout, baseline) and re-themed in
+  // place (effect below), so the create-effect reads the palette straight off
+  // <html> rather than through this state — no first-frame flash of the wrong
+  // syntax colors. The MergeView's two panes are separate EditorStates, so each
+  // needs its own compartment.
+  const isDark = useIsDarkTheme();
+  const themeCompA = useRef(new Compartment());
+  const themeCompB = useRef(new Compartment());
   // Run a chunk-navigation command against the editable pane and refocus it so
   // the moved selection is visible. Stable — reads the view through its ref.
   const runChunkCommand = useCallback((cmd: StateCommand) => {
@@ -223,9 +261,8 @@ export function DiffEditor({
       saveKeymap, // highest precedence so Cmd/Ctrl+S is ours, not the browser's
       keymap.of([indentWithTab]),
       basicSetup,
-      oneDark,
+      themeCompB.current.of(themeExtensions(resolvedThemeNow() === 'dark')),
       baseTheme,
-      mergeTheme,
       lang ?? [],
       wrapExt,
       updateListener,
@@ -248,9 +285,8 @@ export function DiffEditor({
             EditorState.readOnly.of(true),
             EditorView.editable.of(false),
             basicSetup,
-            oneDark,
+            themeCompA.current.of(themeExtensions(resolvedThemeNow() === 'dark')),
             baseTheme,
-            mergeTheme,
             lang ?? [],
             wrapExt,
           ],
@@ -330,6 +366,19 @@ export function DiffEditor({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path, sideBySide, original]);
+
+  // Re-theme both panes in place when the site theme flips.
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    if (!surface) return;
+    const ext = themeExtensions(isDark);
+    if (surface instanceof MergeView) {
+      surface.a.dispatch({ effects: themeCompA.current.reconfigure(ext) });
+      surface.b.dispatch({ effects: themeCompB.current.reconfigure(ext) });
+    } else {
+      surface.dispatch({ effects: themeCompB.current.reconfigure(ext) });
+    }
+  }, [isDark]);
 
   // Apply external `value` changes (e.g. reload-from-disk) to the live doc
   // without resetting cursor/undo and without echoing back through onChange.

--- a/apps/web/components/files-git-panel/file-editor.tsx
+++ b/apps/web/components/files-git-panel/file-editor.tsx
@@ -8,7 +8,8 @@ import { basicSetup } from 'codemirror';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { languageExtensionForPath } from './cm-languages';
 import { SCROLL_PERSIST_MS, scrollToAnchor, topAnchor } from './cm-scroll';
-import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT } from './styles';
+import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT, PANEL_BG } from './styles';
+import { resolvedThemeNow, useIsDarkTheme } from '@/lib/hooks/use-resolved-theme';
 
 /**
  * The one editor surface, isolated behind a stable prop contract
@@ -36,12 +37,15 @@ export interface FileEditorProps {
   onScrollAnchor?: (path: string, line: number, offset: number) => void;
 }
 
-/** Matches the panel's fixed dark surface (independent of the theme token). */
-const PANEL_BG = '#171717';
-
 /** Marks a programmatic doc replacement (external reload) so the change
  * listener doesn't echo it back to the parent as if the user typed it. */
 const External = Annotation.define<boolean>();
+
+// Syntax colors. Dark gets oneDark; light falls through to `basicSetup`'s
+// bundled `defaultHighlightStyle`, which is a light palette — so this is the
+// whole theme swap. Lives in a compartment (below) so toggling the site theme
+// reconfigures the live editor instead of rebuilding it and dropping undo.
+const syntaxTheme = (dark: boolean) => (dark ? oneDark : []);
 
 const baseTheme = EditorView.theme({
   '&': { height: '100%', fontSize: '12px', backgroundColor: PANEL_BG },
@@ -80,7 +84,13 @@ export function FileEditor({
   onScrollAnchorRef.current = onScrollAnchor;
   initialAnchorRef.current = { line: initialScrollLine, offset: initialScrollOffset };
 
+  // The editor is built once per file and re-themed in place (effect at the
+  // bottom), so the create-effect reads the palette straight off <html> rather
+  // than through this state — no first-frame flash of the wrong syntax colors.
+  const isDark = useIsDarkTheme();
+
   const langComp = useRef(new Compartment());
+  const themeComp = useRef(new Compartment());
   const readOnlyComp = useRef(new Compartment());
   const wrapComp = useRef(new Compartment());
 
@@ -115,7 +125,7 @@ export function FileEditor({
           saveKeymap, // highest precedence so Cmd/Ctrl+S is ours, not the browser's
           keymap.of([indentWithTab]),
           basicSetup,
-          oneDark,
+          themeComp.current.of(syntaxTheme(resolvedThemeNow() === 'dark')),
           baseTheme,
           langComp.current.of(lang ?? []),
           readOnlyComp.current.of(EditorState.readOnly.of(readOnly)),
@@ -181,6 +191,12 @@ export function FileEditor({
       effects: wrapComp.current.reconfigure(wrap ? EditorView.lineWrapping : []),
     });
   }, [wrap]);
+
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: themeComp.current.reconfigure(syntaxTheme(isDark)),
+    });
+  }, [isDark]);
 
   return <div ref={containerRef} className="h-full w-full overflow-hidden" />;
 }

--- a/apps/web/components/files-git-panel/file-viewer.tsx
+++ b/apps/web/components/files-git-panel/file-viewer.tsx
@@ -7,21 +7,21 @@ import type { FileViewState } from './use-files-tab';
 import type { DiffNav } from './diff-editor';
 import { isMarkdownPath, languageForFile } from './file-icon';
 import { MarkdownPreview } from './markdown-preview';
-import { SCROLL_STYLE } from './styles';
+import { PANEL_BG, SCROLL_STYLE } from './styles';
 import { SCROLL_PERSIST_MS } from './cm-scroll';
 
 // CodeMirror is loaded only when a file is actually edited, keeping it out of
 // the panel's initial bundle.
 const FileEditor = dynamic(() => import('./file-editor').then((m) => m.FileEditor), {
   ssr: false,
-  loading: () => <div className="h-full w-full" style={{ backgroundColor: '#171717' }} />,
+  loading: () => <div className="h-full w-full" style={{ backgroundColor: PANEL_BG }} />,
 });
 
 // The @codemirror/merge diff surface is likewise loaded only when a tab enters
 // diff mode.
 const DiffEditor = dynamic(() => import('./diff-editor').then((m) => m.DiffEditor), {
   ssr: false,
-  loading: () => <div className="h-full w-full" style={{ backgroundColor: '#171717' }} />,
+  loading: () => <div className="h-full w-full" style={{ backgroundColor: PANEL_BG }} />,
 });
 
 // The live-preview markdown editor (CodeMirror + syntax-hiding decorations) is
@@ -30,7 +30,7 @@ const MarkdownLiveEditor = dynamic(
   () => import('./markdown-live-editor').then((m) => m.MarkdownLiveEditor),
   {
     ssr: false,
-    loading: () => <div className="h-full w-full" style={{ backgroundColor: '#171717' }} />,
+    loading: () => <div className="h-full w-full" style={{ backgroundColor: PANEL_BG }} />,
   },
 );
 
@@ -341,7 +341,7 @@ function TextFileBody({
         <tbody>
           {lines.map((line, idx) => (
             <tr key={idx} data-line={idx + 1}>
-              <td className="w-[3.5rem] min-w-[3.5rem] text-right pr-3 select-none text-muted-foreground/70 sticky left-0 bg-[#171717] tabular-nums align-top">
+              <td className="w-[3.5rem] min-w-[3.5rem] text-right pr-3 select-none text-muted-foreground/70 sticky left-0 bg-panel tabular-nums align-top">
                 {idx + 1}
               </td>
               <td className={wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'}>

--- a/apps/web/components/files-git-panel/files-git-panel.tsx
+++ b/apps/web/components/files-git-panel/files-git-panel.tsx
@@ -73,7 +73,7 @@ import { useInFileFind, type FindOptions } from './use-in-file-find';
 import { useCmFind } from './use-cm-find';
 import { ancestorPaths } from './tree';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
-import { SCROLL_STYLE, TAB_SCROLL_STYLE } from './styles';
+import { DROPDOWN_BG, PANEL_BG, SCROLL_STYLE, TAB_SCROLL_STYLE } from './styles';
 import { useFileMentions } from '@/lib/hooks/use-file-mentions';
 import { toAbsolutePath } from '@/lib/utils';
 
@@ -87,11 +87,6 @@ export type { PanelTab } from './panel-storage';
  * panel spawn the tab itself (clearing any reopened file so the terminal shows).
  */
 export type PanelPendingAction = 'new-terminal';
-
-/** The panel background — a fixed dark surface, independent of the theme token. */
-const PANEL_BG = '#171717';
-/** Dropdown/menu surface — slightly lighter than the panel for contrast. */
-const DROPDOWN_BG = '#2D2D2D';
 
 interface FilesGitPanelProps {
   machineId: string | null;
@@ -1538,7 +1533,7 @@ export function FilesGitPanel({ machineId, cwd, homeDir, instanceId, panel, over
       ) : inViewer && activeFile ? (
         <div className="relative h-full flex flex-col">
           {activeFile.editing && activeFile.externalChange && (
-            <div className="flex items-center gap-2 border-b border-amber-500/40 bg-amber-950/40 px-3 py-1.5 text-xs text-amber-200 flex-shrink-0">
+            <div className="flex items-center gap-2 border-b border-amber-300 bg-amber-100 px-3 py-1.5 text-xs text-amber-900 flex-shrink-0 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-200">
               <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
               <span className="min-w-0 flex-1">This file changed on disk since you opened it.</span>
               <button
@@ -1556,7 +1551,7 @@ export function FilesGitPanel({ machineId, cwd, homeDir, instanceId, panel, over
             </div>
           )}
           {activeFile.saveError && (
-            <div className="flex items-center gap-2 border-b border-red-500/40 bg-red-950/40 px-3 py-1.5 text-xs text-red-200 flex-shrink-0">
+            <div className="flex items-center gap-2 border-b border-red-300 bg-red-100 px-3 py-1.5 text-xs text-red-900 flex-shrink-0 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-200">
               <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0" />
               <span className="min-w-0 flex-1">Couldn’t save: {saveErrorMessage(activeFile.saveError)}</span>
             </div>
@@ -1826,17 +1821,24 @@ export function FilesGitPanel({ machineId, cwd, homeDir, instanceId, panel, over
       style={{ width: centerOverlay ? undefined : panel.effectiveWidth, backgroundColor: PANEL_BG }}
     >
       {/* Resize handle: a wide, invisible hit area with a thin visible separator
-          line that widens + highlights on hover (and while dragging). z-50 so
-          it stays grabbable above the keep-alive terminal overlay (z-45).
+          line that widens + highlights on hover (and while dragging).
           Double-click maximizes into the center overlay. Not shown in the
           overlay itself — it fills the width, and the header's restore button
-          exits. */}
+          exits.
+
+          z-46: above the keep-alive terminal overlay (z-45) so it stays
+          grabbable over a terminal, but BELOW the z-50 modal layer. The panel
+          root is `relative` with no z-index, so it opens no stacking context
+          and this handle competes directly with the dialogs' `fixed z-50`; at
+          z-50 it tied with them and won on DOM order over any dialog rendered
+          earlier in the tree (e.g. the sidebar's delete-session dialog), so the
+          separator drew on top of the scrim. */}
       {!centerOverlay && (
         <div
           onPointerDown={onPointerDown}
           onDoubleClick={panel.toggleMaximized}
           title="Double-click to maximize"
-          className="group absolute left-0 top-0 bottom-0 z-50 w-2 cursor-col-resize"
+          className="group absolute left-0 top-0 bottom-0 z-[46] w-2 cursor-col-resize"
         >
           <div
             className={`absolute inset-y-0 left-0 w-px transition-colors duration-150 group-hover:bg-muted-foreground/60 ${
@@ -1933,7 +1935,7 @@ function FixedTab({
       style={NO_DRAG}
       className={`px-3 py-1 whitespace-nowrap flex-shrink-0 ${
         active
-          ? 'text-foreground font-medium bg-white/[0.06]'
+          ? 'text-foreground font-medium bg-foreground/[0.06]'
           : 'text-muted-foreground hover:text-foreground'
       }`}
     >
@@ -1958,7 +1960,7 @@ function TerminalTab({
     <div
       style={NO_DRAG}
       className={`group/tab flex items-center pl-3 pr-1 py-1 whitespace-nowrap flex-shrink-0 ${
-        active ? 'text-foreground font-medium bg-white/[0.06]' : 'text-muted-foreground'
+        active ? 'text-foreground font-medium bg-foreground/[0.06]' : 'text-muted-foreground'
       }`}
     >
       <button onClick={onSelect} className="mr-1 hover:text-foreground">
@@ -2005,7 +2007,7 @@ function FileTab({
     <div
       style={NO_DRAG}
       className={`group/tab flex items-center pl-2.5 pr-1 py-1 whitespace-nowrap flex-shrink-0 ${
-        active ? 'text-foreground font-medium bg-white/[0.06]' : 'text-muted-foreground'
+        active ? 'text-foreground font-medium bg-foreground/[0.06]' : 'text-muted-foreground'
       }`}
     >
       <button
@@ -2139,7 +2141,7 @@ function TipButton({
       </TooltipTrigger>
       <TooltipContent
         side={side}
-        className="bg-[#1E1E1E] text-foreground border border-foreground/15 shadow-md"
+        className="bg-menu text-menu-foreground border border-menu-border shadow-md"
       >
         {label}
       </TooltipContent>

--- a/apps/web/components/files-git-panel/git-tab.tsx
+++ b/apps/web/components/files-git-panel/git-tab.tsx
@@ -191,14 +191,14 @@ export function GitTab(props: GitTabProps) {
     <div className="flex h-full min-h-0 flex-col">
       {statusError && <GitOfflineBanner code={statusError} />}
       {writeError && (
-        <div className="flex items-start gap-2 border-b border-red-500/40 bg-red-950/40 px-3 py-1.5 text-[11px] font-mono text-red-200 flex-shrink-0">
+        <div className="flex items-start gap-2 border-b border-red-300 bg-red-100 px-3 py-1.5 text-[11px] font-mono text-red-900 flex-shrink-0 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-200">
           <AlertTriangle className="mt-px h-3.5 w-3.5 flex-shrink-0" />
           <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">{writeError}</span>
           <button
             type="button"
             aria-label="Dismiss"
             onClick={onDismissWriteError}
-            className="flex-shrink-0 text-red-200/70 hover:text-red-100"
+            className="flex-shrink-0 text-red-900/70 hover:text-red-900 dark:text-red-200/70 dark:hover:text-red-100"
           >
             <X className="h-3 w-3" />
           </button>
@@ -264,13 +264,13 @@ function CommitBox({
         }}
         placeholder="Commit message"
         rows={message.includes('\n') || message.length > 60 ? 3 : 1}
-        className="w-full resize-none rounded bg-white/[0.06] px-2 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:bg-white/[0.09] focus:outline-none"
+        className="w-full resize-none rounded bg-foreground/[0.06] px-2 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground/60 focus:bg-foreground/[0.09] focus:outline-none"
       />
       <button
         type="button"
         disabled={!canCommit}
         onClick={onCommit}
-        className="flex items-center justify-center gap-1.5 rounded border border-border bg-white/[0.06] px-2 py-1 text-xs font-mono text-foreground hover:bg-white/[0.1] disabled:cursor-not-allowed disabled:opacity-40"
+        className="flex items-center justify-center gap-1.5 rounded border border-border bg-foreground/[0.06] px-2 py-1 text-xs font-mono text-foreground hover:bg-foreground/[0.1] disabled:cursor-not-allowed disabled:opacity-40"
       >
         {committing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
         Commit
@@ -494,7 +494,7 @@ function DiffFileSection({
     // hunks don't bleed into the next file.
     <div className={isOpen ? 'border-b border-border/50' : undefined}>
       <div
-        className="group/row w-full sticky top-7 z-[5] flex items-center gap-2 pr-3 py-2 bg-[#171717] hover:bg-muted/40"
+        className="group/row w-full sticky top-7 z-[5] flex items-center gap-2 pr-3 py-2 bg-panel hover:bg-muted/40"
         style={{ paddingLeft: indent ?? 12 }}
       >
         <button

--- a/apps/web/components/files-git-panel/markdown-live-editor.tsx
+++ b/apps/web/components/files-git-panel/markdown-live-editor.tsx
@@ -9,7 +9,8 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { markdownLivePreview } from './cm-markdown-live';
 import { SCROLL_PERSIST_MS, scrollToAnchor, topAnchor } from './cm-scroll';
-import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT } from './styles';
+import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT, PANEL_BG } from './styles';
+import { resolvedThemeNow, useIsDarkTheme } from '@/lib/hooks/use-resolved-theme';
 
 /**
  * The live-preview markdown editor — the same swappable prop contract as
@@ -38,12 +39,14 @@ export interface MarkdownLiveEditorProps {
   onScrollAnchor?: (path: string, line: number, offset: number) => void;
 }
 
-/** Matches the panel's fixed dark surface (independent of the theme token). */
-const PANEL_BG = '#171717';
-
 /** Marks a programmatic doc replacement (external reload) so the change
  * listener doesn't echo it back to the parent as if the user typed it. */
 const External = Annotation.define<boolean>();
+
+// Dark gets oneDark; light falls through to `basicSetup`'s bundled
+// `defaultHighlightStyle`. Compartmentalized so a theme flip reconfigures the
+// live editor rather than rebuilding it (see FileEditor for the same idiom).
+const syntaxTheme = (dark: boolean) => (dark ? oneDark : []);
 
 const baseTheme = EditorView.theme({
   '&': { height: '100%', fontSize: '13px', backgroundColor: PANEL_BG },
@@ -84,7 +87,13 @@ export function MarkdownLiveEditor({
   onScrollAnchorRef.current = onScrollAnchor;
   initialAnchorRef.current = { line: initialScrollLine, offset: initialScrollOffset };
 
+  // The editor is built once per file and re-themed in place (effect at the
+  // bottom), so the create-effect reads the palette straight off <html> rather
+  // than through this state — no first-frame flash of the wrong syntax colors.
+  const isDark = useIsDarkTheme();
+
   const wrapComp = useRef(new Compartment());
+  const themeComp = useRef(new Compartment());
 
   // Create the editor once per file identity. `value`/`wrap` updates are applied
   // by the effects below so cursor and undo history survive them.
@@ -114,7 +123,7 @@ export function MarkdownLiveEditor({
           saveKeymap, // highest precedence so Cmd/Ctrl+S is ours, not the browser's
           keymap.of([indentWithTab]),
           basicSetup,
-          oneDark,
+          themeComp.current.of(syntaxTheme(resolvedThemeNow() === 'dark')),
           baseTheme,
           // GFM base (not commonmark) so tables + strikethrough are parsed —
           // the live layer renders/styles them.
@@ -174,6 +183,12 @@ export function MarkdownLiveEditor({
       effects: wrapComp.current.reconfigure(wrap ? EditorView.lineWrapping : []),
     });
   }, [wrap]);
+
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: themeComp.current.reconfigure(syntaxTheme(isDark)),
+    });
+  }, [isDark]);
 
   return <div ref={containerRef} className="h-full w-full overflow-hidden" />;
 }

--- a/apps/web/components/files-git-panel/markdown-preview.tsx
+++ b/apps/web/components/files-git-panel/markdown-preview.tsx
@@ -10,8 +10,10 @@ import 'highlight.js/styles/atom-one-dark.css';
 const CODE_FONT = 'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
 
 /** Read-only, document-scale markdown render for the file viewer. Self-contained
- *  (imports its own hljs theme). No rehype-raw: embedded HTML shows as literal
- *  text, never executed. Renders the body only — the viewer owns the scroll. */
+ *  (imports its own hljs theme — atom-one-dark, which app/globals.css re-tints
+ *  to atom-one-light under `html:not(.dark) [data-files-panel]`). No rehype-raw:
+ *  embedded HTML shows as literal text, never executed. Renders the body only —
+ *  the viewer owns the scroll. */
 export function MarkdownPreview({ content }: { content: string }) {
   return (
     <div className="px-4 py-3 text-sm leading-relaxed text-foreground/90">
@@ -25,7 +27,7 @@ export function MarkdownPreview({ content }: { content: string }) {
           h4: ({ children }) => <h4 className="mt-3 mb-1 text-sm font-semibold text-foreground first:mt-0">{children}</h4>,
           p: ({ children }) => <p className="my-2">{children}</p>,
           a: ({ href, children }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-400 underline underline-offset-2 hover:text-blue-300">{children}</a>
+            <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline underline-offset-2 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{children}</a>
           ),
           ul: ({ children }) => <ul className="my-2 list-disc pl-5 space-y-1">{children}</ul>,
           ol: ({ children }) => <ol className="my-2 list-decimal pl-5 space-y-1">{children}</ol>,
@@ -40,7 +42,7 @@ export function MarkdownPreview({ content }: { content: string }) {
             return <code className="rounded bg-muted px-1 py-0.5 text-[0.85em]" style={{ fontFamily: CODE_FONT }}>{children}</code>;
           },
           pre: ({ children }) => (
-            <pre className="custom-scrollbar my-3 overflow-x-auto rounded-md bg-[#282c34] p-3 text-xs" style={{ fontFamily: CODE_FONT }}>{children}</pre>
+            <pre className="custom-scrollbar my-3 overflow-x-auto rounded-md bg-muted p-3 text-xs dark:bg-[#282c34]" style={{ fontFamily: CODE_FONT }}>{children}</pre>
           ),
           table: ({ children }) => (
             <div className="custom-scrollbar my-3 overflow-x-auto">

--- a/apps/web/components/files-git-panel/styles.ts
+++ b/apps/web/components/files-git-panel/styles.ts
@@ -6,13 +6,23 @@ export const SCROLL_STYLE =
   '[&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-thumb]:rounded-full ' +
   'dark:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20';
 
+/** The panel's surface, as a CSS value. Follows the site theme: `--panel` is
+ *  #171717 in dark (what the panel used to hard-code) and white in light. Used
+ *  by the CodeMirror editors and the commit graph, which need a real color
+ *  string rather than a Tailwind class; JSX should prefer `bg-panel`. */
+export const PANEL_BG = 'hsl(var(--panel))';
+
+/** The panel's dropdown/menu surface — the shared `--menu` token (#2D2D2D in
+ *  dark, white in light), so the panel's hand-positioned menus match the rest
+ *  of the app's overlays. */
+export const DROPDOWN_BG = 'hsl(var(--menu))';
+
 // Scrollbar styling for the panel's CodeMirror surfaces (plain editor, markdown
 // live editor, and both diff panels), matching the site-wide `.custom-scrollbar`
 // (app/globals.css): thin 6px, transparent track, rounded, brighten on hover.
-// These editors sit on the panel's *fixed dark* surface (#171717) regardless of
-// the site theme, so the thumb is keyed off `--muted-foreground` (a light token
-// in both themes) at low opacity rather than `--border` — the latter is
-// near-white in the light theme and would flare on the dark panel. Spread
+// The thumb is keyed off `--muted-foreground` at low opacity rather than
+// `--border`: `--border` is near-white in light and would flare against the
+// dark panel, whereas `--muted-foreground` reads on both surfaces. Spread
 // `CM_SCROLLBAR_WEBKIT` into an `EditorView.theme` object and merge
 // `CM_SCROLLBAR_FIREFOX` into that theme's `.cm-scroller` block. Kept here so the
 // three editors can't drift apart.

--- a/apps/web/components/files-git-panel/use-in-file-find.ts
+++ b/apps/web/components/files-git-panel/use-in-file-find.ts
@@ -49,8 +49,10 @@ function highlightApi(): { registry: HighlightRegistryLike; Ctor: HighlightCtor 
 // The `::highlight()` pseudo-element is injected at runtime rather than living
 // in globals.css: the build-time CSS parser (Lightning CSS) rejects it as an
 // unknown pseudo-element, whereas the browser parses it fine. Injected once,
-// lazily, and only where the Custom Highlight API exists. The panel is always
-// dark (#171717), so the dark find palette is used unconditionally.
+// lazily, and only where the Custom Highlight API exists. Both palettes are
+// injected together (the `.dark` rule overrides the light one) so the panel's
+// find highlights follow the theme without re-injecting on every toggle —
+// matching the chat's `mark.find-hit` colors in app/globals.css.
 let stylesInjected = false;
 function ensureHighlightStyles(): void {
   if (stylesInjected || typeof document === 'undefined') return;
@@ -58,7 +60,8 @@ function ensureHighlightStyles(): void {
   const style = document.createElement('style');
   style.dataset.vicoaFileFind = '';
   style.textContent =
-    '::highlight(vicoa-file-find){background-color:rgb(250 204 21 / 0.35);color:inherit;}' +
+    '::highlight(vicoa-file-find){background-color:#fde68a;color:inherit;}' +
+    '.dark ::highlight(vicoa-file-find){background-color:rgb(250 204 21 / 0.35);}' +
     '::highlight(vicoa-file-find-active){background-color:#f97316;color:#1a1205;}';
   document.head.appendChild(style);
 }

--- a/apps/web/lib/hooks/use-resolved-theme.ts
+++ b/apps/web/lib/hooks/use-resolved-theme.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * The palette painted right now, read straight off the `dark` / `light` class
+ * <ThemeProvider> puts on <html>. A blocking script in app/layout.tsx sets that
+ * class before first paint, so this is already correct by the time any client
+ * effect runs. Returns `dark` (what the server renders) when there is no
+ * document, so it is safe to call during SSR.
+ */
+export function resolvedThemeNow(): 'dark' | 'light' {
+  if (typeof document === 'undefined') return 'dark';
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+/**
+ * {@link resolvedThemeNow} as reactive state.
+ *
+ * `useTheme().theme` is the stored *preference*, which can be `system` or a
+ * `plugin:<id>/<theme>` value; neither tells you which palette won. Anything
+ * that has to pick a colour in JS (CodeMirror themes, canvas/SVG paints) needs
+ * the resolved answer, so read it off the class the provider already applied
+ * and track it with a MutationObserver — that covers the mode switcher, the
+ * OS-level change under `system`, and a plugin theme loading late.
+ *
+ * The first render returns `dark` so SSR and hydration agree; the effect
+ * corrects it on mount. Code that runs only on the client (an effect, an
+ * imperative editor setup) should read {@link resolvedThemeNow} directly to
+ * skip that one-render lag.
+ */
+export function useResolvedTheme(): 'dark' | 'light' {
+  const [resolved, setResolved] = useState<'dark' | 'light'>('dark');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const read = () => setResolved(resolvedThemeNow());
+    read();
+    const observer = new MutationObserver(read);
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return resolved;
+}
+
+/** Convenience wrapper around {@link useResolvedTheme}. */
+export function useIsDarkTheme(): boolean {
+  return useResolvedTheme() === 'dark';
+}

--- a/apps/web/scripts/check-theme-colors.mjs
+++ b/apps/web/scripts/check-theme-colors.mjs
@@ -10,8 +10,8 @@
  *
  * Deliberately NOT matched: inline-style hex in JS objects (e.g. label-swatch
  * data) — this only flags the `-[#…]` Tailwind class form. Exempt paths below
- * are either intentionally-fixed-dark panels (VS-Code-style editor + terminal),
- * marketing pages with their own styling, or platform conventions.
+ * are either the intentionally-fixed-dark terminal, marketing pages with their
+ * own styling, or platform conventions.
  *
  * Run: `node scripts/check-theme-colors.mjs` (wired into `pnpm lint`).
  */
@@ -27,9 +27,8 @@ const SCAN_DIRS = ['components', 'app'];
 
 // Prefixes (relative to apps/web/) that are exempt from the rule.
 const EXEMPT_PREFIXES = [
-  // Plane B — intentionally fixed-dark surfaces (editor + terminal), always
-  // dark in every theme by design.
-  'components/files-git-panel/',
+  // Intentionally fixed-dark surface: the terminal emulator, whose ANSI palette
+  // is tuned against a dark background in every theme.
   'components/terminal-pane/',
   // Marketing / public pages: own always-on styling, not app chrome.
   'components/landing/',
@@ -41,6 +40,9 @@ const EXEMPT_PREFIXES = [
 const EXEMPT_FILES = new Set([
   'components/desktop/window-chrome.tsx', // Windows close-button system red (#c42b1c)
   'components/onboarding/intro-slides.tsx', // decorative onboarding gradient
+  // atom-one-dark's own code-block background (#282c34), applied under `dark:`
+  // only — it belongs to the highlight.js theme, not to the app's token set.
+  'components/files-git-panel/markdown-preview.tsx',
 ]);
 
 // Tailwind color utilities that take an arbitrary hex value.


### PR DESCRIPTION
Two fixes to the files/git panel, both reported from using light mode.

## 1. The panel didn't follow the theme

It was deliberately built as a **fixed-dark surface** — `#171717` was hard-coded in five files, and `components/files-git-panel/` was on the exemption list in `scripts/check-theme-colors.mjs`. So it stayed dark while the rest of the app switched to light. Now token-driven:

**New `--panel` token.** Dark keeps `#171717` exactly — the value the panel used to hard-code, so **dark mode is pixel-identical**. Light is pure white, so the pane reads as an editor against the `#FDFCFC` chat canvas. Registered as `--color-panel`, so `bg-panel` works.

**Surfaces.** `styles.ts` now exports `PANEL_BG`/`DROPDOWN_BG` once instead of five copies drifting. The panel, side pane, sticky headers and loading placeholders read `--panel`; the three hand-positioned dropdowns and two tooltips move to the shared `--menu`/`--menu-border`; the `bg-white/[0.06]` tab washes become `bg-foreground/…` (indistinguishable in dark, visible in light).

**Syntax highlighting** — the part that would otherwise stay unreadable on white:

- **CodeMirror** (plain editor, markdown live editor, unified + side-by-side diff): `oneDark` moves into a `Compartment`; light drops it and falls through to `basicSetup`'s bundled light `defaultHighlightStyle`. Flipping the theme *reconfigures* the live editors rather than rebuilding them, so undo history and cursor survive. The `@codemirror/merge` diff tints gain a light variant — and importantly its `{dark: true}` flag no longer claims a dark palette while the site is light (that flag drives CodeMirror's base selection colors, not just the tints).
- **highlight.js** (markdown preview, read-only file view, commit diffs): the app imports `atom-one-dark` globally and shares it with the chat, so light re-tints to `atom-one-light` scoped to `html:not(.dark) [data-files-panel]`. The chat renderer is untouched.

Also themed: commit-graph lane colors (darkened for light — the old amber lane was invisible on white), markdown-live decorations (`rgba(255,255,255,…)` → `--foreground`), find-in-file highlights (now matching the chat's amber), and the amber/red warning banners.

**Guard.** The panel's exemption is removed from `scripts/check-theme-colors.mjs`, so this can't silently regress. One file stays exempt with a note: `markdown-preview.tsx`'s `dark:bg-[#282c34]`, which is atom-one-dark's own background rather than an app token.

**New hook** `lib/hooks/use-resolved-theme.ts` — `useTheme().theme` is the stored *preference* (which can be `system` or `plugin:…`), not the palette that actually won, so this reads the class off `<html>` and tracks it with a `MutationObserver`. `resolvedThemeNow()` is the non-reactive read used at editor-creation time to avoid a first-frame flash of the wrong syntax palette.

## 2. The separator drew on top of dialogs

`files-git-panel.tsx` — the resize handle was `z-50`. The panel root is `relative` with **no** z-index, so it opens no stacking context and the handle competed *directly* with the dialogs' `fixed inset-0 z-50`. Tied on z-index, DOM order decides — and the sidebar's `DeleteSessionDialog` renders in the dashboard layout, i.e. **before** the page, so the separator won and drew over the scrim.

Dropped to `z-[46]`: still above the keep-alive terminal overlay (`z-45`, the reason it was raised in the first place), now below the whole modal layer.

## Scope note

The **terminal tab keeps its dark background**. Its ANSI palette is tuned for dark, it's a separate component (`components/terminal-pane/`), and it stays marked intentionally-fixed-dark — same as a light-themed VS Code with a dark terminal profile. Easy to flip in a follow-up if that's not the call.

## Testing

- `pnpm lint` (tsc + theme-color guard) — green
- `pnpm test` — 704 tests, 60 files, all passing
- `pnpm build` — compiles clean; verified the emitted CSS carries both `--panel` values, the `.bg-panel` utility, the per-theme `--git-graph-*` lanes, and that Lightning CSS accepted the scoped `atom-one-light` rules