### PR TITLE
fix(headless): stop the initial prompt from consuming its own catch-up cursor

### DIFF
--- a/apps/web/components/navigation-header.tsx
+++ b/apps/web/components/navigation-header.tsx
@@ -145,7 +145,7 @@ export function NavigationHeader() {
               title="Vicoa is open source — star us on GitHub"
               className="flex h-10 w-10 items-center justify-center rounded-full text-foreground/80 hover:text-foreground hover:bg-muted transition-all"
             >
-              <GithubIcon className="h-5 w-5" />
+              <GithubIcon className="h-6 w-6" />
             </a>
             <div className="hidden md:flex">
               <UnifiedUserMenu variant="button" />

--- a/backend/src/integrations/headless/acp_base.py
+++ b/backend/src/integrations/headless/acp_base.py
@@ -491,11 +491,11 @@ class ACPWrapperBase(ABC):
 
         # POST initial prompt as a user message and let the WS echo deliver it
         # back into ``message_queue`` — the single path also used for every
-        # subsequent turn. There is NO direct ``message_queue.append`` and NO
-        # self-echo dedup; the codex_native pattern relies on the live
-        # broadcast (after ``wait_until_ready`` confirms catch-up completed,
-        # so the subscription is registered AND we won't double-deliver via
-        # catch-up rows we just bypassed by mark_as_read=True on POST).
+        # subsequent turn. There is NO direct ``message_queue.append``; the
+        # codex_native pattern relies on the live broadcast (after
+        # ``wait_until_ready`` confirms catch-up completed, so the
+        # subscription is registered), with the WS client's ``CatchUpBuffer``
+        # deduping by message id so a later catch-up can't double-deliver.
         initial_prompt: Optional[str] = getattr(self.config, "initial_prompt", None)
         if initial_prompt and initial_prompt.strip() and self.config.agent_instance_id:
             if self._ws_client is not None:
@@ -507,9 +507,17 @@ class ACPWrapperBase(ABC):
                     )
             if self.vicoa_client:
                 try:
+                    # ``mark_as_read=False`` is load-bearing — see the long
+                    # comment on the same POST in ``claude_code.initialize``.
+                    # The default (True) points the server's
+                    # ``last_read_message_id`` at this row, and the catch-up
+                    # cursor fallback then excludes the prompt from its own
+                    # recovery, hanging the session forever when the
+                    # ``ready`` wait above timed out.
                     self.vicoa_client.send_user_message(
                         agent_instance_id=self.config.agent_instance_id,
                         content=initial_prompt,
+                        mark_as_read=False,
                     )
                 except Exception as e:
                     self.log(

--- a/backend/src/integrations/headless/claude_code.py
+++ b/backend/src/integrations/headless/claude_code.py
@@ -1157,11 +1157,10 @@ class HeadlessClaudeRunner:
             # (session 40e02f0a-…). Mirrors ``codex_native.run()`` 2026-06.
             #
             # Wait for the WS subscriber to finish its catch-up handshake
-            # before POSTing. Otherwise the broadcast from this POST can
-            # land in the gap between subscription-registration and the
-            # catch-up SELECT, and the prompt is silently dropped on first
-            # session (subsequent messages work because by then the
-            # subscriber is fully attached).
+            # before POSTing, so the broadcast lands on an attached
+            # subscription and the prompt is delivered in order. The wait is
+            # an optimisation, not the correctness guarantee — see
+            # ``mark_as_read`` below for what covers the timeout path.
             if self._ws_client is not None:
                 ready = await asyncio.to_thread(self._ws_client.wait_until_ready, 10.0)
                 if not ready:
@@ -1169,9 +1168,23 @@ class HeadlessClaudeRunner:
                         "WS catch-up not ready after 10s; POSTing initial prompt anyway"
                     )
             try:
+                # ``mark_as_read=False`` is load-bearing. The default (True)
+                # makes the server point ``last_read_message_id`` at this very
+                # row, and the session-scoped catch-up falls back to that
+                # cursor when the client has no watermark, fetching strictly
+                # ``created_at > cursor``. So a prompt POSTed before the
+                # subscription attached (the ``ready`` timeout above) misses
+                # the live broadcast AND excludes itself from every later
+                # catch-up — including the 10s ``_run_reconcile_backstop``
+                # re-fetch, which replays the same cursor forever. The session
+                # then hangs until a human interrupts it (c0d25529-…, 6h+).
+                # Leaving the cursor alone lets catch-up recover the prompt;
+                # ``CatchUpBuffer`` dedupes it against the live broadcast, and
+                # the first agent message advances the cursor past it anyway.
                 await self.vicoa_client.send_user_message(
                     agent_instance_id=self.session_id,
                     content=self.initial_prompt,
+                    mark_as_read=False,
                 )
             except Exception:
                 self.logger.exception("Failed to POST initial prompt as user message")

--- a/backend/src/integrations/headless/codex_native.py
+++ b/backend/src/integrations/headless/codex_native.py
@@ -355,12 +355,11 @@ class CodexNativeRunner:
                 # cause two turn/start calls for the same input.
                 #
                 # Wait for the WS subscriber to finish its catch-up handshake
-                # before POSTing. Otherwise the broadcast from this POST can
-                # land in the gap between subscription-registration and the
-                # catch-up SELECT, and the prompt is silently dropped on the
-                # first session (subsequent messages work because by then the
-                # subscriber is fully attached). See the codex_native catch-up
-                # race investigation 2026-06-06.
+                # before POSTing, so the broadcast lands on an attached
+                # subscription and the prompt is delivered in order. See the
+                # codex_native catch-up race investigation 2026-06-06. The
+                # wait is an optimisation, not the correctness guarantee —
+                # ``mark_as_read=False`` below covers the timeout path.
                 if self._ws_client is not None:
                     ready = await asyncio.to_thread(
                         self._ws_client.wait_until_ready, 10.0
@@ -371,9 +370,17 @@ class CodexNativeRunner:
                             "POSTing initial prompt anyway"
                         )
                 try:
+                    # ``mark_as_read=False`` is load-bearing — see the long
+                    # comment on the same POST in ``claude_code.initialize``.
+                    # The default (True) points the server's
+                    # ``last_read_message_id`` at this row, and the catch-up
+                    # cursor fallback then excludes the prompt from its own
+                    # recovery, hanging the session forever when the
+                    # ``ready`` wait above timed out.
                     await self.vicoa_client.send_user_message(
                         agent_instance_id=self.session_id,
                         content=self.initial_prompt,
+                        mark_as_read=False,
                     )
                 except Exception:
                     logger.exception(

--- a/backend/src/integrations/headless/tests/test_initial_prompt_catch_up.py
+++ b/backend/src/integrations/headless/tests/test_initial_prompt_catch_up.py
@@ -1,0 +1,91 @@
+"""The initial-prompt POST must not consume its own catch-up cursor.
+
+Every wrapper POSTs its ``initial_prompt`` as a user message and then waits
+for the row to come back over the session WebSocket — there is no direct
+hand-off into the turn queue. Two legs deliver it: the live ``new-message``
+broadcast, and the catch-up ``fetch_messages_request`` issued on connect (and
+re-issued by the 10s reconcile backstop).
+
+``send_user_message`` defaults to ``mark_as_read=True``, which points the
+instance's ``last_read_message_id`` at the row it just created. The
+session-scoped catch-up falls back to that cursor when the client has no
+watermark and selects strictly ``created_at > cursor`` — so a prompt marked
+read excludes *itself* from every later catch-up. If the live broadcast also
+missed it (the ``wait_until_ready`` timeout branch, hit when the WS handshake
+outruns 10s), neither leg can deliver it and the session hangs until a human
+interrupts. Observed on session c0d25529-… : 6h+ idle, thousands of backstop
+re-fetches all returning zero rows.
+
+So ``mark_as_read=False`` on that POST is load-bearing, in all three wrappers.
+It is one keyword argument that no runtime assertion in the happy path would
+miss, so it is pinned structurally. The server-side half of the invariant —
+that the cursor left alone actually recovers the prompt — is covered by
+``backend/tests/test_fetch_messages.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+
+import pytest
+
+# (module, the attribute the POST's ``content=`` is read from). The content
+# expression is what identifies the *initial-prompt* POST among a module's
+# other ``send_user_message`` calls.
+WRAPPERS = [
+    ("integrations.headless.claude_code", "initial_prompt"),
+    ("integrations.headless.codex_native", "initial_prompt"),
+    ("integrations.headless.acp_base", "initial_prompt"),
+]
+
+
+def _initial_prompt_posts(module_name: str, content_name: str) -> list[ast.Call]:
+    """Every ``send_user_message`` call in the module that sends the prompt."""
+    tree = ast.parse(inspect.getsource(importlib.import_module(module_name)))
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "send_user_message"):
+            continue
+        content = next((k for k in node.keywords if k.arg == "content"), None)
+        if content is None:
+            continue
+        # ``content=self.initial_prompt`` or ``content=initial_prompt``.
+        value = content.value
+        name = (
+            value.attr
+            if isinstance(value, ast.Attribute)
+            else value.id
+            if isinstance(value, ast.Name)
+            else None
+        )
+        if name == content_name:
+            calls.append(node)
+    return calls
+
+
+@pytest.mark.parametrize("module_name,content_name", WRAPPERS)
+def test_initial_prompt_post_is_found(module_name: str, content_name: str) -> None:
+    # Guards the parametrised test below against silently matching nothing
+    # after a refactor renames the call or its content expression.
+    assert len(_initial_prompt_posts(module_name, content_name)) == 1
+
+
+@pytest.mark.parametrize("module_name,content_name", WRAPPERS)
+def test_initial_prompt_post_does_not_mark_itself_read(
+    module_name: str, content_name: str
+) -> None:
+    (call,) = _initial_prompt_posts(module_name, content_name)
+    mark_as_read = next((k for k in call.keywords if k.arg == "mark_as_read"), None)
+
+    assert mark_as_read is not None, (
+        f"{module_name}: the initial-prompt POST must pass mark_as_read=False; "
+        "the SDK default (True) makes the prompt invisible to its own catch-up "
+        "recovery and hangs the session when the live broadcast is missed."
+    )
+    assert isinstance(mark_as_read.value, ast.Constant)
+    assert mark_as_read.value.value is False

--- a/backend/tests/test_fetch_messages.py
+++ b/backend/tests/test_fetch_messages.py
@@ -15,7 +15,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from servers.api.ws_handler import handle_fetch_messages_request
-from servers.shared.db.queries import fetch_session_messages
+from servers.shared.db.queries import create_user_message, fetch_session_messages
 from shared.database.enums import SenderType
 from shared.database.models import AgentInstance, Message, User, UserAgent
 from shared.database.session import SessionLocal
@@ -282,6 +282,77 @@ def test_session_scoped_no_watermark_returns_nothing_when_caught_up(
         result = fetch_session_messages(db, instance_id, after=None)
 
     assert result.rows == []
+
+
+@pytest.mark.parametrize("mark_as_read,recovered", [(True, False), (False, True)])
+def test_initial_prompt_is_recoverable_only_when_it_does_not_mark_itself_read(
+    session_instance: tuple[UUID, UUID],
+    mark_as_read: bool,
+    recovered: bool,
+) -> None:
+    # A wrapper POSTs its initial prompt and then waits for the row to come
+    # back over the WS. When the subscription is not attached yet the live
+    # broadcast is missed, leaving the cold-start catch-up (`after=None`) as
+    # the only delivery leg — including the 10s reconcile backstop, which
+    # replays the same query.
+    #
+    # `mark_as_read=True` points `last_read_message_id` at the row just
+    # created, and this fallback selects strictly `created_at > cursor`, so
+    # the prompt excludes *itself*: both legs miss it and the session hangs
+    # (c0d25529-…, 6h+ idle). Leaving the cursor alone makes catch-up recover
+    # it. Pins the reason `mark_as_read=False` is load-bearing at the three
+    # wrapper POST sites (see test_initial_prompt_catch_up.py).
+    user_id, instance_id = session_instance
+
+    with SessionLocal() as db:
+        create_user_message(
+            db,
+            agent_instance_id=str(instance_id),
+            content="the initial prompt",
+            user_id=str(user_id),
+            mark_as_read=mark_as_read,
+        )
+        db.commit()
+
+        result = fetch_session_messages(db, instance_id, after=None)
+
+    assert [row["content"] for row in result.rows] == (
+        ["the initial prompt"] if recovered else []
+    )
+
+
+def test_unread_prompt_recovery_does_not_replay_processed_history(
+    session_instance: tuple[UUID, UUID],
+    add_messages: Callable[[UUID, list[tuple]], list[UUID]],
+) -> None:
+    # The flip side of the test above: not marking the prompt read must not
+    # widen the catch-up back over turns the wrapper already ran. On a
+    # `--resume` the cursor still sits on the last processed message, so the
+    # fallback returns the prompt and nothing older.
+    user_id, instance_id = session_instance
+    ids = add_messages(
+        instance_id,
+        [
+            ("u1", BASE + timedelta(minutes=1), SenderType.USER),
+            ("agent-reply", BASE + timedelta(minutes=2), SenderType.AGENT),
+        ],
+    )
+
+    with SessionLocal() as db:
+        instance = db.query(AgentInstance).filter(AgentInstance.id == instance_id).one()
+        instance.last_read_message_id = ids[1]  # wrapper replied to u1
+        create_user_message(
+            db,
+            agent_instance_id=str(instance_id),
+            content="resume prompt",
+            user_id=str(user_id),
+            mark_as_read=False,
+        )
+        db.commit()
+
+        result = fetch_session_messages(db, instance_id, after=None)
+
+    assert [row["content"] for row in result.rows] == ["resume prompt"]
 
 
 def test_pagination_through_a_single_timestamp_neither_skips_nor_loops(


### PR DESCRIPTION
## The bug

A wrapper POSTs its `initial_prompt` as a user message and then waits for the row to come back over the session WebSocket — there is no direct hand-off into the turn queue. Two legs can deliver it:

1. the live `new-message` broadcast, and
2. the catch-up `fetch_messages_request` issued on connect (and re-issued every 10s by `_run_reconcile_backstop`).

`send_user_message` defaults to `mark_as_read=True` (`sdk/async_client.py:540`), which makes the server point `agent_instances.last_read_message_id` at the row it just created (`servers/shared/db/queries.py:892-893`). The session-scoped catch-up falls back to that cursor when the client has no watermark and selects strictly `created_at > cursor` (`queries.py:233-246`) — so **a prompt marked read excludes itself from every later catch-up**.

When the live broadcast also missed it — the `wait_until_ready(10.0)` timeout branch, hit when the WS handshake outruns 10s — neither leg can deliver it. The backstop then replays the identical empty query every 10s forever. The session sits idle and heartbeating, looking alive in the UI, until a human interrupts it.

Existing comments acknowledged the race but only narrowed the window with the 10s wait; they never closed it.

## Evidence

`~/.vicoa/claude_headless/c78b9378-….log`:

```
00:56:23  WARNING  WS catch-up not ready after 10s; POSTing initial prompt anyway
00:56:39  INFO     session WS connected (instance=c78b9378-…, watermark=None)   ← 16s after the POST
                   …… 6h25m of complete silence ……
07:21:42  INFO     Received control command: interrupt                          ← unstuck by hand
```

`watermark=None` is exactly the condition that sends catch-up down the `last_read_message_id` fallback.

Across local logs, 8 of 1161 claude sessions took the timeout branch. Of the 4 where the WS did eventually connect, **all 4 required manual intervention**:

| session | date | WS connected after POST | outcome |
|---|---|---|---|
| `c78b9378` | 08-26 | +16s | silent **6h25m** → interrupt |
| `c820f388` | 09-02 | +8s | silent **8m17s** → interrupt |
| `5df9d2d4` | 08-29 | +16s | silent **3m44s** → interrupt |
| `47562935` | 09-03 | +12s | silent 72s → ran a different input |

Not Claude-specific: `codex_native` and `acp_base` (gemini / cursor / copilot / kimi) use the same pattern.

## The fix

Pass `mark_as_read=False` on the initial-prompt POST in all three wrappers. Verified safe:

- **No double delivery.** `CatchUpBuffer._seen` (`session_ws_client.py:72-80`) dedupes by message id and persists across reconnects for the process lifetime. The `acp_base` comment claiming `mark_as_read=True` is what prevents double delivery was stale — corrected here.
- **No history replay.** Any agent message advances `last_read_message_id` (`queries.py:566`), so the cursor moves past the prompt as soon as the first turn produces output.
- **Strictly better on crash.** Today `True` silently *drops* the prompt if the wrapper restarts before replying; `False` recovers it.

The `wait_until_ready(10.0)` waits stay (they keep message ordering), but the comments now say plainly that the wait is an optimisation and `mark_as_read=False` is the correctness guarantee.

## Tests

- `backend/src/integrations/headless/tests/test_initial_prompt_catch_up.py` (new) — AST-parses all three wrappers and pins that the initial-prompt `send_user_message` passes `mark_as_read=False`. Verified it actually catches regressions: removing the keyword from `claude_code.py` turns it red.
- `backend/tests/test_fetch_messages.py` — three DB-backed cases through the real `create_user_message` → `fetch_session_messages(after=None)` path: `True` returns 0 rows, `False` recovers the prompt, and recovery does not replay already-processed history.

Checks: `make lint` clean (ruff + pyright + WS freeze check), `make test-unit` 1999 passed / 1 skipped, `tests/test_fetch_messages.py` 19 passed, `pnpm lint` clean.

No schema change, no migration.

## Also included

Second commit bumps the marketing header's GitHub icon from 20px to 24px — it sat visually smaller than the neighbouring menu and avatar controls.