### PR TITLE
web: render prepaid billing providers (coinpay) on the settings page

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -359,6 +359,20 @@ usually want:
 - **`TWILIO_*`** — SMS/email when an agent is waiting on you.
 - **`SENTRY_DSN`** — error tracking.
 
+### Billing
+
+Vicoa's own billing is closed, but the seam it plugs into is open: on start,
+`backend/main.py` imports a Python package named `cloud` if one is on
+`PYTHONPATH` and lets it mount routers and register hooks
+(`backend/src/shared/hooks.py`). The backend `Dockerfile` takes an
+`OVERLAY_SRC` build arg that copies such a package into the image, and the web,
+desktop and mobile clients already call `/api/v1/billing/*`, so an overlay can
+turn the Upgrade button into a real checkout without touching this repo.
+
+One community overlay exists:
+[vicoa-coinpay-overlay](https://github.com/profullstack/vicoa-coinpay-overlay)
+sells prepaid Pro passes for crypto through CoinPay (`provider: "coinpay"`).
+
 ## Troubleshooting
 
 **The dashboard loads but nothing updates live.** The realtime bridge is

--- a/apps/web/app/dashboard/settings/billing-settings-section.tsx
+++ b/apps/web/app/dashboard/settings/billing-settings-section.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getBackendAPI, type BillingSubscription } from '@/lib/backend-api';
 import posthog from 'posthog-js';
-import { getBillingPlanLabel } from '@/lib/billing';
+import { describePrepaidPass, getBillingPlanLabel, isPrepaidProvider } from '@/lib/billing';
 
 const freePlanFeatures = [
   'Web & mobile access',
@@ -76,6 +76,8 @@ export function BillingSettingsSection({
   const isStripePro = billingSubscription?.plan_type === 'pro' && billingSubscription.provider === 'stripe';
   const isMobileStorePro = billingSubscription?.plan_type === 'pro'
     && (billingSubscription.provider === 'apple' || billingSubscription.provider === 'google');
+  const isPrepaidPro = billingSubscription?.plan_type === 'pro'
+    && isPrepaidProvider(billingSubscription.provider);
 
   return (
     <Card>
@@ -163,6 +165,35 @@ export function BillingSettingsSection({
                 ? 'Your subscription is managed in the App Store.'
                 : 'Your subscription is managed in the Google Play Store.'}
             </p>
+          </div>
+        ) : isPrepaidPro && billingSubscription ? (
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-base font-medium text-foreground">
+                Pro Plan
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {describePrepaidPass(billingSubscription)}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              className="cursor-pointer"
+              onClick={handleOpenPortal}
+              disabled={billingAction !== null}
+            >
+              {billingAction === 'portal' ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Opening
+                </>
+              ) : (
+                <>
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Extend pass
+                </>
+              )}
+            </Button>
           </div>
         ) : (
           <div>

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -311,7 +311,12 @@ export interface BillingSubscription {
   agent_limit: number;
   current_period_end: string | null;
   cancel_at_period_end: boolean;
-  provider: 'stripe' | 'apple' | 'google' | null;
+  /**
+   * Who took the money. `stripe` and the app stores renew on their own;
+   * `coinpay` is a prepaid pass (a self-hosted billing overlay) that simply
+   * ends at `current_period_end` unless the user buys more time.
+   */
+  provider: 'stripe' | 'apple' | 'google' | 'coinpay' | null;
 }
 
 export interface BillingUsage {

--- a/apps/web/lib/billing.test.ts
+++ b/apps/web/lib/billing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describePrepaidPass,
+  formatBillingDate,
+  getBillingPlanLabel,
+  getBillingProviderLabel,
+  isPrepaidProvider,
+} from './billing';
+
+describe('billing labels', () => {
+  it('maps plan types and falls back to the raw value', () => {
+    expect(getBillingPlanLabel()).toBe('Free');
+    expect(getBillingPlanLabel('pro')).toBe('Pro');
+    expect(getBillingPlanLabel('team')).toBe('team');
+  });
+
+  it('names every provider the backend can report', () => {
+    expect(getBillingProviderLabel('stripe')).toBe('Stripe');
+    expect(getBillingProviderLabel('apple')).toBe('App Store');
+    expect(getBillingProviderLabel('google')).toBe('Google Play');
+    expect(getBillingProviderLabel('coinpay')).toBe('CoinPay');
+    expect(getBillingProviderLabel(null)).toBeNull();
+  });
+});
+
+describe('prepaid providers', () => {
+  it('only coinpay is prepaid', () => {
+    expect(isPrepaidProvider('coinpay')).toBe(true);
+    expect(isPrepaidProvider('stripe')).toBe(false);
+    expect(isPrepaidProvider(null)).toBe(false);
+  });
+
+  it('describes a running pass, a cancelled pass, and an open-ended one', () => {
+    const ends = formatBillingDate('2026-10-05T12:00:00Z');
+    expect(ends).toMatch(/2026/);
+    expect(
+      describePrepaidPass({ provider: 'coinpay', current_period_end: '2026-10-05T12:00:00Z', cancel_at_period_end: false })
+    ).toBe(`Paid through CoinPay. Your pass runs until ${ends}; extend it any time to add more days.`);
+    expect(
+      describePrepaidPass({ provider: 'coinpay', current_period_end: '2026-10-05T12:00:00Z', cancel_at_period_end: true })
+    ).toBe(`Paid through CoinPay. Your pass ends on ${ends}.`);
+    expect(
+      describePrepaidPass({ provider: 'coinpay', current_period_end: null, cancel_at_period_end: false })
+    ).toBe('Paid through CoinPay. Nothing renews on its own.');
+  });
+});

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -24,9 +24,34 @@ export function getBillingProviderLabel(
       return 'App Store';
     case 'google':
       return 'Google Play';
+    case 'coinpay':
+      return 'CoinPay';
     default:
       return null;
   }
+}
+
+/**
+ * A prepaid provider cannot charge again: the pass ends at
+ * `current_period_end` and "manage" means "buy more time", which the backend
+ * serves through the portal endpoint as a fresh checkout.
+ */
+export function isPrepaidProvider(provider?: BillingSubscription['provider']) {
+  return provider === 'coinpay';
+}
+
+/** One line for the settings page: when a prepaid pass ends, and whether it is meant to be renewed. */
+export function describePrepaidPass(
+  subscription: Pick<BillingSubscription, 'provider' | 'current_period_end' | 'cancel_at_period_end'>
+) {
+  const provider = getBillingProviderLabel(subscription.provider) ?? 'crypto';
+  const ends = formatBillingDate(subscription.current_period_end);
+  if (!ends) {
+    return `Paid through ${provider}. Nothing renews on its own.`;
+  }
+  return subscription.cancel_at_period_end
+    ? `Paid through ${provider}. Your pass ends on ${ends}.`
+    : `Paid through ${provider}. Your pass runs until ${ends}; extend it any time to add more days.`;
 }
 
 export function formatBillingDate(value?: string | null) {

--- a/apps/web/lib/desktop-paywall.ts
+++ b/apps/web/lib/desktop-paywall.ts
@@ -3,7 +3,7 @@
  *
  * Entitlement is `plan_type === 'pro'` — there is no `is_pro` boolean. The
  * backend keeps ONE `subscriptions` row per user with a `provider` column
- * (`stripe | apple | google`), so an existing iOS/Android subscriber already
+ * (`stripe | apple | google | coinpay`), so an existing iOS/Android subscriber already
  * resolves as pro here and is never re-prompted. No mobile-specific check
  * needed.
  *


### PR DESCRIPTION
## What

The billing card on `/dashboard/settings` branches on `subscription.provider` and knows `stripe`, `apple` and `google`. Anything else lands on the fallback: "Billing information is available, but this subscription type is not yet configurable here."

Self-hosted deployments can plug billing into the backend's `cloud` overlay slot (`find_spec("cloud")` in `backend/main.py` plus the hooks in `shared/hooks.py` and the Dockerfile's `OVERLAY_SRC`). The first such overlay, [vicoa-coinpay-overlay](https://github.com/profullstack/vicoa-coinpay-overlay), reports `provider: "coinpay"`: a prepaid crypto pass that ends at `current_period_end` rather than renewing. This PR makes the web render that case properly.

- `lib/backend-api.ts`: add `'coinpay'` to the `provider` union, with a comment on what a prepaid provider means.
- `lib/billing.ts`: `getBillingProviderLabel('coinpay')`, plus `isPrepaidProvider()` and `describePrepaidPass()` (end date, and whether the pass is set to lapse via `cancel_at_period_end`).
- `billing-settings-section.tsx`: a prepaid branch showing "Pro Plan", the pass description, and an **Extend pass** button. It reuses `handleOpenPortal`; a prepaid overlay answers `POST /billing/portal` with a fresh checkout URL, so "manage" naturally means "buy more time".
- `lib/billing.test.ts`: unit coverage for the helpers.
- `SELF_HOSTING.md`: a short "Billing" note under Optional integrations documenting the overlay seam, which was not written down anywhere.
- `lib/desktop-paywall.ts`: comment only.

Stripe and app-store users see no change; the new branch sits after theirs.

## Migrations / env vars

None. The backend already stores `provider` as free text; vicoa.ai's own overlay is untouched.

## Verified

- `vitest run lib/billing.test.ts`: 4 passing.
- `tsc --noEmit` (after `fumadocs-mdx` generated `.source`): clean.
- `node scripts/check-theme-colors.mjs`: clean.
- The overlay's own integration suite drives the real `/api/v1/billing/*` contract this UI reads (subscription row with `provider: "coinpay"`, `current_period_end`, `cancel_at_period_end`, portal returning a checkout URL).

Not verified: I could not capture a screenshot of the new branch, since rendering `/dashboard/settings` needs a signed-in session against a backend reporting a CoinPay subscription. The branch is a copy of the Stripe block's layout with different copy and button text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtrzgpYQVreqBJMjRtzD4m
