### PR TITLE
Find in conversation: search text hidden by collapsed rows

### DIFF
--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -1446,6 +1446,8 @@ function AgentInstanceContent() {
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState('');
   const [findActive, setFindActive] = useState(0);
+  // Incremented by every ⌘F; the find bar focuses + selects its input on change.
+  const [findFocusToken, setFindFocusToken] = useState(0);
   // Trimmed: the highlighters must use the exact term the match set was built
   // from, or a trailing space would count hits it then fails to highlight.
   const findNeedle = findQuery.trim();
@@ -1515,6 +1517,10 @@ function AgentInstanceContent() {
     const selection = typeof window !== 'undefined' ? window.getSelection?.()?.toString().trim() ?? '' : '';
     if (selection) setFindQuery(selection.slice(0, 200));
     setFindOpen(true);
+    // Bump on every ⌘F, not just the first: with the bar already up its mount
+    // autofocus can't re-run, so a second ⌘F (from the composer, say) would
+    // leave the caret where it was. The bar refocuses + selects on each bump.
+    setFindFocusToken((token) => token + 1);
   }, []);
 
   const closeFind = useCallback(() => setFindOpen(false), []);
@@ -2531,6 +2537,7 @@ function AgentInstanceContent() {
         {findOpen && !fileOverlay && (
           <ChatFindBar
             query={findQuery}
+            focusToken={findFocusToken}
             onQueryChange={setFindQuery}
             matchCount={findMatches.length}
             activeOrdinal={findMatches.length > 0 ? findActive + 1 : 0}

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -26,6 +26,7 @@ import { MessageItem, resolveAgentType, DateSeparator, ThinkingIndicator, vibing
 import { ChatFindBar } from '@/components/dashboard/chat-find-bar';
 import { FindHighlightProvider } from '@/components/dashboard/chat-find-context';
 import { groupSubagents } from '@/components/dashboard/subagent-grouping';
+import { getChatItemSearchText } from '@/lib/chat-search';
 import { buildForkTranscript, saveForkContext } from '@/lib/fork-session';
 import { computeTurnEnds, type TurnMessageEntry } from '@/lib/agent-turns';
 import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
@@ -1438,29 +1439,54 @@ function AgentInstanceContent() {
   // --- Find in conversation -------------------------------------------------
   // Client-side find over the LOADED transcript. Native ⌘F / findInPage only
   // sees Virtuoso's rendered rows; this searches the in-memory message array
-  // and uses scrollToIndex to reach off-screen hits. Matches are message-level
-  // (one per matching text message) so they map 1:1 onto chatItems indices.
+  // and uses scrollToIndex to reach off-screen hits. Matches are row-level
+  // (one per matching chat item) so they map 1:1 onto chatItems indices, and
+  // they cover text a row only reveals once expanded — a collapsed tool use's
+  // command/output, a sub-agent group's children (see lib/chat-search.ts).
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState('');
   const [findActive, setFindActive] = useState(0);
+  // Trimmed: the highlighters must use the exact term the match set was built
+  // from, or a trailing space would count hits it then fails to highlight.
+  const findNeedle = findQuery.trim();
 
   const findMatches = useMemo(() => {
-    const needle = findQuery.trim().toLowerCase();
+    const needle = findNeedle.toLowerCase();
     if (!findOpen || !needle) return [] as number[];
+    const itemsAgentType = resolveAgentType(instance?.agent_type_name || undefined);
     const hits: number[] = [];
     chatItems.forEach((item, index) => {
-      if (item.type === 'message' && getMessageVisibleText(item.message).toLowerCase().includes(needle)) {
+      if (getChatItemSearchText(item, itemsAgentType).toLowerCase().includes(needle)) {
         hits.push(index);
       }
     });
     return hits;
-  }, [chatItems, findQuery, findOpen]);
+  }, [chatItems, findNeedle, findOpen, instance?.agent_type_name]);
 
   // Chat-item key (== message id) of the focused match, for the active-row glow.
   const findActiveKey =
     findMatches.length > 0
       ? chatItems[findMatches[Math.min(findActive, findMatches.length - 1)]]?.key ?? null
       : null;
+
+  // Stepping onto a match that lives inside a collapsed group expands it, so
+  // the hit the counter promised is actually on screen (Chrome does the same
+  // for <details>). Left expanded afterwards — re-collapsing as you step past
+  // would resize rows under the scroll anchor.
+  useEffect(() => {
+    if (!findOpen || !findActiveKey) return;
+    const target = findMatches[Math.min(findActive, findMatches.length - 1)];
+    const activeItem = target === undefined ? undefined : chatItems[target];
+    if (!activeItem || (activeItem.type !== 'tool-group' && activeItem.type !== 'subagent-group')) return;
+    if (expandedToolItems.has(findActiveKey)) return;
+    setExpandedToolItems((prev) => new Set(prev).add(findActiveKey));
+    // Expanding grows the row by its whole detail, so recenter once it has
+    // painted — otherwise the hit can land below the fold.
+    const frame = requestAnimationFrame(() =>
+      virtuosoRef.current?.scrollToIndex({ index: target, align: 'center' }),
+    );
+    return () => cancelAnimationFrame(frame);
+  }, [findOpen, findActiveKey, findActive, findMatches, chatItems, expandedToolItems]);
 
   const scrollToMatch = useCallback(
     (matchIndex: number) => {
@@ -2292,7 +2318,7 @@ function AgentInstanceContent() {
       </div> */}
 
       {/* Messages Area - virtualized via react-virtuoso */}
-      <FindHighlightProvider query={findOpen ? findQuery : ''} activeKey={findActiveKey}>
+      <FindHighlightProvider query={findOpen ? findNeedle : ''} activeKey={findActiveKey}>
       <div className="relative flex-1 min-h-0">
         {!hasMessageItems ? (
           // No real messages yet (a lone "thinking" item doesn't count — it
@@ -2398,7 +2424,13 @@ function AgentInstanceContent() {
                 return (
                   <div className="max-w-4xl mx-auto px-6">
                     <div className="flex justify-start mb-1">
-                      <div className="rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono">
+                      <div
+                        className={`rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono ${
+                          findActiveKey === item.key
+                            ? 'find-active-message ring-2 ring-amber-400 dark:ring-amber-500'
+                            : ''
+                        }`}
+                      >
                         <ToolUseGroup
                           messages={item.messages}
                           agentType={agentType}
@@ -2415,7 +2447,13 @@ function AgentInstanceContent() {
                 return (
                   <div className="max-w-4xl mx-auto px-6">
                     <div className="flex justify-start mb-1">
-                      <div className="rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono">
+                      <div
+                        className={`rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono ${
+                          findActiveKey === item.key
+                            ? 'find-active-message ring-2 ring-amber-400 dark:ring-amber-500'
+                            : ''
+                        }`}
+                      >
                         <SubagentGroup
                           messages={item.messages}
                           subagentType={item.subagentType}

--- a/apps/web/components/dashboard/chat-find-bar.tsx
+++ b/apps/web/components/dashboard/chat-find-bar.tsx
@@ -6,6 +6,8 @@ import { NO_DRAG } from '@/lib/app-region';
 
 interface ChatFindBarProps {
   query: string;
+  /** Changes on every ⌘F — each change refocuses and selects the input. */
+  focusToken: number;
   onQueryChange: (query: string) => void;
   matchCount: number;
   /** 1-based position of the active match; 0 when there are none. */
@@ -22,6 +24,7 @@ interface ChatFindBarProps {
  */
 export function ChatFindBar({
   query,
+  focusToken,
   onQueryChange,
   matchCount,
   activeOrdinal,
@@ -32,12 +35,14 @@ export function ChatFindBar({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    // Autofocus + select on open so a prefilled selection is replaceable.
+    // Autofocus + select on open, and again on every later ⌘F (the token
+    // changes), so a prefilled selection — or the term already in the box — is
+    // replaceable by just typing.
     const el = inputRef.current;
     if (!el) return;
     el.focus();
     el.select();
-  }, []);
+  }, [focusToken]);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {

--- a/apps/web/components/dashboard/chat-message-item.tsx
+++ b/apps/web/components/dashboard/chat-message-item.tsx
@@ -123,7 +123,11 @@ export const MessageItem = memo(function MessageItem({ message, onOptionClick, o
   if (thinking) {
     return (
       <div className={compact ? 'flex justify-start' : 'flex justify-start mb-1'}>
-        <div className="rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono">
+        <div
+          className={`rounded-xl px-4 py-0.5 flex-1 min-w-0 text-sm leading-relaxed font-mono ${
+            isFindActive ? 'find-active-message ring-2 ring-amber-400 dark:ring-amber-500' : ''
+          }`}
+        >
           <StandaloneThinkingCard content={userVisibleContent} agentType={agentType} />
         </div>
       </div>

--- a/apps/web/components/dashboard/thinking-card.tsx
+++ b/apps/web/components/dashboard/thinking-card.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Brain, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MessageMarkdown } from '@/components/ui/message-markdown';
+import { HighlightedText, useFindHighlight } from '@/components/dashboard/chat-find-context';
 import type { MessageResponse } from '@/lib/backend-api';
 
 /**
@@ -57,8 +58,13 @@ export function ThinkingCard({
   expanded: boolean;
   onToggle: () => void;
 }) {
+  const { query: findQuery } = useFindHighlight();
   const body = displayBody(content);
   const preview = body.split('\n').find((line) => line.trim())?.trim() ?? '';
+  // Undefined unless the body really matches, so a non-matching card keeps
+  // MessageMarkdown's memo instead of re-parsing on every keystroke.
+  const highlightQuery =
+    findQuery !== '' && body.toLowerCase().includes(findQuery.toLowerCase()) ? findQuery : undefined;
 
   return (
     <div>
@@ -72,7 +78,7 @@ export function ThinkingCard({
         <span className="min-w-0 shrink-0 text-muted-foreground">Thinking</span>
         {!expanded && preview && (
           <span className="min-w-0 truncate italic text-muted-foreground/70" title={preview}>
-            {preview}
+            <HighlightedText text={preview} query={findQuery} />
           </span>
         )}
         <ChevronRight
@@ -85,7 +91,9 @@ export function ThinkingCard({
       {expanded && (
         <div className="ml-1.5 mt-1.5 border-l border-border/40 pl-2.5 italic text-muted-foreground">
           <div className="markdown-content">
-            <MessageMarkdown agentType={agentType}>{body}</MessageMarkdown>
+            <MessageMarkdown agentType={agentType} highlightQuery={highlightQuery}>
+              {body}
+            </MessageMarkdown>
           </div>
         </div>
       )}
@@ -105,11 +113,15 @@ export function StandaloneThinkingCard({
   agentType: UiAgentType;
 }) {
   const [expanded, setExpanded] = useState(false);
+  // Find searches the reasoning body (it is the row's `content`), so a match
+  // has to open the card — otherwise the hit is counted but never shown.
+  const { query: findQuery } = useFindHighlight();
+  const findHit = findQuery !== '' && displayBody(content).toLowerCase().includes(findQuery.toLowerCase());
   return (
     <ThinkingCard
       content={content}
       agentType={agentType}
-      expanded={expanded}
+      expanded={expanded || findHit}
       onToggle={() => setExpanded((current) => !current)}
     />
   );

--- a/apps/web/components/dashboard/tool-use-display.tsx
+++ b/apps/web/components/dashboard/tool-use-display.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MessageMarkdown } from '@/components/ui/message-markdown';
+import { HighlightedText, useFindHighlight } from '@/components/dashboard/chat-find-context';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { MessageResponse } from '@/lib/backend-api';
 import {
@@ -44,6 +45,11 @@ export type { ParsedToolUse, ToolUseAgentType, ToolUseSummary } from './tool-use
  * - File-based tools (Edit/Read/Write…) show `Tool basename` (+N -M when the
  *   agent reports it); the full path appears in the tooltip and above the
  *   code block when expanded.
+ *
+ * Find-in-conversation aware: a row whose hidden detail matches the active
+ * find query reveals that detail on its own (the transcript-level search
+ * counts it as a hit, so it has to be visible), and every label / body it
+ * renders highlights the term.
  */
 
 function DiffStat({ stat }: { stat: string }) {
@@ -82,8 +88,10 @@ function FileChip({
   /** Render as a bordered pill with a start-ellipsized name (group row). */
   inline?: boolean;
 }) {
+  const { query: findQuery } = useFindHighlight();
   const hasPreview = diffContent.trim().length > 0;
   const label = relativizeFilePath(fullPath, fileName, projectPath);
+  const labelNode = <HighlightedText text={label} query={findQuery} />;
   const inner = inline ? (
     // Bordered pill; the border separates files so no "·" is needed. The name
     // uses a CSS start-ellipsis (rtl base direction + native text-overflow):
@@ -96,7 +104,7 @@ function FileChip({
         style={{ direction: 'rtl' }}
         title={label}
       >
-        <span dir="ltr">{label}</span>
+        <span dir="ltr">{labelNode}</span>
       </span>
       {diffStat && <DiffStat stat={diffStat} />}
     </span>
@@ -106,7 +114,7 @@ function FileChip({
         className="min-w-0 truncate text-muted-foreground"
         title={hasPreview ? undefined : (fullPath ?? undefined)}
       >
-        {label}
+        {labelNode}
       </span>
       {diffStat && <DiffStat stat={diffStat} />}
     </span>
@@ -231,17 +239,32 @@ export function ToolUseLine({
   projectPath?: string | null;
 }) {
   const parsed = useMemo(() => parseToolUse(content, agentType), [content, agentType]);
+  const { query: findQuery } = useFindHighlight();
+  // Only hand the query to bodies that actually contain it — a non-matching
+  // MessageMarkdown keeps `highlightQuery` undefined and so keeps its memo.
+  const highlightIn = (text: string) =>
+    findQuery !== '' && text.toLowerCase().includes(findQuery.toLowerCase()) ? findQuery : undefined;
   if (!parsed) {
     // Unparseable tool-ish content — fall back to plain markdown.
     return (
       <div className="markdown-content">
-        <MessageMarkdown agentType={agentType}>{content}</MessageMarkdown>
+        <MessageMarkdown agentType={agentType} highlightQuery={highlightIn(content)}>
+          {content}
+        </MessageMarkdown>
       </div>
     );
   }
 
   const summary = summarizeToolUse(parsed);
   const expandable = summary.hasDetail || summary.description.length > LONG_DESCRIPTION_CHARS;
+  // Find counts this row's hidden detail as a hit (lib/chat-search.ts), so a
+  // matching term forces the detail open — otherwise stepping onto the match
+  // would land on a collapsed row with nothing highlighted. Reverts when the
+  // query is cleared; the user's own toggle is untouched.
+  const findDetailText = [parsed.toolDescription, parsed.remainingContent, summary.fullPath ?? ''].join('\n');
+  const findRevealsDetail =
+    findQuery !== '' && findDetailText.toLowerCase().includes(findQuery.toLowerCase());
+  const showDetail = expandable && (expanded || findRevealsDetail);
   // Edit/Write/MultiEdit that carry a diff (or a new-file body) render as a
   // bordered file pill — same as the group row — and preview on hover while
   // collapsed. Read/etc. and content-less writes keep the plain filename.
@@ -274,15 +297,17 @@ export function ToolUseLine({
             diffStat={summary.diffStat}
             // Hover preview only while collapsed — the diff is shown inline
             // below once expanded (the border stays either way).
-            diffContent={expanded ? '' : editDiffContent}
+            diffContent={showDetail ? '' : editDiffContent}
             agentType={agentType}
             projectPath={projectPath}
           />
         ) : (
-          !(expandable && expanded) && (
+          !showDetail && (
             <>
               {summary.description && (
-                <span className="min-w-0 truncate text-muted-foreground">{summary.description}</span>
+                <span className="min-w-0 truncate text-muted-foreground">
+                  <HighlightedText text={summary.description} query={findQuery} />
+                </span>
               )}
               {summary.diffStat && <DiffStat stat={summary.diffStat} />}
             </>
@@ -292,38 +317,43 @@ export function ToolUseLine({
           <ChevronRight
             className={cn(
               'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform',
-              expanded && 'rotate-90',
+              showDetail && 'rotate-90',
             )}
           />
         )}
       </button>
 
-      {expandable && expanded && (
+      {showDetail && (
         <div className="mt-1.5 space-y-1.5">
           {summary.fullPath && (
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
               {/* Project-relative path here too; hover for the absolute path. */}
               <span className="break-all" title={summary.fullPath}>
-                {relativizeFilePath(summary.fullPath, summary.fileName ?? '', projectPath)}
+                <HighlightedText
+                  text={relativizeFilePath(summary.fullPath, summary.fileName ?? '', projectPath)}
+                  query={findQuery}
+                />
               </span>
               {summary.diffStat && <DiffStat stat={summary.diffStat} />}
             </div>
           )}
           {!summary.fullPath && !parsed.isMultilineDescription && summary.description && (
             <code className="block w-fit max-w-full break-all rounded bg-muted px-1.5 py-1 text-xs text-muted-foreground">
-              {summary.description}
+              <HighlightedText text={summary.description} query={findQuery} />
             </code>
           )}
           {parsed.isMultilineDescription && parsed.toolDescription && (
             <div className="markdown-content">
-              <MessageMarkdown agentType={agentType}>
+              <MessageMarkdown agentType={agentType} highlightQuery={highlightIn(parsed.toolDescription)}>
                 {'```\n' + parsed.toolDescription.replace(/^`|`$/g, '').trim() + '\n```'}
               </MessageMarkdown>
             </div>
           )}
           {parsed.remainingContent && (
             <div className="markdown-content">
-              <MessageMarkdown agentType={agentType}>{parsed.remainingContent}</MessageMarkdown>
+              <MessageMarkdown agentType={agentType} highlightQuery={highlightIn(parsed.remainingContent)}>
+                {parsed.remainingContent}
+              </MessageMarkdown>
             </div>
           )}
         </div>
@@ -351,6 +381,7 @@ export function ToolUseGroup({
   // Per-tool expansion inside an expanded group. Local state: it resets if
   // the row is recycled offscreen by the virtual list, which is acceptable.
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+  const { query: findQuery } = useFindHighlight();
 
   // "Run 2 commands, edit 2 files, read a file" — distinct tools, first-use order.
   const runLabel = useMemo(
@@ -446,7 +477,7 @@ export function ToolUseGroup({
           </>
         ) : (
           <span className="min-w-0 truncate text-muted-foreground" title={runLabel}>
-            {runLabel}
+            <HighlightedText text={runLabel} query={findQuery} />
           </span>
         )}
         <ChevronRight

--- a/apps/web/lib/chat-search.test.ts
+++ b/apps/web/lib/chat-search.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest';
+import { getChatItemSearchText, getMessageSearchText } from './chat-search';
+import type { MessageResponse } from '@/lib/backend-api';
+
+function message(over: Partial<MessageResponse> & { id: string }): MessageResponse {
+  return {
+    content: '',
+    sender_type: 'agent',
+    created_at: '2026-09-07T10:00:00',
+    requires_user_input: false,
+    ...over,
+  };
+}
+
+const readTool = message({
+  id: 't1',
+  content: 'Using tool: **Read** - `app/dashboard/page.tsx`\nexport const SECRET_TOKEN = 1;',
+});
+const bashTool = message({
+  id: 't2',
+  content: 'Using tool: **Bash** - `pnpm test`\n```\n2 tests failed in worktree-selection\n```',
+});
+
+describe('getMessageSearchText', () => {
+  test('includes the detail a collapsed tool use hides', () => {
+    const text = getMessageSearchText(readTool, 'claude');
+    expect(text).toContain('SECRET_TOKEN');
+    expect(text).toContain('app/dashboard/page.tsx');
+    expect(text).toContain('Read');
+  });
+
+  test('plain prose is unchanged', () => {
+    expect(getMessageSearchText(message({ id: 'm1', content: 'Here is the plan.' }), 'claude')).toBe(
+      'Here is the plan.',
+    );
+  });
+
+  test('unparseable tool-ish content falls back to the raw text', () => {
+    const odd = message({ id: 'm2', content: '🔧 nothing parseable here' });
+    expect(getMessageSearchText(odd, 'claude')).toBe('🔧 nothing parseable here');
+  });
+});
+
+describe('getChatItemSearchText', () => {
+  test('a collapsed tool group is searched across all of its tool uses', () => {
+    const text = getChatItemSearchText({ type: 'tool-group', messages: [readTool, bashTool] }, 'claude');
+    expect(text).toContain('SECRET_TOKEN');
+    expect(text).toContain('2 tests failed in worktree-selection');
+  });
+
+  test('a sub-agent group covers its header and its children', () => {
+    const text = getChatItemSearchText(
+      {
+        type: 'subagent-group',
+        subagentType: 'Explore',
+        description: 'find the search code',
+        messages: [readTool, message({ id: 'c1', content: 'found it in chat-search.ts' })],
+      },
+      'claude',
+    );
+    expect(text).toContain('Explore');
+    expect(text).toContain('find the search code');
+    expect(text).toContain('SECRET_TOKEN');
+    expect(text).toContain('found it in chat-search.ts');
+  });
+
+  test('separators and the thinking indicator carry nothing', () => {
+    expect(getChatItemSearchText({ type: 'separator' }, 'claude')).toBe('');
+    expect(getChatItemSearchText({ type: 'thinking' }, 'claude')).toBe('');
+  });
+});

--- a/apps/web/lib/chat-search.ts
+++ b/apps/web/lib/chat-search.ts
@@ -1,0 +1,72 @@
+/**
+ * Searchable text for find-in-conversation.
+ *
+ * The find bar searches the in-memory transcript rather than the DOM, so it
+ * must look at everything a row would show once fully expanded — otherwise
+ * text that only appears after expanding a collapsed tool use / sub-agent /
+ * thinking row is unfindable. `getMessageVisibleText` alone covers only the
+ * prose of a plain message; these helpers add the tool-use detail (command,
+ * output, diff) and the grouped rows' children.
+ */
+
+import type { MessageResponse } from '@/lib/backend-api';
+import { getMessageVisibleText } from '@/components/dashboard/chat-message-item';
+import {
+  isToolUseContent,
+  parseToolUse,
+  type ToolUseAgentType,
+} from '@/components/dashboard/tool-use-parsing';
+
+/**
+ * Structural shape of the instance page's `ChatItem` union — only the fields
+ * that carry text. Kept minimal so the page's richer items (which also carry
+ * `key`/`date`) assign to it without importing page-level types here.
+ */
+export type SearchableChatItem =
+  | { type: 'separator' }
+  | { type: 'thinking' }
+  | { type: 'message'; message: MessageResponse }
+  | { type: 'tool-group'; messages: MessageResponse[] }
+  | { type: 'subagent-group'; messages: MessageResponse[]; subagentType: string; description: string };
+
+/**
+ * Everything one message contributes to find: its visible prose, plus — for a
+ * tool use — the tool name, the full command/path and the detail hidden behind
+ * the collapsed row.
+ */
+export function getMessageSearchText(message: MessageResponse, agentType: ToolUseAgentType): string {
+  const visible = getMessageVisibleText(message);
+  if (!isToolUseContent(visible)) return visible;
+  const parsed = parseToolUse(visible, agentType);
+  // Unparseable tool-ish content renders as raw markdown, so search it as-is.
+  if (!parsed) return visible;
+  return [parsed.toolName, parsed.toolDescription, parsed.remainingContent]
+    .filter((part) => part.trim() !== '')
+    .join('\n');
+}
+
+/** The same, for a whole chat item — groups fold in every child they hide. */
+export function getChatItemSearchText(item: SearchableChatItem, agentType: ToolUseAgentType): string {
+  switch (item.type) {
+    case 'message':
+      return getMessageSearchText(item.message, agentType);
+    case 'tool-group':
+      return item.messages.map((message) => getMessageSearchText(message, agentType)).join('\n');
+    case 'subagent-group':
+      return [
+        item.subagentType,
+        item.description,
+        ...item.messages.map((message) => getMessageSearchText(message, agentType)),
+      ]
+        .filter((part) => part.trim() !== '')
+        .join('\n');
+    default:
+      // Separators and the "thinking" indicator carry no searchable text.
+      return '';
+  }
+}
+
+/** True when `text` contains `needle` (already lowercased, non-empty). */
+export function matchesNeedle(text: string, needle: string): boolean {
+  return needle !== '' && text.toLowerCase().includes(needle);
+}


### PR DESCRIPTION
## The bug

Find-in-conversation (⌘F) reported "No results" for text that was plainly in the transcript, whenever that text sat under a collapsed tool use.

`findMatches` only considered `item.type === 'message'` chat items, and only their visible prose (`getMessageVisibleText`). Everything behind a collapse was invisible to the search:

- a `tool-group` row's tool names, commands, file paths, output and diffs
- a `subagent-group`'s header and children
- a reasoning card's body (matched, but rendered inside a card that stayed shut)

## The fix

**`apps/web/lib/chat-search.ts`** (new) — `getMessageSearchText` / `getChatItemSearchText` derive the text a row shows *once fully expanded*: for a tool use, the tool name + full command/path + detail body; for a group, every child; for a sub-agent group, its header, description and children.

**`page.tsx`** — the find memo searches every chat item through that helper. Stepping onto a match inside a collapsed group expands it (and recenters after the row grows), and grouped rows get the same amber active-match ring messages already had. The provider is now handed the *trimmed* query: matching used `.trim()` while highlighting didn't, so a trailing space counted hits it then failed to mark.

**`tool-use-display.tsx`** — find-aware. A line whose hidden detail matches reveals that detail on its own, and the run label, file chips, paths, command and output highlight the term. `highlightQuery` is only passed to bodies that actually match, so non-matching rows keep `MessageMarkdown`'s memo.

**`thinking-card.tsx`** + the thinking branch of `chat-message-item.tsx` — same defect class: the card auto-opens on a match, highlights, and gets the active ring.

Auto-expansion is sticky (the group stays open after you step past, as Chrome does with `<details>`) — re-collapsing would resize rows under the scroll anchor.

## Testing

- `pnpm test` — 762 tests / 67 files pass, including 6 new ones in `lib/chat-search.test.ts` covering collapsed tool detail, tool groups, sub-agent groups and the unparseable-tool fallback.
- `pnpm lint` (tsc + theme check) exits 0.
- Verified in the running app: ⌘F now finds and reveals text under a collapsed tool use.

Web/desktop renderer only — no backend, schema or mobile changes.