### PR TITLE
feat(web): open terminal links with ⌘/Ctrl+click

### DIFF
--- a/apps/web/components/terminal-pane/terminal-links.css
+++ b/apps/web/components/terminal-pane/terminal-links.css
@@ -1,0 +1,8 @@
+/* Terminal links open on ⌘/Ctrl+click only (see terminal-links.ts). xterm
+   shows the pointer cursor whenever a link is hovered, which would promise
+   that a plain click does something — so suppress it unless the modifier is
+   actually held. `inherit` rather than a literal keeps xterm's own cursor for
+   the state (text normally, default while an app has mouse events enabled). */
+[data-link-modifier='false'] .xterm .xterm-cursor-pointer {
+  cursor: inherit;
+}

--- a/apps/web/components/terminal-pane/terminal-links.test.ts
+++ b/apps/web/components/terminal-pane/terminal-links.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isLinkModifierHeld, shouldOpenTerminalLink, trackLinkModifier } from './terminal-links';
+
+/** A left-click mouseup with no modifier, overridable per case. */
+const click = (over: Partial<MouseEvent> = {}): MouseEvent =>
+  ({ button: 0, metaKey: false, ctrlKey: false, ...over }) as MouseEvent;
+
+const URL = 'https://vicoa.ai/docs';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('isLinkModifierHeld', () => {
+  it('is ⌘ on macOS and Ctrl elsewhere', () => {
+    expect(isLinkModifierHeld(click({ metaKey: true }), true)).toBe(true);
+    expect(isLinkModifierHeld(click({ ctrlKey: true }), false)).toBe(true);
+  });
+
+  it('never accepts the other platform’s modifier', () => {
+    // Ctrl+click on macOS is a right-click — it must not open a link.
+    expect(isLinkModifierHeld(click({ ctrlKey: true }), true)).toBe(false);
+    expect(isLinkModifierHeld(click({ metaKey: true }), false)).toBe(false);
+  });
+});
+
+describe('shouldOpenTerminalLink', () => {
+  it('opens on ⌘/Ctrl + left click', () => {
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), URL, true)).toBe(true);
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), URL, false)).toBe(true);
+  });
+
+  it('ignores a plain click, so a stray click in a TUI cannot hijack the browser', () => {
+    expect(shouldOpenTerminalLink(click(), URL, true)).toBe(false);
+    expect(shouldOpenTerminalLink(click(), URL, false)).toBe(false);
+  });
+
+  it('ignores non-left buttons (middle-click pastes, right-click opens the menu)', () => {
+    expect(shouldOpenTerminalLink(click({ button: 1, metaKey: true }), URL, true)).toBe(false);
+    expect(shouldOpenTerminalLink(click({ button: 2, ctrlKey: true }), URL, false)).toBe(false);
+  });
+
+  it('only opens http(s) URLs', () => {
+    const modified = click({ metaKey: true });
+    expect(shouldOpenTerminalLink(modified, 'http://localhost:3000/', true)).toBe(true);
+    expect(shouldOpenTerminalLink(modified, 'javascript:alert(1)', true)).toBe(false);
+    expect(shouldOpenTerminalLink(modified, 'file:///etc/passwd', true)).toBe(false);
+    expect(shouldOpenTerminalLink(modified, 'vicoa://auth/callback', true)).toBe(false);
+  });
+
+  it('falls back to the detected platform when none is passed', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' });
+    expect(shouldOpenTerminalLink(click({ metaKey: true }), URL)).toBe(true);
+    expect(shouldOpenTerminalLink(click({ ctrlKey: true }), URL)).toBe(false);
+  });
+});
+
+describe('trackLinkModifier', () => {
+  /** Minimal window/element stand-ins — the node test env has neither. */
+  const setup = () => {
+    const listeners = new Map<string, (event: unknown) => void>();
+    const attrs: Record<string, string> = {};
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' });
+    vi.stubGlobal('window', {
+      addEventListener: (type: string, fn: (event: unknown) => void) => listeners.set(type, fn),
+      removeEventListener: (type: string) => listeners.delete(type),
+    });
+    const el = {
+      setAttribute: (name: string, value: string) => {
+        attrs[name] = value;
+      },
+    } as HTMLElement;
+    return { listeners, attrs, el };
+  };
+
+  it('mirrors the held modifier onto the element and cleans up', () => {
+    const { listeners, attrs, el } = setup();
+    const stop = trackLinkModifier(el);
+    expect(attrs['data-link-modifier']).toBe('false');
+
+    listeners.get('keydown')?.({ metaKey: true, ctrlKey: false });
+    expect(attrs['data-link-modifier']).toBe('true');
+
+    // keyup of ⌘ reports metaKey: false, which disarms without special-casing.
+    listeners.get('keyup')?.({ metaKey: false, ctrlKey: false });
+    expect(attrs['data-link-modifier']).toBe('false');
+
+    // A swallowed keyup (⌘Tab away) must not leave links armed.
+    listeners.get('keydown')?.({ metaKey: true, ctrlKey: false });
+    listeners.get('blur')?.(undefined);
+    expect(attrs['data-link-modifier']).toBe('false');
+
+    stop();
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/apps/web/components/terminal-pane/terminal-links.ts
+++ b/apps/web/components/terminal-pane/terminal-links.ts
@@ -1,0 +1,97 @@
+// Terminal link activation: ⌘/Ctrl+click opens a URL in the browser.
+//
+// Both link flavours route here — the `https?://…` text the WebLinksAddon
+// finds, and OSC 8 hyperlinks emitted by agent CLIs (wired via the
+// `linkHandler` option in terminal-options.ts).
+//
+// Why a custom handler instead of xterm's default:
+//
+//  1. The default opens with a bare `window.open()` and then assigns
+//     `location.href`. The Electron shell denies that popup in its
+//     `setWindowOpenHandler` (apps/desktop/src/window.ts), so `window.open()`
+//     returns null and the click silently does nothing — on desktop, which is
+//     where the terminal is used most. `openExternalUrl` hands the URL to the
+//     preload bridge (system browser) there, and opens a new tab on the web.
+//
+//  2. xterm activates a link on ANY left click, so a stray click on a URL
+//     printed by a running TUI would hijack the browser. Real terminals
+//     (VS Code, iTerm2, Windows Terminal, Ghostty) all gate activation behind
+//     the platform modifier; we match that.
+
+import { isMacPlatform } from '@/lib/desktop-shortcuts';
+import { openExternalUrl } from '@/lib/open-external';
+
+/** The modifier flags of a mouse/key event — all the decision needs. */
+export interface LinkModifierState {
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
+
+/**
+ * Is the OS's link modifier held? ⌘ on macOS, Ctrl on Windows/Linux.
+ * Deliberately not "either one": Ctrl+click on macOS is a right-click
+ * (context menu), which must never open a link.
+ */
+export function isLinkModifierHeld(
+  event: LinkModifierState,
+  mac: boolean = isMacPlatform(),
+): boolean {
+  return mac ? event.metaKey : event.ctrlKey;
+}
+
+/** Belt-and-braces: only ever hand http(s) to the opener. The web-links regex
+ *  and xterm's OSC 8 handling are http-only already, so this just keeps a
+ *  future regex/provider change from reaching `openExternalUrl` with, say, a
+ *  `javascript:` URL. */
+function isOpenableUrl(uri: string): boolean {
+  return /^https?:\/\//i.test(uri);
+}
+
+/** The pure decision behind `openTerminalLink`, split out so it can be tested
+ *  without a DOM. */
+export function shouldOpenTerminalLink(
+  event: LinkModifierState & Pick<MouseEvent, 'button'>,
+  uri: string,
+  mac: boolean = isMacPlatform(),
+): boolean {
+  // `button === 0`: xterm activates on mouseup, and only a left click should
+  // open (middle-click is paste on Linux, right-click opens the menu).
+  return event.button === 0 && isLinkModifierHeld(event, mac) && isOpenableUrl(uri);
+}
+
+/** Link `activate` handler for both the WebLinksAddon and OSC 8 hyperlinks. */
+export function openTerminalLink(event: MouseEvent, uri: string): void {
+  if (!shouldOpenTerminalLink(event, uri)) return;
+  openExternalUrl(uri);
+}
+
+/** Set on the pane element while the link modifier is held; terminal-links.css
+ *  keys the pointer cursor off it. */
+export const LINK_MODIFIER_ATTR = 'data-link-modifier';
+
+/**
+ * Mirror "is the link modifier held?" onto `el` as a data attribute, so a
+ * hovered link only shows the pointer cursor when a click would actually open
+ * it. Returns an unsubscribe.
+ */
+export function trackLinkModifier(el: HTMLElement): () => void {
+  const set = (held: boolean): void => {
+    el.setAttribute(LINK_MODIFIER_ATTR, held ? 'true' : 'false');
+  };
+  // keydown and keyup both carry the post-event modifier flags (pressing ⌘
+  // sets metaKey, releasing it clears it), so one reader serves both.
+  const handleKey = (event: KeyboardEvent): void => set(isLinkModifierHeld(event));
+  // ⌘Tab / ⌘-clicking into another window swallows the keyup, which would
+  // otherwise leave links armed forever.
+  const handleBlur = (): void => set(false);
+
+  set(false);
+  window.addEventListener('keydown', handleKey);
+  window.addEventListener('keyup', handleKey);
+  window.addEventListener('blur', handleBlur);
+  return () => {
+    window.removeEventListener('keydown', handleKey);
+    window.removeEventListener('keyup', handleKey);
+    window.removeEventListener('blur', handleBlur);
+  };
+}

--- a/apps/web/components/terminal-pane/terminal-options.ts
+++ b/apps/web/components/terminal-pane/terminal-options.ts
@@ -6,6 +6,7 @@
 // ANSI colors are the Tailwind 400-series the dashboard already leans on.
 
 import type { ITerminalOptions, ITheme } from '@xterm/xterm';
+import { openTerminalLink } from './terminal-links';
 
 export const VICOA_TERMINAL_BACKGROUND = '#161C24';
 
@@ -67,6 +68,11 @@ export function buildTerminalOptions(): ITerminalOptions {
     macOptionIsMeta: false,
     macOptionClickForcesSelection: true,
     drawBoldTextInBrightColors: true,
+    // OSC 8 hyperlinks (agent CLIs emit them for docs/PR URLs). Plain `http://`
+    // text is handled by the WebLinksAddon; both activate the same way —
+    // ⌘/Ctrl+click, opened outside the app. xterm only forwards http(s) here
+    // unless `allowNonHttpProtocols` is set, which it isn't.
+    linkHandler: { activate: openTerminalLink },
     theme: VICOA_TERMINAL_THEME,
   };
 }

--- a/apps/web/components/terminal-pane/terminal-pane.tsx
+++ b/apps/web/components/terminal-pane/terminal-pane.tsx
@@ -15,11 +15,14 @@
 import '@xterm/xterm/css/xterm.css';
 // Bundled "Symbols Nerd Font Mono" @font-face (powerline + Nerd Font glyphs).
 import './terminal-fonts.css';
+// Modifier-aware pointer cursor over links (see terminal-links.ts).
+import './terminal-links.css';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import type { PtyTransport } from './pty-transport';
 import { buildTerminalOptions, VICOA_TERMINAL_BACKGROUND } from './terminal-options';
+import { openTerminalLink, trackLinkModifier } from './terminal-links';
 import { RpcError } from '@/lib/ws-client';
 
 const RESIZE_DEBOUNCE_MS = 50;
@@ -111,6 +114,10 @@ export function TerminalPane({
       boundTransport.write(data);
     };
 
+    // Armed synchronously (not inside the async import below) so the pane is
+    // never briefly in a state where holding ⌘/Ctrl doesn't register.
+    unsubs.push(trackLinkModifier(container));
+
     setStatus({ kind: 'loading' });
 
     void (async () => {
@@ -130,7 +137,9 @@ export function TerminalPane({
       term.loadAddon(fitAddon);
       term.loadAddon(new SearchAddon());
       term.loadAddon(new Unicode11Addon());
-      term.loadAddon(new WebLinksAddon());
+      // ⌘/Ctrl+click opens the URL outside the app; a plain click is left to
+      // the shell/TUI underneath (see terminal-links.ts).
+      term.loadAddon(new WebLinksAddon(openTerminalLink));
       // Activate wide-char tables before any write, or CJK/emoji cells bake in
       // at single width (Orca's pane-lifecycle ordering).
       term.unicode.activeVersion = '11';


### PR DESCRIPTION
Clicking a URL in the terminal did nothing on desktop. `WebLinksAddon` was loaded with its default activation handler, which opens a link with a bare `window.open()` and then assigns `location.href` on the returned window — the Electron shell denies that popup in its `setWindowOpenHandler` (`apps/desktop/src/window.ts`, the URL is `about:blank` at that point, not http(s)), so `window.open()` returned `null`, the addon logged *"Opening link blocked as opener could not be cleared"*, and nothing happened. OSC 8 hyperlinks — what the agent CLIs actually emit for docs/PR links — went through xterm's own default with the same result.

## What changed

New `components/terminal-pane/terminal-links.ts` owns activation for both link flavours:

- **Routes through `lib/open-external`'s `openExternalUrl`**, which hands the URL to the preload bridge (system browser) on desktop and opens a new tab on the web. Same helper the sidebar/settings external links already use.
- **Requires the platform modifier** — ⌘ on macOS, Ctrl on Windows/Linux, via the existing `isMacPlatform()`. Deliberately not "either one": Ctrl+click on macOS is a right-click and must never open a link.
- **Only ever hands http(s) to the opener.** The web-links regex and xterm's OSC 8 path are http-only already; this keeps a future regex change from reaching the opener with a `javascript:` URL.
- `terminal-options.ts` wires the same handler into xterm's `linkHandler` so OSC 8 hyperlinks activate identically.

## Why gate on a modifier

xterm activates links on **any** left click, so a stray click on a URL printed by a running TUI hijacks the browser. Every comparable terminal gates this: iTerm2 (⌘+click), Windows Terminal (Ctrl+click), Ghostty (⌘/Ctrl+click, with an opt-in config to drop the modifier), VS Code's integrated terminal (⌘/Ctrl+click, with a "Follow link (cmd + click)" hover hint).

Side effect worth calling out: a **plain** click no longer opens a link in the plain-web dashboard, where the addon's default happened to work. That's the intended trade.

Since a plain click now does nothing, the pointer cursor shouldn't promise otherwise: `trackLinkModifier` mirrors "modifier held" onto the pane as `data-link-modifier`, and `terminal-links.css` suppresses xterm's hover pointer unless it's set (`cursor: inherit`, so xterm keeps its own text/default cursor for the state). Underline-on-hover is untouched — a link still looks like one. Tracking is armed synchronously at effect start, before the async xterm import, so the pane is never briefly deaf to the modifier, and is torn down with the rest of the pane's listeners.

## Scope

Renderer-only — no Electron main-process change needed, the `vicoa:open-external` IPC already exists and already validates the scheme. Ships to desktop with the next desktop release.

## Testing

- New `terminal-links.test.ts`: 8 tests over the pure decision (platform modifier, wrong-platform modifier rejected, plain click ignored, non-left buttons ignored, http(s)-only, platform fallback) and the modifier tracking (including the swallowed-keyup ⌘Tab case).
- `pnpm test` 712 passed (61 files) · `pnpm lint` exit 0 · `pnpm build` exit 0.
- Manual: not yet exercised in a packaged desktop build — worth a click-through on macOS and Windows before the next release.