### PR TITLE
fix(backend): stop the Inbox create race from 500ing /api/v1/projects

### DIFF
--- a/backend/src/backend/tests/test_tasks.py
+++ b/backend/src/backend/tests/test_tasks.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
 
 from shared.database import (
     Machine,
@@ -52,6 +54,50 @@ class TestInboxHelper:
 
         again = get_or_create_inbox(test_db, test_user.id)
         assert again.id == inbox.id
+
+    def test_losing_the_create_race_reuses_the_winner(
+        self, test_db, test_user, postgres_container
+    ):
+        """A concurrent insert wins uq_projects_user_inbox; we reuse its row.
+
+        Regression: rolling back the SAVEPOINT already expunges the pending
+        Project, so the follow-up expunge raised InvalidRequestError and turned
+        a handled race into a 500 on GET /api/v1/projects.
+        """
+        other_engine = create_engine(postgres_container.get_connection_url())
+        OtherSession = sessionmaker(bind=other_engine)
+        raced = []
+
+        def insert_winner(session, flush_context, instances):
+            """Commit the rival Inbox from another connection mid-flush."""
+            if raced or not any(
+                isinstance(obj, Project) and obj.is_inbox for obj in session.new
+            ):
+                return
+            raced.append(True)
+            other = OtherSession()
+            try:
+                other.add(Project(user_id=test_user.id, name="Inbox", is_inbox=True))
+                other.commit()
+            finally:
+                other.close()
+
+        event.listen(test_db, "before_flush", insert_winner)
+        try:
+            inbox = get_or_create_inbox(test_db, test_user.id)
+        finally:
+            event.remove(test_db, "before_flush", insert_winner)
+            other_engine.dispose()
+
+        assert raced, "the rival insert never fired"
+        assert inbox.is_inbox is True
+        assert inbox.user_id == test_user.id
+        assert (
+            test_db.query(Project)
+            .filter(Project.user_id == test_user.id, Project.is_inbox.is_(True))
+            .count()
+            == 1
+        )
 
 
 class TestProjectsAPI:

--- a/backend/src/shared/database/tasks.py
+++ b/backend/src/shared/database/tasks.py
@@ -56,8 +56,12 @@ def get_or_create_inbox(db: Session, user_id: UUID) -> Project:
         db.flush()
         nested.commit()
     except IntegrityError:
+        # Rolling back the SAVEPOINT already restores the session snapshot,
+        # which expunges anything added inside it — so guard the expunge or it
+        # raises InvalidRequestError and masks the race we are handling.
         nested.rollback()
-        db.expunge(inbox)
+        if inbox in db:
+            db.expunge(inbox)
         winner = _existing()
         if winner is None:  # pragma: no cover - only under pathological races
             raise


### PR DESCRIPTION
## Problem

Sentry `347778fb040d4d42953fe8ec1e0fd60b` — `InvalidRequestError: Instance <Project> is not present in this Session` on `GET /api/v1/projects`, one user, production.

Three stacked exceptions, but only one bug. The Inbox ("No project" bucket) is created lazily on first read, and losing a concurrent create is *supposed* to be handled: the `uq_projects_user_inbox` partial unique index lets one row win, the loser catches `IntegrityError`, rolls back its SAVEPOINT and re-reads the winner. So the `UniqueViolation` at the bottom of the trace is by design.

The recovery path itself was broken. Rolling back a SAVEPOINT already restores the session snapshot, which expunges anything `add()`ed inside it — so the follow-up `db.expunge(inbox)` operated on an object that was no longer in the session and raised `InvalidRequestError`, before `_existing()` could pick up the winner. A handled race surfaced as a 500.

The race is routine rather than exotic: `apps/web/app/dashboard/tasks/page.tsx:146` fires `listProjects()` and `listProjects(true)` in one `Promise.all`, and `sidebar-sessions.tsx:371` fires its own — so any user who doesn't have an Inbox row yet races with themselves on first load. Migration `c9d4e1f7a2b3` creates the table without backfilling Inbox rows, which is why this started firing right after rollout.

## Fix

Guard the expunge. The design — lazy create + partial unique index + reuse-the-winner — is unchanged; only the error branch was wrong.

```python
nested.rollback()
if inbox in db:
    db.expunge(inbox)
winner = _existing()
```

## Test

The existing `test_creates_inbox_once` never reached the `except` branch — a single session short-circuits on the initial read — so the broken recovery path had no coverage at all. The new test commits a rival Inbox from a second connection via a `before_flush` listener, producing a real `UniqueViolation` rather than a mocked one. With the guard removed it fails with exactly the Sentry error; with it, `get_or_create_inbox` returns the winner and one Inbox row survives.

`pytest src/backend/tests/test_tasks.py` → 53 passed. `make lint` → clean.

## Not in scope

Backfilling Inbox rows for existing users (an `INSERT ... SELECT ... ON CONFLICT DO NOTHING` migration) would keep most users off the race path entirely. Worth doing, but separate from stopping the 500 — happy to follow up.