### PR TITLE
Copy and fork actions on chat messages

### DIFF
--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, useMemo, useSyncExternalStore } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { AgentTypeIcon } from '@/components/dashboard/agent-type-icon';
 import { Button } from '@/components/ui/button';
@@ -26,6 +26,7 @@ import { MessageItem, resolveAgentType, DateSeparator, ThinkingIndicator, vibing
 import { ChatFindBar } from '@/components/dashboard/chat-find-bar';
 import { FindHighlightProvider } from '@/components/dashboard/chat-find-context';
 import { groupSubagents } from '@/components/dashboard/subagent-grouping';
+import { buildForkTranscript, saveForkContext } from '@/lib/fork-session';
 import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
 import { FilesGitPanel, FilesGitPanelToggle, usePanelState, type PanelPendingAction } from '@/components/files-git-panel';
 import { ChatInput, PermissionModeValue, OpencodeAgentModeValue, type ChatUploadedAttachment, type ChatInputHandle } from '@/components/chat-input';
@@ -177,6 +178,7 @@ const STICK_TOLERANCE_PX = 72;
 
 function AgentInstanceContent() {
   const params = useParams();
+  const router = useRouter();
   const instanceId = params.instanceId as string;
   const dashboardContext = useAgentDashboard();
   const { refreshData, updateInstanceStatus } = dashboardContext;
@@ -1277,6 +1279,42 @@ function AgentInstanceContent() {
 
   // Memoize grouped messages to avoid re-grouping on every render
   const groupedMessages = useMemo(() => groupMessagesByDate(orderedVisibleMessages), [orderedVisibleMessages]);
+
+  // Fork: open the new-session page carrying the transcript up to this agent
+  // message as a chat-history attachment, on the same machine/folder/agent so
+  // the new run picks up where the old one left off (see lib/fork-session.ts).
+  const handleForkMessage = useCallback(
+    (message: MessageResponse) => {
+      const detail = instance;
+      if (!detail) return;
+      const { text, messageCount } = buildForkTranscript({
+        messages: orderedVisibleMessages,
+        boundaryMessageId: message.id,
+        agentType: resolveAgentType(detail.agent_type_name || undefined),
+        sourceTitle: detail.name,
+        sourceDirectory: toAbsolutePath(detail.project, detail.home_dir),
+      });
+      saveForkContext({
+        text,
+        messageCount,
+        sourceInstanceId: instanceId,
+        sourceTitle: detail.name || 'Untitled session',
+      });
+      const query = new URLSearchParams({ fork: '1' });
+      if (detail.project) query.set('directory', detail.project);
+      if (detail.machine_id) query.set('machineId', detail.machine_id);
+      // `session_config.agent` is the catalog id the daemon was spawned with;
+      // `agent_type_name` is the editable row name and only a fallback (same
+      // precedence the session gear uses below).
+      const configuredAgent =
+        typeof detail.session_config?.agent === 'string' ? detail.session_config.agent.trim().toLowerCase() : '';
+      const forkAgent =
+        configuredAgent || (detail.agent_type_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      if (forkAgent) query.set('agent', forkAgent);
+      router.push(`/dashboard/agents/new-session?${query.toString()}`);
+    },
+    [instance, instanceId, orderedVisibleMessages, router],
+  );
 
   // Focus mode: the files/git panel covers the transcript as a full-width layer
   // between the header and composer (see the render below). Derived from the
@@ -2387,6 +2425,7 @@ function AgentInstanceContent() {
                     onOptionClick={handleOptionClick}
                     onAskUserQuestionSubmit={handleAskUserQuestionSubmit}
                     onAskUserQuestionCancel={handleAskUserQuestionCancel}
+                    onFork={handleForkMessage}
                     agentTypeName={instance.agent_type_name}
                     projectPath={projectRootPath}
                   />

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -20,13 +20,14 @@ import { getMessageStore } from '@/lib/message-store';
 import { useMessageStream } from '@/lib/hooks/use-ws-stream';
 import { extractMessageOptions, formatTaskNotifications } from '@/components/ui/message-markdown-utils';
 import { GitBranchBadge } from '@/components/dashboard/git-branch-badge';
-import { ToolUseGroup, parseToolUse } from '@/components/dashboard/tool-use-display';
+import { ToolUseGroup, isToolUseContent, parseToolUse } from '@/components/dashboard/tool-use-display';
 import { SubagentGroup } from '@/components/dashboard/subagent-group';
 import { MessageItem, resolveAgentType, DateSeparator, ThinkingIndicator, vibingMessages, getMessageVisibleText } from '@/components/dashboard/chat-message-item';
 import { ChatFindBar } from '@/components/dashboard/chat-find-bar';
 import { FindHighlightProvider } from '@/components/dashboard/chat-find-context';
 import { groupSubagents } from '@/components/dashboard/subagent-grouping';
 import { buildForkTranscript, saveForkContext } from '@/lib/fork-session';
+import { computeTurnEnds, type TurnMessageEntry } from '@/lib/agent-turns';
 import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
 import { FilesGitPanel, FilesGitPanelToggle, usePanelState, type PanelPendingAction } from '@/components/files-git-panel';
 import { ChatInput, PermissionModeValue, OpencodeAgentModeValue, type ChatUploadedAttachment, type ChatInputHandle } from '@/components/chat-input';
@@ -1393,6 +1394,26 @@ function AgentInstanceContent() {
     return items;
   }, [groupedMessages, showThinking, thinkingSettingEnabled, instance?.agent_type_name]);
 
+  // Turn-end lookup for the hover footer: only the last agent message of each
+  // run since the previous user message carries copy/fork, and copying it
+  // yields that whole turn. Derived from `chatItems` rather than the raw
+  // messages so it sees exactly what renders — anything folded into a
+  // tool-group or a thinking card is inside the turn but never anchors it.
+  const turnCopyText = useMemo(() => {
+    const entries: TurnMessageEntry[] = [];
+    for (const item of chatItems) {
+      if (item.type !== 'message') continue;
+      const text = getMessageVisibleText(item.message);
+      const kind: TurnMessageEntry['kind'] = USER_SENDER_TYPES.has(item.message.sender_type)
+        ? 'user'
+        : parseThinkingPayload(item.message) || isToolUseContent(text)
+          ? 'other'
+          : 'agent';
+      entries.push({ id: item.message.id, kind, text });
+    }
+    return computeTurnEnds(entries);
+  }, [chatItems]);
+
   // Whether the list has any real message rows. A lone "thinking" item doesn't
   // count — we render the SessionEmptyState (not the virtual list) until a real
   // message arrives, so the Virtuoso-tied overlays/buttons gate on this too.
@@ -2426,6 +2447,7 @@ function AgentInstanceContent() {
                     onAskUserQuestionSubmit={handleAskUserQuestionSubmit}
                     onAskUserQuestionCancel={handleAskUserQuestionCancel}
                     onFork={handleForkMessage}
+                    turnCopyText={turnCopyText.get(item.message.id)}
                     agentTypeName={instance.agent_type_name}
                     projectPath={projectRootPath}
                   />

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -70,6 +70,7 @@ import {
   type WorktreeMode,
 } from '@/lib/worktree-selection';
 import { loadPromptDraft, savePromptDraft, clearPromptDraft } from '@/lib/new-session-draft';
+import { clearForkContext, loadForkContext, type ForkContext } from '@/lib/fork-session';
 import { currentPathname, openCreatedSession } from '@/lib/new-session-navigation';
 import { getDesktopConfig } from '@/lib/runtime-config';
 import { DRAG_REGION, NO_DRAG } from '@/lib/app-region';
@@ -78,6 +79,7 @@ import { comboInline, getShortcutCombo, matchesShortcut } from '@/lib/desktop-sh
 import { getDesktopShellBridge } from '@/lib/desktop-shell';
 import { collectComposerDrop, folderPathToMention } from '@/lib/chat-drop';
 import { FolderRefChip } from '@/components/folder-ref-chip';
+import { ForkContextChip } from '@/components/dashboard/fork-context-chip';
 import { postInstanceMessage } from '@/lib/agent-instance-api';
 import { MAX_ATTACHMENTS_PER_MESSAGE, MAX_ATTACHMENT_BYTES, type ChatUploadedAttachment } from '@/components/chat-input';
 import { formatFileSize } from '@/components/chat-attachments';
@@ -253,9 +255,20 @@ function NewSessionContent() {
       return dir && branch ? { path: dir, branch } : null;
     })(),
   );
+  // `?machineId=` / `?agent=` come from a fork (the chat page's per-message
+  // fork button): a forked session must land on the SAME machine and agent as
+  // the session it continues, otherwise the carried-over paths are meaningless.
+  // Machine is snapshotted into a ref and consumed once by loadMachines, like
+  // `?directory=`; agent is applied in the config-hydration effect below.
+  const pendingMachineRef = useRef<string | null>(searchParams.get('machineId'));
+  const agentParam = searchParams.get('agent');
+  // `?fork=1` marks the chat-history payload in sessionStorage as ours to pick
+  // up (kept out of the URL — a transcript is far too big for a query string).
+  const forkParam = searchParams.get('fork');
+
   // `?taskId=` (the Tasks page's "Start session" action) preselects the Task
   // chip. Read reactively rather than snapshotted into a ref at first render
-  // like the two above: this page renders inside a Suspense boundary under PPR
+  // like the link params above: this page renders inside a Suspense boundary under PPR
   // (`experimental.ppr`, next.config.ts), so `useSearchParams()` can resolve a
   // render late and a first-render snapshot latches `null` and drops the link.
   // `consumedTaskIdRef` keeps it single-shot — once loaded, clearing the chip
@@ -311,6 +324,9 @@ function NewSessionContent() {
   // basename is just the repo name, so it can't stand in for the branch).
   const [selectedWorktreeBranch, setSelectedWorktreeBranch] = useState<string | null>(null);
   const [prompt, setPrompt] = useState('');
+  // Chat history carried over by a fork, shown as a removable composer chip and
+  // prepended to the first message on submit.
+  const [forkContext, setForkContext] = useState<ForkContext | null>(null);
   // Task seeding this session (plan §6): its title/description + chosen sub-tasks
   // top the first prompt, and the spawned instance is linked back via task_id.
   const [selectedTask, setSelectedTask] = useState<TaskResponse | null>(null);
@@ -506,9 +522,15 @@ function NewSessionContent() {
         : defaultsFor(AGENT_CATALOG_FALLBACK, agent.id);
     }
     setPerAgentConfigs(next);
-    if (persisted.lastAgent && next[persisted.lastAgent]) {
+    // A forked session keeps the source session's agent; otherwise resume the
+    // last one used.
+    if (agentParam && next[agentParam]) {
+      setActiveAgent(agentParam);
+    } else if (persisted.lastAgent && next[persisted.lastAgent]) {
       setActiveAgent(persisted.lastAgent);
     }
+    // Run once on mount; `agentParam` is a link parameter, not live state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Background catalog fetch — reconcile per-agent configs against the live
@@ -632,12 +654,21 @@ function NewSessionContent() {
         const persisted = loadPersistedSelection();
         const persistedMatch = sorted.find((m) => m.machine_id === persisted.lastMachineId);
         const firstOnline = sorted.find(isMachineOnline);
-        // Prefer persisted if it's still online; otherwise the first online;
-        // otherwise the first machine in the list (which is offline).
+        // A `?machineId=` link (fork) pins the machine, even offline — landing
+        // on a different machine would silently point the carried directory at
+        // a path that doesn't exist there.
+        const pendingMachineId = pendingMachineRef.current;
+        pendingMachineRef.current = null;
+        const pendingMachineMatch = pendingMachineId
+          ? sorted.find((m) => m.machine_id === pendingMachineId)
+          : undefined;
+        // Otherwise prefer persisted if it's still online; then the first
+        // online; otherwise the first machine in the list (which is offline).
         const preferredMachine =
-          persistedMatch && isMachineOnline(persistedMatch)
+          pendingMachineMatch ??
+          (persistedMatch && isMachineOnline(persistedMatch)
             ? persistedMatch
-            : firstOnline ?? sorted[0];
+            : firstOnline ?? sorted[0]);
         setSelectedMachineId(preferredMachine.machine_id);
         const pendingDirectory = pendingDirectoryRef.current;
         pendingDirectoryRef.current = null;
@@ -916,6 +947,23 @@ function NewSessionContent() {
     // this before its declaration below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, router]);
+
+  // Pick up the transcript a fork left in sessionStorage. Kept there (rather
+  // than cleared on read) so a reload of this `?fork=1` URL restores the chip;
+  // it is dropped when the session actually spawns, or when the user removes
+  // the chip.
+  const consumedForkRef = useRef(false);
+  useEffect(() => {
+    if (consumedForkRef.current || forkParam !== '1') return;
+    consumedForkRef.current = true;
+    const stored = loadForkContext();
+    if (stored) setForkContext(stored);
+  }, [forkParam]);
+
+  const removeForkContext = useCallback(() => {
+    setForkContext(null);
+    clearForkContext();
+  }, []);
 
   // A worktree selection is tied to a specific machine + directory; clear it
   // whenever either changes so a stale path can't carry into a different repo.
@@ -1202,7 +1250,12 @@ function NewSessionContent() {
       const folderText = pendingFolderRefs
         .map((p) => `@${folderPathToMention(p, projectPath)}`)
         .join(' ');
-      const finalPrompt = [composedPrompt, folderText].filter(Boolean).join(' ');
+      const typedPrompt = [composedPrompt, folderText].filter(Boolean).join(' ');
+      // A fork opens with the source transcript above whatever the user typed,
+      // so the new agent reads the history first and the instruction last.
+      const finalPrompt = forkContext
+        ? [forkContext.text, typedPrompt].filter(Boolean).join('\n\n')
+        : typedPrompt;
       const images = pendingImages;
 
       // With images attached the prompt can NOT ride along in the spawn
@@ -1241,6 +1294,9 @@ function NewSessionContent() {
       }
       persistSelection();
       clearPromptDraft();
+      // The forked history is consumed by this spawn.
+      clearForkContext();
+      setForkContext(null);
       // The task is consumed by this spawn — forget it so the next visit starts
       // task-free (machine/directory/worktree intentionally persist as context).
       restoredTaskIdRef.current = '';
@@ -1363,7 +1419,7 @@ function NewSessionContent() {
       setErrorMessage(message);
       setIsSubmitting(false);
     }
-  }, [api, selectedMachineId, directory, sessionConfig, prompt, selectedTask, subtasks, pendingImages, pendingFolderRefs, machines, isSubmitting, worktreeMode, selectedWorktreePath, persistSelection, refreshData, router]);
+  }, [api, selectedMachineId, directory, sessionConfig, prompt, selectedTask, subtasks, pendingImages, pendingFolderRefs, forkContext, machines, isSubmitting, worktreeMode, selectedWorktreePath, persistSelection, refreshData, router]);
 
   // Insert the highlighted command into the prompt (vs. the chat input, which
   // sends immediately — starting a session is heavier, so we let the user
@@ -1758,8 +1814,15 @@ function NewSessionContent() {
               {/* Pending attachments — previews only; these upload after the
                   session exists (see handleSubmit). Folder chips reference a
                   path and fold into the prompt on submit. */}
-              {(pendingImages.length > 0 || pendingFolderRefs.length > 0) && (
+              {(pendingImages.length > 0 || pendingFolderRefs.length > 0 || !!forkContext) && (
                 <div className="flex items-center gap-2 mb-2 flex-wrap">
+                  {forkContext && (
+                    <ForkContextChip
+                      title={forkContext.sourceTitle}
+                      messageCount={forkContext.messageCount}
+                      onRemove={removeForkContext}
+                    />
+                  )}
                   {pendingFolderRefs.map((path) => (
                     <FolderRefChip key={path} path={path} onRemove={() => removeFolderRef(path)} />
                   ))}

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -10,6 +10,7 @@ import { AskUserQuestionPanel, type AskUserQuestionSubmitPayload, parseAskUserQu
 import { ChatAttachments, extractChatAttachments } from '@/components/chat-attachments';
 import { StandaloneThinkingCard, parseThinkingPayload } from '@/components/dashboard/thinking-card';
 import { CollapsibleUserMessage } from '@/components/dashboard/collapsible-user-message';
+import { MessageActions } from '@/components/dashboard/message-actions';
 import { stripPermissionModeCommandTokens } from '@/lib/session-control-messages';
 import { CONTROL_COMMAND_JSON_REGEX, isControlEnvelope } from '@/lib/control-messages';
 import { HighlightedText, useFindHighlight } from '@/components/dashboard/chat-find-context';
@@ -67,11 +68,14 @@ export function resolveAgentType(agentTypeName?: string): UiAgentType {
   return 'claude';
 }
 
-export const MessageItem = memo(function MessageItem({ message, onOptionClick, onAskUserQuestionSubmit, onAskUserQuestionCancel, agentTypeName, projectPath, compact = false }: {
+export const MessageItem = memo(function MessageItem({ message, onOptionClick, onAskUserQuestionSubmit, onAskUserQuestionCancel, onFork, agentTypeName, projectPath, compact = false }: {
   message: MessageResponse;
   onOptionClick?: (option: string) => void;
   onAskUserQuestionSubmit?: (payload: AskUserQuestionSubmitPayload) => void;
   onAskUserQuestionCancel?: (messageId: string) => void;
+  // Start a new session seeded with the transcript up to this agent message.
+  // Absent on user rows and on sub-agent children (they aren't fork points).
+  onFork?: (message: MessageResponse) => void;
   agentTypeName?: string;
   /** Project root, so tool-use file paths render relative to it. */
   projectPath?: string | null;
@@ -135,9 +139,14 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
     !isUser || attachments.length === 0 ||
     !!userVisibleContent.trim() || !!askUserQuestion || options.length > 0;
 
+  // Tool-use fallback rows are their own affordance (expand/collapse) and
+  // carry no prose worth copying or forking from.
+  const isToolRow = !isUser && isToolUseContent(userVisibleContent);
+  const showActions = !compact && !isToolRow;
+
   return (
     <div
-      className={`flex gap-3 ${
+      className={`group/message flex gap-3 ${
         isUser
           ? compact ? 'justify-end' : 'justify-end mt-6 mb-6'
           : compact ? 'justify-start' : 'justify-start mb-1'
@@ -219,6 +228,14 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
                 </div>
               )}
             </div>
+          )}
+          {showActions && (
+            <MessageActions
+              timestamp={message.created_at}
+              text={userVisibleContent}
+              onFork={!isUser && onFork ? () => onFork(message) : undefined}
+              align={isUser ? 'right' : 'left'}
+            />
           )}
         </div>
       </div>

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -68,7 +68,7 @@ export function resolveAgentType(agentTypeName?: string): UiAgentType {
   return 'claude';
 }
 
-export const MessageItem = memo(function MessageItem({ message, onOptionClick, onAskUserQuestionSubmit, onAskUserQuestionCancel, onFork, agentTypeName, projectPath, compact = false }: {
+export const MessageItem = memo(function MessageItem({ message, onOptionClick, onAskUserQuestionSubmit, onAskUserQuestionCancel, onFork, turnCopyText, agentTypeName, projectPath, compact = false }: {
   message: MessageResponse;
   onOptionClick?: (option: string) => void;
   onAskUserQuestionSubmit?: (payload: AskUserQuestionSubmitPayload) => void;
@@ -76,6 +76,11 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
   // Start a new session seeded with the transcript up to this agent message.
   // Absent on user rows and on sub-agent children (they aren't fork points).
   onFork?: (message: MessageResponse) => void;
+  // Set only on the message that ENDS an agent turn, to the whole turn's prose
+  // (see lib/agent-turns.ts). Its presence is what gives an agent message a
+  // hover footer at all — mid-turn messages get none, so a run of agent
+  // messages stays as tight as it was before the footer existed.
+  turnCopyText?: string;
   agentTypeName?: string;
   /** Project root, so tool-use file paths render relative to it. */
   projectPath?: string | null;
@@ -140,9 +145,10 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
     !!userVisibleContent.trim() || !!askUserQuestion || options.length > 0;
 
   // Tool-use fallback rows are their own affordance (expand/collapse) and
-  // carry no prose worth copying or forking from.
+  // carry no prose worth copying or forking from. Every user message gets a
+  // footer; an agent message only gets one when it ends a turn.
   const isToolRow = !isUser && isToolUseContent(userVisibleContent);
-  const showActions = !compact && !isToolRow;
+  const showActions = !compact && !isToolRow && (isUser || turnCopyText !== undefined);
 
   return (
     <div
@@ -232,7 +238,7 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
           {showActions && (
             <MessageActions
               timestamp={message.created_at}
-              text={userVisibleContent}
+              text={turnCopyText ?? userVisibleContent}
               onFork={!isUser && onFork ? () => onFork(message) : undefined}
               align={isUser ? 'right' : 'left'}
             />

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -164,9 +164,7 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
             <Bot className="w-5 h-5 text-muted-foreground" />
           )}
         </div> */}
-        {/* `relative` anchors the hover footer, which floats below the bubble
-            rather than taking a row of its own (see MessageActions). */}
-        <div className={`relative flex min-w-0 flex-1 flex-col gap-1.5 ${isUser ? 'items-end' : 'items-stretch'}`}>
+        <div className={`flex min-w-0 flex-1 flex-col gap-1.5 ${isUser ? 'items-end' : 'items-stretch'}`}>
           {/* Images get their OWN bubble stacked above the text bubble, so an
               image + caption reads as two user messages rather than one. */}
           {attachments.length > 0 && (

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -164,7 +164,9 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
             <Bot className="w-5 h-5 text-muted-foreground" />
           )}
         </div> */}
-        <div className={`flex min-w-0 flex-1 flex-col gap-1.5 ${isUser ? 'items-end' : 'items-stretch'}`}>
+        {/* `relative` anchors the hover footer, which floats below the bubble
+            rather than taking a row of its own (see MessageActions). */}
+        <div className={`relative flex min-w-0 flex-1 flex-col gap-1.5 ${isUser ? 'items-end' : 'items-stretch'}`}>
           {/* Images get their OWN bubble stacked above the text bubble, so an
               image + caption reads as two user messages rather than one. */}
           {attachments.length > 0 && (

--- a/apps/web/components/dashboard/fork-context-chip.tsx
+++ b/apps/web/components/dashboard/fork-context-chip.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Split, X } from 'lucide-react';
+
+/**
+ * Chat history carried into the composer by a fork — the visual twin of the
+ * folder/file attachment chips, but it carries text: the source transcript is
+ * prepended to the first message at send time. Removing it starts the session
+ * with a clean slate.
+ */
+export function ForkContextChip({
+  title,
+  messageCount,
+  onRemove,
+}: {
+  title: string;
+  messageCount: number;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="relative">
+      <span
+        className="flex h-14 w-40 items-center gap-2 rounded-lg border border-border bg-muted-foreground/5 px-3"
+        title={`Chat history from ${title || 'an earlier session'}`}
+      >
+        <Split className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+        <span className="flex min-w-0 flex-col text-left">
+          <span className="truncate text-[11px] font-medium">{title || 'Chat history'}</span>
+          <span className="text-[10px] text-muted-foreground">
+            {messageCount} message{messageCount === 1 ? '' : 's'}
+          </span>
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute -top-1.5 -right-1.5 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border bg-background hover:bg-accent"
+        title="Remove chat history"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/message-actions.tsx
+++ b/apps/web/components/dashboard/message-actions.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Check, Copy, Split } from 'lucide-react';
+import { formatDateGroup, parseUTCTimestamp } from '@/lib/message-grouping';
+
+/**
+ * Local time for the message footer — bare "10:30 AM" today, and widening to
+ * "Yesterday …" / "Jan 15, …" / "Jan 15, 2024, …" as the message ages. Shares
+ * the date separators' formatter so both read alike.
+ */
+export function formatMessageTime(timestamp: string): string {
+  if (!timestamp) return '';
+  const date = parseUTCTimestamp(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return formatDateGroup(date);
+}
+
+const ACTION_BUTTON_CLASS =
+  'cursor-pointer rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+
+/**
+ * Hover-revealed footer under a chat bubble: copy, fork (agent turns only) and
+ * the message's time. The row is always in the layout and only fades in, so
+ * hovering never changes a row's height — Virtuoso would otherwise re-measure
+ * and shift the transcript under the cursor.
+ */
+export const MessageActions = memo(function MessageActions({
+  timestamp,
+  text,
+  onFork,
+  align,
+}: {
+  timestamp: string;
+  /** Text put on the clipboard — the message as rendered, not the raw payload. */
+  text: string;
+  /** Omitted for user messages: a fork always resumes from an agent turn. */
+  onFork?: () => void;
+  align: 'left' | 'right';
+}) {
+  const [copied, setCopied] = useState(false);
+  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (resetRef.current) clearTimeout(resetRef.current);
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (resetRef.current) clearTimeout(resetRef.current);
+      resetRef.current = setTimeout(() => setCopied(false), 1800);
+    } catch {
+      // Clipboard can be blocked (insecure context / denied permission); the
+      // message stays selectable on screen.
+    }
+  }, [text]);
+
+  // An image-only message has no text to copy — it still gets a time.
+  const copyButton = text.trim() ? (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={copied ? 'Copied' : 'Copy message'}
+      aria-label={copied ? 'Copied' : 'Copy message'}
+      className={ACTION_BUTTON_CLASS}
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  ) : null;
+
+  const forkButton = onFork ? (
+    <button
+      type="button"
+      onClick={onFork}
+      title="Fork into a new session from here"
+      aria-label="Fork into a new session from here"
+      className={ACTION_BUTTON_CLASS}
+    >
+      <Split className="h-3.5 w-3.5" />
+    </button>
+  ) : null;
+
+  const time = (
+    <span className="px-1 font-mono text-[11px] text-muted-foreground/60">
+      {formatMessageTime(timestamp)}
+    </span>
+  );
+
+  return (
+    <div
+      className={`-mt-1 flex items-center gap-0.5 pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${
+        align === 'right' ? 'justify-end pr-3' : 'justify-start pl-3'
+      }`}
+    >
+      {/* Mirrored around the bubble's edge: the icons sit outermost either way,
+          so a user row reads "time, copy" and an agent row "copy, fork, time". */}
+      {align === 'right' ? (
+        <>
+          {time}
+          {copyButton}
+          {forkButton}
+        </>
+      ) : (
+        <>
+          {copyButton}
+          {forkButton}
+          {time}
+        </>
+      )}
+    </div>
+  );
+});

--- a/apps/web/components/dashboard/message-actions.tsx
+++ b/apps/web/components/dashboard/message-actions.tsx
@@ -21,14 +21,9 @@ const ACTION_BUTTON_CLASS =
 
 /**
  * Hover-revealed footer under a chat bubble: copy, fork (agent turns only) and
- * the message's time.
- *
- * Absolutely positioned, so it costs the transcript no vertical space at all —
- * reserving a row for it pushed every message 24px apart, and letting it into
- * the flow only on hover would make Virtuoso re-measure and shift rows under
- * the cursor. The trade-off is that it floats over the top of the next row
- * while visible, hence the toolbar chrome (surface + hairline + shadow) and the
- * z-index. Requires a `relative` parent carrying `group/message`.
+ * the message's time. The row is always in the layout and only fades in, so
+ * hovering never changes a row's height — Virtuoso would otherwise re-measure
+ * and shift the transcript under the cursor.
  */
 export const MessageActions = memo(function MessageActions({
   timestamp,
@@ -95,8 +90,8 @@ export const MessageActions = memo(function MessageActions({
 
   return (
     <div
-      className={`absolute top-full z-10 mt-0.5 flex items-center gap-0.5 rounded-md border border-border/60 bg-background px-0.5 shadow-sm pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${
-        align === 'right' ? 'right-2' : 'left-2'
+      className={`-mt-1 flex items-center gap-0.5 pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${
+        align === 'right' ? 'justify-end pr-3' : 'justify-start pl-3'
       }`}
     >
       {/* Mirrored around the bubble's edge: the icons sit outermost either way,

--- a/apps/web/components/dashboard/message-actions.tsx
+++ b/apps/web/components/dashboard/message-actions.tsx
@@ -20,10 +20,14 @@ const ACTION_BUTTON_CLASS =
   'cursor-pointer rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
 
 /**
- * Hover-revealed footer under a chat bubble: copy, fork (agent turns only) and
- * the message's time. The row is always in the layout and only fades in, so
- * hovering never changes a row's height — Virtuoso would otherwise re-measure
- * and shift the transcript under the cursor.
+ * Hover-revealed footer under a chat bubble: copy, fork and the message's time.
+ * Every user message gets one; on the agent side only the message that ends a
+ * turn does (see lib/agent-turns.ts), so a run of agent messages doesn't stack
+ * up a reserved row each.
+ *
+ * The row is always in the layout and only fades in, so hovering never changes
+ * a row's height — Virtuoso would otherwise re-measure and shift the transcript
+ * under the cursor.
  */
 export const MessageActions = memo(function MessageActions({
   timestamp,
@@ -32,7 +36,10 @@ export const MessageActions = memo(function MessageActions({
   align,
 }: {
   timestamp: string;
-  /** Text put on the clipboard — the message as rendered, not the raw payload. */
+  /**
+   * Text put on the clipboard — the message as rendered, not the raw payload.
+   * On an agent footer that is the whole turn, not just the final message.
+   */
   text: string;
   /** Omitted for user messages: a fork always resumes from an agent turn. */
   onFork?: () => void;

--- a/apps/web/components/dashboard/message-actions.tsx
+++ b/apps/web/components/dashboard/message-actions.tsx
@@ -21,9 +21,14 @@ const ACTION_BUTTON_CLASS =
 
 /**
  * Hover-revealed footer under a chat bubble: copy, fork (agent turns only) and
- * the message's time. The row is always in the layout and only fades in, so
- * hovering never changes a row's height — Virtuoso would otherwise re-measure
- * and shift the transcript under the cursor.
+ * the message's time.
+ *
+ * Absolutely positioned, so it costs the transcript no vertical space at all —
+ * reserving a row for it pushed every message 24px apart, and letting it into
+ * the flow only on hover would make Virtuoso re-measure and shift rows under
+ * the cursor. The trade-off is that it floats over the top of the next row
+ * while visible, hence the toolbar chrome (surface + hairline + shadow) and the
+ * z-index. Requires a `relative` parent carrying `group/message`.
  */
 export const MessageActions = memo(function MessageActions({
   timestamp,
@@ -90,8 +95,8 @@ export const MessageActions = memo(function MessageActions({
 
   return (
     <div
-      className={`-mt-1 flex items-center gap-0.5 pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${
-        align === 'right' ? 'justify-end pr-3' : 'justify-start pl-3'
+      className={`absolute top-full z-10 mt-0.5 flex items-center gap-0.5 rounded-md border border-border/60 bg-background px-0.5 shadow-sm pointer-events-none opacity-0 transition-opacity duration-150 group-hover/message:pointer-events-auto group-hover/message:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100 ${
+        align === 'right' ? 'right-2' : 'left-2'
       }`}
     >
       {/* Mirrored around the bubble's edge: the icons sit outermost either way,

--- a/apps/web/content/docs/changelog/desktop-app.mdx
+++ b/apps/web/content/docs/changelog/desktop-app.mdx
@@ -5,6 +5,17 @@ description: Release notes for the Vicoa desktop app (macOS, Windows) — new fe
 
 # Desktop App
 
+### v0.1.22
+6 September, 2026
+- Bundle Vicoa CLI daemon [v1.7.18](/docs/changelog/vicoa-cli#v1718)
+- Start sessions with Pi and Oh My Pi — both in the new-session picker, with their models, icons, and install checks
+- Open links in the terminal with ⌘/Ctrl+click
+- Find Vicoa's source on GitHub from inside the app and the site
+- Fix long worktree setup commands being truncated when typed into a fresh terminal, so setup chains actually run
+- Fix the files and git panel ignoring the light theme, and its separator sitting on top of dialogs
+- Show project icons in the Settings navigation and add a settings gear to the sidebar
+- Fix a session's awaiting-input dot staying lit after you'd viewed and left it
+
 ### v0.1.21
 3 September, 2026
 - Bundle Vicoa CLI daemon [v1.7.17](/docs/changelog/vicoa-cli#v1717)

--- a/apps/web/content/docs/changelog/vicoa-cli.mdx
+++ b/apps/web/content/docs/changelog/vicoa-cli.mdx
@@ -5,6 +5,12 @@ description: Release notes for the Vicoa CLI and daemon — new agent support, b
 
 # Vicoa CLI
 
+### v1.7.18
+6 September, 2026
+- Add native Pi and Oh My Pi (`omp`) support
+- Fix a session hanging idle forever after start: its `initial_prompt` was POSTed with `mark_as_read=True`, pointing the catch-up cursor at the prompt itself so every later replay excluded it — when the WebSocket handshake also outran the 10s live-broadcast wait, nothing could deliver it
+- Fix the Inbox auto-create race 500ing `/api/v1/projects`
+
 ### v1.7.17
 3 September, 2026
 - Add a declarative plugin system — `vicoa plugin` commands to scan, install (git clone or directory copy; never runs install scripts), enable, and trust Tier 1 plugins under `~/.vicoa/plugins/`

--- a/apps/web/lib/agent-turns.test.ts
+++ b/apps/web/lib/agent-turns.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { computeTurnEnds, type TurnMessageEntry } from './agent-turns';
+
+const user = (id: string, text = 'ask'): TurnMessageEntry => ({ id, kind: 'user', text });
+const agent = (id: string, text: string): TurnMessageEntry => ({ id, kind: 'agent', text });
+const other = (id: string): TurnMessageEntry => ({ id, kind: 'other', text: 'Using tool: Read' });
+
+describe('computeTurnEnds', () => {
+  test('only the last agent message of a run anchors the footer', () => {
+    const ends = computeTurnEnds([user('u1'), agent('a1', 'one'), agent('a2', 'two')]);
+    expect([...ends.keys()]).toEqual(['a2']);
+    expect(ends.get('a2')).toBe('one\n\ntwo');
+  });
+
+  test('a user message closes the turn, opening a new one', () => {
+    const ends = computeTurnEnds([
+      user('u1'),
+      agent('a1', 'one'),
+      user('u2'),
+      agent('a2', 'two'),
+      agent('a3', 'three'),
+    ]);
+    expect([...ends.keys()]).toEqual(['a1', 'a3']);
+    expect(ends.get('a1')).toBe('one');
+    expect(ends.get('a3')).toBe('two\n\nthree');
+  });
+
+  test('tool runs and reasoning stay inside the turn without anchoring it', () => {
+    const ends = computeTurnEnds([
+      user('u1'),
+      agent('a1', 'plan'),
+      other('t1'),
+      agent('a2', 'done'),
+      other('t2'),
+    ]);
+    expect([...ends.keys()]).toEqual(['a2']);
+    expect(ends.get('a2')).toBe('plan\n\ndone');
+  });
+
+  test('empty agent messages drop out of the copied text', () => {
+    const ends = computeTurnEnds([agent('a1', '  '), agent('a2', 'real')]);
+    expect(ends.get('a2')).toBe('real');
+  });
+
+  test('no agent messages means no footers', () => {
+    expect(computeTurnEnds([user('u1'), user('u2')]).size).toBe(0);
+  });
+});

--- a/apps/web/lib/agent-turns.ts
+++ b/apps/web/lib/agent-turns.ts
@@ -1,0 +1,56 @@
+/**
+ * Turn boundaries in the rendered transcript.
+ *
+ * A turn is the run of agent messages since the last user message. Only its
+ * LAST message carries the hover footer — one copy/fork per turn instead of one
+ * per message, which is what keeps the transcript tight (every footer reserves
+ * a row, so a footer per message pushed consecutive agent rows 28px apart).
+ * Copying that footer yields the whole turn's prose, not just the final chunk.
+ */
+
+export type TurnMessageKind =
+  /** Ends the current turn. */
+  | 'user'
+  /** Agent prose — part of the turn, and a candidate footer anchor. */
+  | 'agent'
+  /** Tool runs, reasoning cards: inside the turn, but never a footer anchor. */
+  | 'other';
+
+export interface TurnMessageEntry {
+  id: string;
+  kind: TurnMessageKind;
+  /** Visible text, concatenated into the turn's clipboard payload. */
+  text: string;
+}
+
+/**
+ * Map each turn-ending agent message id to that whole turn's concatenated
+ * prose. Ids absent from the map are mid-turn (or not agent messages) and get
+ * no footer.
+ */
+export function computeTurnEnds(entries: TurnMessageEntry[]): Map<string, string> {
+  const ends = new Map<string, string>();
+  let run: TurnMessageEntry[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+    const text = run
+      .map((entry) => entry.text.trim())
+      .filter(Boolean)
+      .join('\n\n');
+    ends.set(run[run.length - 1].id, text);
+    run = [];
+  };
+
+  for (const entry of entries) {
+    if (entry.kind === 'user') {
+      flush();
+      continue;
+    }
+    if (entry.kind === 'agent') run.push(entry);
+  }
+  // The transcript's trailing turn has no user message after it to close it.
+  flush();
+
+  return ends;
+}

--- a/apps/web/lib/fork-session.test.ts
+++ b/apps/web/lib/fork-session.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { buildForkTranscript } from './fork-session';
+import type { MessageResponse } from '@/lib/backend-api';
+
+function message(over: Partial<MessageResponse> & { id: string }): MessageResponse {
+  return {
+    content: '',
+    sender_type: 'agent',
+    created_at: '2026-09-07T10:00:00',
+    requires_user_input: false,
+    ...over,
+  };
+}
+
+const transcript: MessageResponse[] = [
+  message({ id: 'm1', sender_type: 'user', content: 'add a login page' }),
+  message({ id: 'm2', content: 'Using tool: **Read** - `app/page.tsx`\nfile contents here' }),
+  message({ id: 'm3', content: 'Here is the plan.' }),
+  message({ id: 'm4', sender_type: 'user', content: 'go ahead' }),
+  message({ id: 'm5', content: 'Done.' }),
+];
+
+describe('buildForkTranscript', () => {
+  test('stops at the boundary message, inclusive', () => {
+    const { text, messageCount } = buildForkTranscript({
+      messages: transcript,
+      boundaryMessageId: 'm3',
+      agentType: 'claude',
+    });
+    expect(text).toContain('User: add a login page');
+    expect(text).toContain('Agent: Here is the plan.');
+    expect(text).not.toContain('go ahead');
+    expect(text).not.toContain('Done.');
+    expect(messageCount).toBe(3);
+  });
+
+  test('tool uses become a single action line, header carries the source', () => {
+    const { text } = buildForkTranscript({
+      messages: transcript,
+      boundaryMessageId: 'm5',
+      agentType: 'claude',
+      sourceTitle: 'Login work',
+      sourceDirectory: '/Users/nick/app',
+    });
+    expect(text).toMatch(/^<chat-history>\n/);
+    expect(text).toMatch(/<\/chat-history>$/);
+    expect(text).toContain('Source session: Login work');
+    expect(text).toContain('Source directory: /Users/nick/app');
+    expect(text).toContain('Agent (tool): Read app/page.tsx');
+  });
+
+  test('an unknown boundary falls back to the whole timeline', () => {
+    const { messageCount } = buildForkTranscript({
+      messages: transcript,
+      boundaryMessageId: 'gone',
+      agentType: 'claude',
+    });
+    expect(messageCount).toBe(5);
+  });
+
+  test('thinking rows and the input placeholder are skipped', () => {
+    const { text, messageCount } = buildForkTranscript({
+      messages: [
+        message({ id: 't1', content: 'Reasoning: pondering', message_metadata: { thinking: { source: 'claude' } } }),
+        message({ id: 't2', sender_type: 'user', content: 'Waiting for your input...' }),
+        message({ id: 't3', content: 'Ready.' }),
+      ],
+      boundaryMessageId: 't3',
+      agentType: 'claude',
+    });
+    expect(text).not.toContain('pondering');
+    expect(text).not.toContain('Waiting for your input');
+    expect(messageCount).toBe(1);
+  });
+});

--- a/apps/web/lib/fork-session.ts
+++ b/apps/web/lib/fork-session.ts
@@ -1,0 +1,147 @@
+/**
+ * Forking a session: capture the transcript up to a chosen agent message and
+ * hand it to the new-session page as a chat-history attachment, so a new
+ * session starts with the old conversation as context instead of a blank slate.
+ *
+ * The payload rides sessionStorage rather than the URL — a transcript is orders
+ * of magnitude too big for a query string — and is consumed on the first
+ * successful spawn (a reload of `?fork=1` re-reads it, so the chip survives).
+ */
+
+import { MessageResponse } from '@/lib/backend-api';
+import { getMessageVisibleText } from '@/components/dashboard/chat-message-item';
+import { parseToolUse, type ToolUseAgentType } from '@/components/dashboard/tool-use-parsing';
+import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
+import { shouldHideControlMessage } from '@/lib/session-control-messages';
+
+const FORK_KEY = 'vicoa:fork-context';
+
+/** Longest a single transcript entry may be before it is elided. */
+const MAX_ENTRY_CHARS = 4000;
+/** Overall budget; older entries are dropped first so the fork keeps the tail. */
+const MAX_TOTAL_CHARS = 120_000;
+
+const USER_SENDER_TYPES = new Set(['user', 'human', 'USER', 'HUMAN']);
+
+export interface ForkContext {
+  /** The `<chat-history>` block prepended to the new session's first message. */
+  text: string;
+  /** Transcript entries the block covers — the composer chip's "N messages". */
+  messageCount: number;
+  /** Session the fork came from, for the chip's label/tooltip. */
+  sourceInstanceId: string;
+  sourceTitle: string;
+}
+
+function clampEntry(text: string): string {
+  if (text.length <= MAX_ENTRY_CHARS) return text;
+  return `${text.slice(0, MAX_ENTRY_CHARS)}\n… (truncated)`;
+}
+
+/** One line for a tool-use message: the action, never its output. */
+function formatToolEntry(message: MessageResponse, agentType: ToolUseAgentType): string | null {
+  const parsed = parseToolUse(message.content, agentType);
+  if (!parsed) return null;
+  const description = parsed.toolDescription.split('\n')[0].replace(/`/g, '').trim();
+  const label = [parsed.toolName, description].filter(Boolean).join(' ').trim();
+  return label ? `Agent (tool): ${label}` : null;
+}
+
+function formatEntry(message: MessageResponse, agentType: ToolUseAgentType): string | null {
+  // Reasoning blocks are the model's scratchpad, not conversation — a fresh
+  // agent has its own, so carrying them over is noise.
+  if (parseThinkingPayload(message)) return null;
+  if (shouldHideControlMessage(message)) return null;
+
+  const isUser = USER_SENDER_TYPES.has(message.sender_type);
+  if (!isUser) {
+    const tool = formatToolEntry(message, agentType);
+    if (tool) return tool;
+  }
+  const text = getMessageVisibleText(message).trim();
+  if (!text || text === 'Waiting for your input...') return null;
+  return `${isUser ? 'User' : 'Agent'}: ${clampEntry(text)}`;
+}
+
+/**
+ * Render the transcript up to and including `boundaryMessageId` as the text
+ * block a forked session opens with. An unknown boundary id (the message was
+ * pruned mid-click) falls back to the whole timeline rather than failing.
+ */
+export function buildForkTranscript(input: {
+  messages: MessageResponse[];
+  boundaryMessageId: string;
+  agentType: ToolUseAgentType;
+  sourceTitle?: string | null;
+  sourceDirectory?: string | null;
+}): { text: string; messageCount: number } {
+  const boundaryIndex = input.messages.findIndex((m) => m.id === input.boundaryMessageId);
+  const selected = input.messages.slice(0, boundaryIndex >= 0 ? boundaryIndex + 1 : undefined);
+
+  const entries: string[] = [];
+  for (const message of selected) {
+    const entry = formatEntry(message, input.agentType);
+    if (entry) entries.push(entry);
+  }
+
+  // Trim from the front — the messages nearest the fork point are the ones the
+  // new session actually needs.
+  let total = entries.reduce((sum, entry) => sum + entry.length + 1, 0);
+  let dropped = 0;
+  while (entries.length > 1 && total > MAX_TOTAL_CHARS) {
+    total -= entries[0].length + 1;
+    entries.shift();
+    dropped += 1;
+  }
+  if (dropped > 0) {
+    entries.unshift(`… ${dropped} earlier message${dropped === 1 ? '' : 's'} omitted …`);
+  }
+
+  const header = ['Chat history from an earlier Vicoa session, for context.'];
+  const title = input.sourceTitle?.trim();
+  const directory = input.sourceDirectory?.trim();
+  if (title) header.push(`Source session: ${title}`);
+  if (directory) header.push(`Source directory: ${directory}`);
+
+  const body = entries.length > 0 ? entries.join('\n') : 'No chat history to display.';
+  return {
+    text: `<chat-history>\n${header.join('\n')}\n\n${body}\n</chat-history>`,
+    messageCount: entries.length - (dropped > 0 ? 1 : 0),
+  };
+}
+
+export function saveForkContext(context: ForkContext): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(FORK_KEY, JSON.stringify(context));
+  } catch {
+    /* ignore quota errors — the fork just starts without its history */
+  }
+}
+
+export function loadForkContext(): ForkContext | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(FORK_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ForkContext>;
+    if (typeof parsed?.text !== 'string' || !parsed.text) return null;
+    return {
+      text: parsed.text,
+      messageCount: typeof parsed.messageCount === 'number' ? parsed.messageCount : 0,
+      sourceInstanceId: typeof parsed.sourceInstanceId === 'string' ? parsed.sourceInstanceId : '',
+      sourceTitle: typeof parsed.sourceTitle === 'string' ? parsed.sourceTitle : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearForkContext(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(FORK_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/apps/web/lib/message-grouping.ts
+++ b/apps/web/lib/message-grouping.ts
@@ -8,14 +8,16 @@ import { MessageResponse } from '@/lib/backend-api';
  * (no Z, no offset) are treated as local time by V8, so we append Z when no
  * timezone designator is present.
  */
-function parseUTCTimestamp(ts: string): Date {
+export function parseUTCTimestamp(ts: string): Date {
   if (!ts) return new Date(0);
   const hasTimezone = ts.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(ts);
   return new Date(hasTimezone ? ts : ts + 'Z');
 }
 
-// Helper function to format date for grouping
-function formatDateGroup(date: Date): string {
+// Helper function to format date for grouping. Also the per-message hover
+// timestamp (components/dashboard/message-actions.tsx), so a message's own
+// label reads the same as the separator above it.
+export function formatDateGroup(date: Date): string {
   const today = new Date();
   const messageDate = new Date(date);
 


### PR DESCRIPTION
Adds a hover-revealed footer to the chat transcript: **copy**, **fork** and the message's **time**.

## Behaviour

- **User messages** — every one gets a footer: the timestamp, then the copy icon outermost at the right edge.
- **Agent messages** — one footer per *turn*, on the last agent message before the next user message. Copy yields that whole turn's prose; fork uses that message as its boundary, so it captures the complete turn. Mid-turn agent messages get no footer, which keeps a run of agent rows as tight as it was before.
- **Timestamps** widen with age, reusing the date separators' formatter so a message reads like the separator above it: `10:30 AM` → `Yesterday 10:30 AM` → `Jan 15, 10:30 AM` → `Jan 15, 2024, 10:30 AM`.
- Tool-use rows, thinking cards and sub-agent children get no footer.

## Fork

Modelled on paseo's fork affordance. Forking captures the transcript up to and including that message and hands it to the new-session page as a removable **chat history** chip in the composer; on submit it is prepended above whatever the user typed.

- The transcript renders as a `<chat-history>` block: user/agent prose, tool uses collapsed to a single action line, reasoning dropped. Capped at 4k per entry and 120k total, trimmed oldest-first so the fork keeps the messages nearest the fork point.
- It rides `sessionStorage`, not the URL — a transcript is orders of magnitude too big for a query string. `?fork=1` marks it as this page's to pick up, so a reload restores the chip.
- The fork also carries the source session's **machine, directory and agent** (`?machineId=`, `?directory=`, `?agent=`) so the new run continues in the same place. The machine is pinned even when offline — landing elsewhere would point the carried directory at a path that doesn't exist. An agent id that isn't in the catalog falls back to the persisted one.

## Layout note

The footer row is always in the layout and only fades in, so hovering never changes a row's height — the virtualized list would otherwise re-measure and shift the transcript under the cursor. That reserves ~24px per footer, which is why the agent side is one-per-turn rather than one-per-message.

Also includes the pending v0.1.22 desktop / v1.7.18 CLI changelog entries.

## Testing

- `pnpm lint`, `pnpm build`, and the full vitest suite (66 files / 756 tests) pass.
- New unit coverage: `lib/fork-session.test.ts` (boundary handling, tool lines, caps) and `lib/agent-turns.test.ts` (turn boundaries).
- Not exercised against a live daemon — the hover interaction and the end-to-end fork spawn are worth a manual pass.