### PR TITLE
User avatars: one PrincipalAvatar for every principal

### DIFF
--- a/apps/mobile/lib/components/principal_avatar/principal_avatar.dart
+++ b/apps/mobile/lib/components/principal_avatar/principal_avatar.dart
@@ -19,14 +19,20 @@ import '/flutter_flow/flutter_flow_theme.dart';
 /// platform. Nothing else in the app should draw an avatar.
 enum PrincipalType { user, team, agent }
 
-/// Web's `xs | sm | md | lg`, in logical pixels.
-enum PrincipalAvatarSize { xs, sm, md, lg }
+/// Web's `xs | sm | md | lg | xl`, in logical pixels.
+enum PrincipalAvatarSize { xs, sm, md, lg, xl }
 
-const Map<PrincipalAvatarSize, double> _sizePx = {
-  PrincipalAvatarSize.xs: 16.0,
-  PrincipalAvatarSize.sm: 24.0,
-  PrincipalAvatarSize.md: 32.0,
-  PrincipalAvatarSize.lg: 56.0,
+/// Box size and the initial's type size, mirroring the SIZES table in
+/// apps/web/components/ui/principal-avatar.tsx one-for-one. The letter runs
+/// ~0.25-0.30 of the box (higher at the small end only because 16px has a
+/// legibility floor) so the monogram reads as a mark rather than filling the
+/// circle. Change one table, change the other.
+const Map<PrincipalAvatarSize, ({double box, double text})> _metrics = {
+  PrincipalAvatarSize.xs: (box: 16.0, text: 8.0),
+  PrincipalAvatarSize.sm: (box: 24.0, text: 9.0),
+  PrincipalAvatarSize.md: (box: 32.0, text: 11.0),
+  PrincipalAvatarSize.lg: (box: 56.0, text: 16.0),
+  PrincipalAvatarSize.xl: (box: 80.0, text: 20.0),
 };
 
 /// paseo's IDENTITY_COLORS — muted tones tuned for a white letter on top.
@@ -57,14 +63,15 @@ int _hashString(String seed) {
 Color identityColor(String seed) =>
     kIdentityPalette[_hashString(seed) % kIdentityPalette.length];
 
-/// Up to two initials from a display name, or null when there is no name.
-String? principalInitials(String? name) {
+/// A principal's single initial, or null when there is no name.
+///
+/// One letter, not two: a monogram reads as a mark at any size, while "AL" in a
+/// 24px circle is two shapes fighting for the same space. `runes` (not
+/// `codeUnits`) so an emoji or an astral-plane name is not sliced in half.
+String? principalInitial(String? name) {
   final trimmed = (name ?? '').trim();
   if (trimmed.isEmpty) return null;
-  final words = trimmed.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
-  String first(String w) => String.fromCharCode(w.runes.first).toUpperCase();
-  if (words.length >= 2) return '${first(words[0])}${first(words[1])}';
-  return first(trimmed);
+  return String.fromCharCode(trimmed.runes.first).toUpperCase();
 }
 
 class PrincipalAvatar extends StatelessWidget {
@@ -97,7 +104,8 @@ class PrincipalAvatar extends StatelessWidget {
 
   final PrincipalAvatarSize size;
 
-  double get _px => _sizePx[size]!;
+  double get _px => _metrics[size]!.box;
+  double get _textPx => _metrics[size]!.text;
 
   /// Agents are square-ish (a thing, not a face); people and teams are round.
   BorderRadius get _radius => type == PrincipalType.agent
@@ -148,18 +156,20 @@ class PrincipalAvatar extends StatelessWidget {
   }
 
   Widget _fallback(BuildContext context) {
-    final initials = principalInitials(name);
-    if (initials != null) {
+    final initial = principalInitial(name);
+    if (initial != null) {
       return Container(
         color: identityColor(id?.isNotEmpty == true ? id! : name!),
         alignment: Alignment.center,
         child: Text(
-          initials,
+          initial,
           style: TextStyle(
             color: Colors.white,
-            fontWeight: FontWeight.w600,
+            // Matches the web's font-normal — a heavier monogram reads as a
+            // badge rather than as identity.
+            fontWeight: FontWeight.w400,
             height: 1.0,
-            fontSize: _px * 0.4,
+            fontSize: _textPx,
           ),
         ),
       );

--- a/apps/mobile/lib/components/principal_avatar/principal_avatar.dart
+++ b/apps/mobile/lib/components/principal_avatar/principal_avatar.dart
@@ -1,0 +1,174 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '/backend/supabase/supabase.dart';
+import '/custom_code/actions/vicoa_api_config.dart';
+import '/flutter_flow/flutter_flow_theme.dart';
+
+/// PrincipalAvatar — the Flutter twin of
+/// `apps/web/components/ui/principal-avatar.tsx` (collaboration P0).
+///
+/// One widget, three principal types (user, team, agent), three fallback
+/// levels:
+///   1. the stored image, fetched from our own backend with the session bearer;
+///   2. initials on the deterministic hash-palette color;
+///   3. a generic per-type glyph, when there is no name to make initials from.
+///
+/// The palette and the hash are copied verbatim from
+/// `apps/web/lib/project-icons.ts`, so a principal gets the same color on every
+/// platform. Nothing else in the app should draw an avatar.
+enum PrincipalType { user, team, agent }
+
+/// Web's `xs | sm | md | lg`, in logical pixels.
+enum PrincipalAvatarSize { xs, sm, md, lg }
+
+const Map<PrincipalAvatarSize, double> _sizePx = {
+  PrincipalAvatarSize.xs: 16.0,
+  PrincipalAvatarSize.sm: 24.0,
+  PrincipalAvatarSize.md: 32.0,
+  PrincipalAvatarSize.lg: 56.0,
+};
+
+/// paseo's IDENTITY_COLORS — muted tones tuned for a white letter on top.
+/// Keep in sync with PROJECT_AVATAR_PALETTE in apps/web/lib/project-icons.ts.
+const List<Color> kIdentityPalette = [
+  Color(0xFF7A6AA8), // violet
+  Color(0xFF3D7EA6), // sky
+  Color(0xFF388068), // emerald
+  Color(0xFFA4673A), // orange
+  Color(0xFFB05C80), // pink
+  Color(0xFF6A70B8), // indigo
+  Color(0xFF368080), // teal
+  Color(0xFFB06260), // red
+  Color(0xFF8F7838), // amber
+  Color(0xFF5179B0), // blue
+];
+
+/// paseo's hashIdentityKey (hash*31 + charCode, unsigned 32-bit) — the web
+/// version relies on JS `>>> 0`, so mask to 32 bits here to match exactly.
+int _hashString(String seed) {
+  int hash = 0;
+  for (final unit in seed.runes) {
+    hash = (hash * 31 + unit) & 0xFFFFFFFF;
+  }
+  return hash;
+}
+
+Color identityColor(String seed) =>
+    kIdentityPalette[_hashString(seed) % kIdentityPalette.length];
+
+/// Up to two initials from a display name, or null when there is no name.
+String? principalInitials(String? name) {
+  final trimmed = (name ?? '').trim();
+  if (trimmed.isEmpty) return null;
+  final words = trimmed.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
+  String first(String w) => String.fromCharCode(w.runes.first).toUpperCase();
+  if (words.length >= 2) return '${first(words[0])}${first(words[1])}';
+  return first(trimmed);
+}
+
+class PrincipalAvatar extends StatelessWidget {
+  const PrincipalAvatar({
+    super.key,
+    required this.type,
+    this.id,
+    this.name,
+    this.avatarImageUri,
+    this.updatedAt,
+    this.size = PrincipalAvatarSize.md,
+  });
+
+  final PrincipalType type;
+
+  /// Stable id — seeds the fallback color and addresses the stored image.
+  final String? id;
+
+  /// Display name — the seed for initials. On a shared or public surface this
+  /// must be a display name and nothing else: an email may never appear there
+  /// (P0 privacy rule). In the signed-in user's own chrome, falling back to
+  /// their own email for an initial is fine.
+  final String? name;
+
+  /// Backend-relative served URL (e.g. `users.avatar_image_uri`), or null.
+  final String? avatarImageUri;
+
+  /// Cache-buster — the row's `updated_at`; the avatar URL itself is stable.
+  final String? updatedAt;
+
+  final PrincipalAvatarSize size;
+
+  double get _px => _sizePx[size]!;
+
+  /// Agents are square-ish (a thing, not a face); people and teams are round.
+  BorderRadius get _radius => type == PrincipalType.agent
+      ? BorderRadius.circular(_px * 0.22)
+      : BorderRadius.circular(_px / 2);
+
+  IconData get _glyph {
+    switch (type) {
+      case PrincipalType.team:
+        return Icons.groups_rounded;
+      case PrincipalType.agent:
+        return Icons.smart_toy_outlined;
+      case PrincipalType.user:
+        return Icons.person_rounded;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: _radius,
+      child: SizedBox(
+        width: _px,
+        height: _px,
+        child: _content(context),
+      ),
+    );
+  }
+
+  Widget _content(BuildContext context) {
+    // Only users have stored images today; teams (P3) and agents (P1) reuse
+    // this widget for their initials/glyph until they do.
+    if (type == PrincipalType.user && id != null && (avatarImageUri ?? '').isNotEmpty) {
+      // The URL is stable across replacements, so `updated_at` is both the
+      // cache-buster and the disk-cache key.
+      final version = updatedAt == null ? '' : '?v=${Uri.encodeComponent(updatedAt!)}';
+      final url = '${getVicoaApiBaseUrl()}/api/v1/users/$id/avatar$version';
+      final token = SupaFlow.client.auth.currentSession?.accessToken ?? '';
+      return CachedNetworkImage(
+        imageUrl: url,
+        httpHeaders: {'Authorization': 'Bearer $token'},
+        fit: BoxFit.cover,
+        placeholder: (context, _) => _fallback(context),
+        errorWidget: (context, _, __) => _fallback(context),
+      );
+    }
+    return _fallback(context);
+  }
+
+  Widget _fallback(BuildContext context) {
+    final initials = principalInitials(name);
+    if (initials != null) {
+      return Container(
+        color: identityColor(id?.isNotEmpty == true ? id! : name!),
+        alignment: Alignment.center,
+        child: Text(
+          initials,
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.w600,
+            height: 1.0,
+            fontSize: _px * 0.4,
+          ),
+        ),
+      );
+    }
+    final theme = FlutterFlowTheme.of(context);
+    return Container(
+      color: theme.alternate.withValues(alpha: 0.4),
+      alignment: Alignment.center,
+      child: Icon(_glyph, size: _px * 0.55, color: theme.secondaryText),
+    );
+  }
+}

--- a/apps/mobile/lib/components/principal_avatar/self_avatar.dart
+++ b/apps/mobile/lib/components/principal_avatar/self_avatar.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '/custom_code/actions/index.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'principal_avatar.dart';
+
+/// The signed-in user's own avatar.
+///
+/// `FFAppState().user` (a FlutterFlow struct) carries no avatar field, and the
+/// picture lives in our backend rather than in Supabase, so this reads
+/// `GET /api/v1/auth/me` once on mount. Until it answers — and whenever the
+/// account has no stored image — `PrincipalAvatar` shows initials, so there is
+/// no spinner and no layout shift.
+class SelfAvatar extends StatefulWidget {
+  const SelfAvatar({super.key, this.size = PrincipalAvatarSize.lg});
+
+  final PrincipalAvatarSize size;
+
+  @override
+  State<SelfAvatar> createState() => _SelfAvatarState();
+}
+
+class _SelfAvatarState extends State<SelfAvatar> {
+  String? _avatarImageUri;
+  String? _updatedAt;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final profile = await vicoaApiRequest('get', '/api/v1/auth/me', null);
+      if (!mounted || profile is! Map) return;
+      setState(() {
+        _avatarImageUri = profile['avatar_image_uri'] as String?;
+        _updatedAt = profile['updated_at'] as String?;
+      });
+    } catch (_) {
+      // Best-effort: no avatar just means initials.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FFAppState().user;
+    return PrincipalAvatar(
+      type: PrincipalType.user,
+      id: user.id,
+      // Falls back to the email only to derive an initial; the widget never
+      // renders it.
+      name: user.name.isNotEmpty ? user.name : user.email,
+      avatarImageUri: _avatarImageUri,
+      updatedAt: _updatedAt,
+      size: widget.size,
+    );
+  }
+}

--- a/apps/mobile/lib/profile/account/account_widget.dart
+++ b/apps/mobile/lib/profile/account/account_widget.dart
@@ -5,6 +5,8 @@ import '/backend/push_notifications/notification_util.dart';
 import '/flutter_flow/flutter_flow_animations.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
+import '/components/principal_avatar/principal_avatar.dart';
+import '/components/principal_avatar/self_avatar.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/l10n/app_localizations.dart';
@@ -421,6 +423,17 @@ class _AccountWidgetState extends State<AccountWidget>
                 mainAxisSize: MainAxisSize.max,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  // Profile photo (collaboration P0). Rendered by the one
+                  // avatar widget the app has; upload lives on web/desktop
+                  // Settings -> Profile for now.
+                  Padding(
+                    padding:
+                        EdgeInsetsDirectional.fromSTEB(16.0, 24.0, 16.0, 0.0),
+                    child: Align(
+                      alignment: AlignmentDirectional(0.0, 0.0),
+                      child: SelfAvatar(size: PrincipalAvatarSize.lg),
+                    ),
+                  ),
                   Padding(
                     padding:
                         EdgeInsetsDirectional.fromSTEB(16.0, 16.0, 16.0, 0.0),

--- a/apps/web/app/api/supabase-user/route.ts
+++ b/apps/web/app/api/supabase-user/route.ts
@@ -2,6 +2,38 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/auth/supabase-server';
 import { isBuiltinAuth } from '@/lib/auth/auth-provider';
 import { getBuiltinClaimsFromCookies } from '@/lib/auth/builtin-server';
+import { getSupabaseToken } from '@/lib/auth/supabase-helpers';
+
+/**
+ * The backend's copy of the caller's identity — the avatar lives there, not in
+ * Supabase (we re-host it rather than hot-link the IdP's CDN). Best-effort: a
+ * backend hiccup must not sign the user out of the dashboard, it just means
+ * `<PrincipalAvatar>` falls back to initials this render.
+ */
+async function fetchBackendAvatar(): Promise<{
+  avatarImageUri: string | null;
+  updatedAt: string | null;
+}> {
+  const empty = { avatarImageUri: null, updatedAt: null };
+  try {
+    const token = await getSupabaseToken(true);
+    if (!token) return empty;
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8000';
+    const response = await fetch(`${backendUrl}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    });
+    if (!response.ok) return empty;
+    const profile = await response.json();
+    return {
+      avatarImageUri: profile?.avatar_image_uri ?? null,
+      updatedAt: profile?.updated_at ?? null,
+    };
+  } catch (error) {
+    console.error('Failed to load backend profile avatar:', error);
+    return empty;
+  }
+}
 
 export async function GET() {
   try {
@@ -17,6 +49,7 @@ export async function GET() {
         name: claims.name ?? '',
         email: claims.email ?? '',
         role: 'member',
+        ...(await fetchBackendAvatar()),
       });
     }
 
@@ -48,7 +81,8 @@ export async function GET() {
       name: displayName || user.user_metadata?.name || '',
       email: user.email,
       createdAt: user.created_at,
-      role: user.user_metadata?.role || 'member'
+      role: user.user_metadata?.role || 'member',
+      ...(await fetchBackendAvatar()),
     };
 
     return NextResponse.json(userData);

--- a/apps/web/app/api/users/[userId]/avatar/route.ts
+++ b/apps/web/app/api/users/[userId]/avatar/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseToken } from '@/lib/auth/supabase-helpers';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Stream a principal's avatar bytes through cookie-authenticated Next.js, so a
+ * plain <img src="/api/users/{id}/avatar"> works without the client ever
+ * holding the backend bearer token — the exact mirror of
+ * /api/projects/[projectId]/icon. The backend URL is stable across
+ * replacements, so callers cache-bust with the row's updated_at
+ * (see lib/principals.ts).
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> }
+) {
+  try {
+    const { userId } = await params;
+    if (!UUID_PATTERN.test(userId)) {
+      return NextResponse.json({ error: 'Invalid user id' }, { status: 400 });
+    }
+
+    const accessToken = await getSupabaseToken(true);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_API_URL || 'http://localhost:8000';
+    const response = await fetch(`${backendUrl}/api/v1/users/${userId}/avatar`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok || !response.body) {
+      return NextResponse.json(
+        { error: `Backend responded with ${response.status}` },
+        { status: response.status }
+      );
+    }
+
+    return new NextResponse(response.body, {
+      status: 200,
+      headers: {
+        'Content-Type': response.headers.get('content-type') ?? 'application/octet-stream',
+        'Cache-Control': 'private, max-age=300',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (error) {
+    console.error('User avatar fetch failed:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/dashboard/dashboard-layout.tsx
+++ b/apps/web/app/dashboard/dashboard-layout.tsx
@@ -33,7 +33,7 @@ import {
   Search,
   Settings,
 } from 'lucide-react';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
 import { AgentDashboardProvider, useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
 import useSWR from 'swr';
 import type { AuthUser } from '@/lib/auth/user';
@@ -228,23 +228,19 @@ function DashboardSidebar({
 
   const userEmail = user?.email || '';
 
-  const userInitials = useMemo(() => {
-    if (user?.name) {
-      const parts = user.name.trim().split(/\s+/).filter(Boolean);
-      if (parts.length >= 2) {
-        return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
-      }
-      if (parts.length === 1) {
-        return parts[0][0].toUpperCase();
-      }
-    }
-
-    if (user?.email) {
-      return user.email.charAt(0).toUpperCase();
-    }
-
-    return 'U';
-  }, [user]);
+  // The one identity object the sidebar renders. `<PrincipalAvatar>` owns the
+  // whole fallback chain (stored image → initials → glyph), so there is no
+  // separate initials computation here any more.
+  const userPrincipal = useMemo(
+    () => ({
+      type: 'user' as const,
+      id: user?.id,
+      name: user?.name || user?.email,
+      avatarImageUri: user?.avatarImageUri,
+      updatedAt: user?.updatedAt,
+    }),
+    [user],
+  );
 
   const handleTabClick = useCallback((tab: string) => {
     if (tab === 'agent-hub') {
@@ -576,13 +572,11 @@ function DashboardSidebar({
                   title={!showSideBar ? userDisplayName : undefined}
                 >
                   <div className="flex items-center w-full">
-                    <Avatar className={cn("h-8 w-8", showSideBar && "mr-3")}>
-                      <AvatarFallback className={cn(
-                        "bg-primary/10 text-primary uppercase text-xs font-normal"
-                      )}>
-                        {userInitials || <User className="h-4 w-4 text-muted-foreground" />}
-                      </AvatarFallback>
-                    </Avatar>
+                    <PrincipalAvatar
+                      principal={userPrincipal}
+                      size="md"
+                      className={cn(showSideBar && "mr-3")}
+                    />
                     <div className={cn("flex-1 min-w-0 text-left", !showSideBar && "hidden")}>
                         {user.name ? (
                         <>

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { WorktreeSetupSection } from '@/components/dashboard/worktree-setup-section';
 import { ProjectDisplaySection } from '@/components/dashboard/project-display-section';
 import { ProjectIcon } from '@/components/dashboard/task-ui';
+import { UserAvatarEditor } from '@/components/dashboard/user-avatar-editor';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
@@ -50,6 +51,9 @@ type SupabaseUser = {
   email: string;
   createdAt: string;
   role?: string;
+  /** Backend avatar fields, threaded through /api/supabase-user. */
+  avatarImageUri?: string | null;
+  updatedAt?: string | null;
 };
 
 const tabs = [
@@ -542,8 +546,30 @@ function SupabaseProfileForm({ user, onRefresh }: SupabaseProfileFormProps) {
     }
   };
 
+  const handleUploadAvatar = async (file: File) => {
+    await getBackendAPI(true).uploadMyAvatar(file);
+    await onRefresh();
+  };
+
+  const handleRemoveAvatar = async () => {
+    await getBackendAPI(true).deleteMyAvatar();
+    await onRefresh();
+  };
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Identity first: the photo is what other people see of this account. */}
+      <UserAvatarEditor
+        principal={{
+          type: 'user',
+          id: user.id,
+          name: user.name || user.email,
+          avatarImageUri: user.avatarImageUri,
+          updatedAt: user.updatedAt,
+        }}
+        onUploadImage={handleUploadAvatar}
+        onRemoveImage={handleRemoveAvatar}
+      />
       <div className="grid gap-4">
         <div className="space-y-2">
           <Label htmlFor="supabase-name">Full name</Label>

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { LogIn, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -44,6 +44,9 @@ import {
   type CliLinkStatus,
 } from '@/lib/desktop-cli';
 import { DRAG_REGION } from '@/lib/app-region';
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import { UserAvatarEditor } from '@/components/dashboard/user-avatar-editor';
+import type { UserProfile } from '@/lib/backend-api';
 import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
 import { computeStreaks, formatCompact, formatDays } from '@/lib/profile-stats';
 import {
@@ -167,6 +170,10 @@ function ProfileSection() {
   const [email, setEmail] = useState<string | null>(null);
   const [name, setName] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
+  // The avatar is ours, not Supabase's, so it comes from the backend profile
+  // rather than the session above. Kept in state so upload/remove can refresh
+  // it without a full page reload.
+  const [profile, setProfile] = useState<UserProfile | null>(null);
   const [activity, setActivity] = useState<ProfileActivity | null>(null);
   const [activityLoading, setActivityLoading] = useState(true);
 
@@ -201,6 +208,20 @@ function ProfileSection() {
   }, [config?.mode]);
 
   const isCloud = config?.mode === 'cloud';
+
+  const refreshProfile = useCallback(async () => {
+    if (!api) return;
+    setProfile(await api.getCurrentUserProfile());
+  }, [api]);
+
+  // Local mode has no cloud account, so there is no backend profile to read and
+  // nothing to upload to — that branch renders a plain avatar below.
+  useEffect(() => {
+    if (!isCloud || !api) return;
+    void refreshProfile().catch(() => {
+      /* no profile just means initials */
+    });
+  }, [isCloud, api, refreshProfile]);
 
   // Activity (stat tiles + heatmap): the server aggregate, cached + synced
   // incrementally, with a comprehensive session-level fallback. Paint any
@@ -238,6 +259,14 @@ function ProfileSection() {
   if (!mounted) return null;
 
   const displayName = name || email || (isCloud ? 'Your profile' : 'Local session');
+  const avatarPrincipal = {
+    type: 'user' as const,
+    id: userId ?? undefined,
+    // Falls back to the email only to derive an initial; never rendered as text.
+    name: profile?.display_name || name || email,
+    avatarImageUri: profile?.avatar_image_uri,
+    updatedAt: profile?.updated_at,
+  };
   // Show the email under the name, unless the name slot already shows it.
   const subEmail = email && email !== displayName ? email : null;
   const loading = activityLoading && !activity;
@@ -248,10 +277,25 @@ function ProfileSection() {
 
   return (
     <section className="flex flex-col items-center">
-      {/* Identity */}
-      <div className="flex h-20 w-20 items-center justify-center rounded-full bg-foreground/10 text-2xl font-light text-foreground/80">
-        {initialsFrom(displayName, email)}
-      </div>
+      {/* Identity. Cloud mode can edit the photo; local mode has no account to
+          attach one to (and no API client yet, briefly, on first paint), so it
+          just renders. */}
+      {isCloud && api ? (
+        <UserAvatarEditor
+          principal={avatarPrincipal}
+          size="xl"
+          onUploadImage={async (file) => {
+            await api.uploadMyAvatar(file);
+            await refreshProfile();
+          }}
+          onRemoveImage={async () => {
+            await api.deleteMyAvatar();
+            await refreshProfile();
+          }}
+        />
+      ) : (
+        <PrincipalAvatar principal={avatarPrincipal} size="xl" />
+      )}
       <h1 className="mt-4 text-2xl font-light tracking-tight text-foreground">{displayName}</h1>
       {subEmail && <p className="mt-1 text-sm text-muted-foreground">{subEmail}</p>}
 
@@ -294,12 +338,6 @@ function ProfileSection() {
 // --- Profile helpers -------------------------------------------------------
 
 /** Up to two uppercase initials from a name, falling back to the email. */
-function initialsFrom(name: string, email: string | null): string {
-  const words = name.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
-  const base = words[0] || email?.split('@')[0] || '';
-  return base.slice(0, 2).toUpperCase() || '?';
-}
 
 function StatCell({ label, value }: { label: string; value: string }) {
   return (

--- a/apps/web/components/dashboard/desktop-sidebar.tsx
+++ b/apps/web/components/dashboard/desktop-sidebar.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useSWR from 'swr';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Plus, Loader2, LogIn, LogOut, User, PanelLeft, ListTodo, CalendarClock, BookOpen, Cog, ArrowUpCircle, Smartphone, Flag, Search } from 'lucide-react';
+import { Plus, Loader2, LogIn, LogOut, PanelLeft, ListTodo, CalendarClock, BookOpen, Cog, ArrowUpCircle, Smartphone, Flag, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -27,6 +28,8 @@ import { comboKeycaps, getShortcutCombo } from '@/lib/desktop-shortcuts';
 import { SidebarSessions } from '@/components/dashboard/sidebar-sessions';
 import { PluginSidebarItems } from '@/components/plugins/plugin-sidebar-items';
 import { SetupChecklist } from '@/components/dashboard/setup-checklist';
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import type { AuthUser } from '@/lib/auth/user';
 import { useTerminalSessions } from '@/components/terminal-pane/terminal-sessions';
 
 // Selected-row highlight for the nav buttons (New Session / Mobile / Tasks).
@@ -367,8 +370,16 @@ function LocalAccountArea() {
 /** Cloud (logged-in) mode: account email + sign out via the Electron bridge. */
 function CloudAccountArea() {
   const [email, setEmail] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
   const [signingOut, setSigningOut] = useState(false);
   const [reportIssueOpen, setReportIssueOpen] = useState(false);
+  // The avatar lives in our backend, not in the Supabase session, so it is
+  // fetched separately; until it arrives (or when there is none)
+  // `<PrincipalAvatar>` falls back to initials, then to the person glyph this
+  // row used to render unconditionally.
+  const { data: profile } = useSWR<AuthUser>('/api/supabase-user', (url: string) =>
+    fetch(url).then((res) => (res.ok ? res.json() : null)),
+  );
 
   useEffect(() => {
     const supabase = createClient();
@@ -378,11 +389,20 @@ function CloudAccountArea() {
       // Cloud mode always carries a validated Supabase session now (the gate
       // enforces it), so identity comes straight from the session.
       setEmail(session?.user?.email ?? null);
+      setUserId(session?.user?.id ?? null);
     });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  const principal = {
+    type: 'user' as const,
+    id: userId ?? profile?.id,
+    name: profile?.name || email,
+    avatarImageUri: profile?.avatarImageUri,
+    updatedAt: profile?.updatedAt,
+  };
 
   const handleSignOut = async () => {
     if (signingOut) return;
@@ -421,7 +441,7 @@ function CloudAccountArea() {
           aria-label="Account menu"
           className="flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10"
         >
-          <User className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <PrincipalAvatar principal={principal} size="sm" className="size-4" />
           <span className="flex-1 min-w-0 truncate text-xs text-muted-foreground" title={email ?? undefined}>
             {email ?? 'Signed in'}
           </span>
@@ -430,7 +450,7 @@ function CloudAccountArea() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="top" className="w-56 font-mono text-xs">
         <div className="flex items-center gap-2 bg-muted/40 px-3 py-2">
-          <User className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <PrincipalAvatar principal={principal} size="sm" className="size-4" />
           <span className="min-w-0 truncate text-muted-foreground" title={email ?? undefined}>
             {email ?? 'Account'}
           </span>

--- a/apps/web/components/dashboard/user-avatar-editor.tsx
+++ b/apps/web/components/dashboard/user-avatar-editor.tsx
@@ -12,7 +12,7 @@
 import { useRef, useState } from 'react';
 import { Camera, Loader2, X } from 'lucide-react';
 
-import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import { PrincipalAvatar, type PrincipalAvatarSize } from '@/components/ui/principal-avatar';
 import type { Principal } from '@/lib/principals';
 import { cn } from '@/lib/utils';
 
@@ -20,15 +20,25 @@ import { cn } from '@/lib/utils';
 // courtesy check so an oversized file fails instantly instead of after upload.
 const MAX_AVATAR_BYTES = 8 * 1024 * 1024;
 
+// The badges have to grow with the avatar or they swamp a 56px one and vanish
+// on an 80px one. Only the two sizes a profile surface actually uses.
+const BADGES: Record<'lg' | 'xl', { camera: string; icon: string; remove: string }> = {
+  lg: { camera: 'size-6', icon: 'size-3', remove: 'size-5' },
+  xl: { camera: 'size-7', icon: 'size-3.5', remove: 'size-6' },
+};
+
 export function UserAvatarEditor({
   principal,
+  size = 'lg',
   onUploadImage,
   onRemoveImage,
 }: {
   principal: Principal;
+  size?: Extract<PrincipalAvatarSize, 'lg' | 'xl'>;
   onUploadImage: (file: File) => Promise<void> | void;
   onRemoveImage: () => Promise<void> | void;
 }) {
+  const badge = BADGES[size];
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -70,7 +80,7 @@ export function UserAvatarEditor({
           aria-label={principal.avatarImageUri ? 'Change profile photo' : 'Upload a profile photo'}
           className="group/trigger relative block cursor-pointer rounded-full disabled:cursor-default"
         >
-          <PrincipalAvatar principal={principal} size="lg" />
+          <PrincipalAvatar principal={principal} size={size} />
           <span
             aria-hidden="true"
             className={cn(
@@ -87,12 +97,13 @@ export function UserAvatarEditor({
           <span
             aria-hidden="true"
             className={cn(
-              'absolute -bottom-0.5 -right-0.5 inline-flex size-6 items-center justify-center',
+              'absolute -bottom-0.5 -right-0.5 inline-flex items-center justify-center',
+              badge.camera,
               'rounded-full border-2 border-background bg-muted text-muted-foreground',
               'transition-colors group-hover/avatar:bg-foreground group-hover/avatar:text-background',
             )}
           >
-            <Camera className="size-3" />
+            <Camera className={badge.icon} />
           </span>
         </button>
         {/* Remove only exists once there is something to remove. */}
@@ -103,13 +114,14 @@ export function UserAvatarEditor({
             aria-label="Remove profile photo"
             title="Remove photo"
             className={cn(
-              'absolute -right-1 -top-1 inline-flex size-5 cursor-pointer items-center justify-center',
+              'absolute -right-1 -top-1 inline-flex cursor-pointer items-center justify-center',
+              badge.remove,
               'rounded-full border-2 border-background bg-muted text-muted-foreground opacity-0',
               'transition-opacity hover:text-foreground',
               'group-hover/avatar:opacity-100 focus-visible:opacity-100',
             )}
           >
-            <X className="size-3" />
+            <X className={badge.icon} />
           </button>
         )}
       </div>

--- a/apps/web/components/dashboard/user-avatar-editor.tsx
+++ b/apps/web/components/dashboard/user-avatar-editor.tsx
@@ -1,16 +1,20 @@
 'use client';
 
-// Profile-photo editor: a large PrincipalAvatar next to upload/remove actions.
-// The sibling of project-icon-editor.tsx (same 8MB client-side bound, same
-// "controlled — the caller supplies the mutations" shape), minus the emoji
-// picker: a person is not an emoji.
+// Profile-photo editor: the avatar IS the control. Clicking it opens the file
+// picker; a small camera badge on the corner is the affordance, and hovering
+// dims the image so the badge reads as an action rather than decoration.
+//
+// No separate "Upload photo" button and no permanent help text: a 56px avatar
+// with a camera on it is already the web's most recognisable "change your
+// picture" idiom, and the constraints (type, size) are enforced server-side —
+// they only need saying when something is actually rejected.
 
 import { useRef, useState } from 'react';
-import { ImagePlus, Loader2, Trash2 } from 'lucide-react';
+import { Camera, Loader2, X } from 'lucide-react';
 
 import { PrincipalAvatar } from '@/components/ui/principal-avatar';
 import type { Principal } from '@/lib/principals';
-import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 // Matches MAX_AVATAR_UPLOAD_BYTES in backend/api/users.py — this is only a
 // courtesy check so an oversized file fails instantly instead of after upload.
@@ -57,43 +61,59 @@ export function UserAvatarEditor({
   };
 
   return (
-    <div className="flex items-center gap-4">
-      {busy ? (
-        <span className="inline-flex size-14 items-center justify-center rounded-full bg-muted">
-          <Loader2 className="size-5 animate-spin text-muted-foreground" />
-        </span>
-      ) : (
-        <PrincipalAvatar principal={principal} size="lg" />
-      )}
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={busy}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <ImagePlus className="mr-2 size-3.5" />
-            {principal.avatarImageUri ? 'Change photo' : 'Upload photo'}
-          </Button>
-          {principal.avatarImageUri && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={busy}
-              onClick={() => void run(onRemoveImage)}
-            >
-              <Trash2 className="mr-2 size-3.5" />
-              Remove
-            </Button>
+    <div className="space-y-2">
+      <div className="group/avatar relative w-fit">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => fileInputRef.current?.click()}
+          aria-label={principal.avatarImageUri ? 'Change profile photo' : 'Upload a profile photo'}
+          className="group/trigger relative block cursor-pointer rounded-full disabled:cursor-default"
+        >
+          <PrincipalAvatar principal={principal} size="lg" />
+          <span
+            aria-hidden="true"
+            className={cn(
+              'absolute inset-0 rounded-full bg-black/45 opacity-0 transition-opacity',
+              'group-hover/avatar:opacity-100 group-focus-visible/trigger:opacity-100',
+              busy && 'opacity-100',
+            )}
+          />
+          {busy && (
+            <Loader2 className="absolute inset-0 m-auto size-5 animate-spin text-white" />
           )}
-        </div>
-        <p className={error ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}>
-          {error ?? 'PNG, JPEG, WebP or GIF, up to 8MB. Shown wherever you appear.'}
-        </p>
+          {/* The affordance: a camera sitting on the avatar's corner, ringed in
+              the page background so it reads as a badge at any avatar color. */}
+          <span
+            aria-hidden="true"
+            className={cn(
+              'absolute -bottom-0.5 -right-0.5 inline-flex size-6 items-center justify-center',
+              'rounded-full border-2 border-background bg-muted text-muted-foreground',
+              'transition-colors group-hover/avatar:bg-foreground group-hover/avatar:text-background',
+            )}
+          >
+            <Camera className="size-3" />
+          </span>
+        </button>
+        {/* Remove only exists once there is something to remove. */}
+        {principal.avatarImageUri && !busy && (
+          <button
+            type="button"
+            onClick={() => void run(onRemoveImage)}
+            aria-label="Remove profile photo"
+            title="Remove photo"
+            className={cn(
+              'absolute -right-1 -top-1 inline-flex size-5 cursor-pointer items-center justify-center',
+              'rounded-full border-2 border-background bg-muted text-muted-foreground opacity-0',
+              'transition-opacity hover:text-foreground',
+              'group-hover/avatar:opacity-100 focus-visible:opacity-100',
+            )}
+          >
+            <X className="size-3" />
+          </button>
+        )}
       </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
       <input
         ref={fileInputRef}
         type="file"

--- a/apps/web/components/dashboard/user-avatar-editor.tsx
+++ b/apps/web/components/dashboard/user-avatar-editor.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+// Profile-photo editor: a large PrincipalAvatar next to upload/remove actions.
+// The sibling of project-icon-editor.tsx (same 8MB client-side bound, same
+// "controlled — the caller supplies the mutations" shape), minus the emoji
+// picker: a person is not an emoji.
+
+import { useRef, useState } from 'react';
+import { ImagePlus, Loader2, Trash2 } from 'lucide-react';
+
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import type { Principal } from '@/lib/principals';
+import { Button } from '@/components/ui/button';
+
+// Matches MAX_AVATAR_UPLOAD_BYTES in backend/api/users.py — this is only a
+// courtesy check so an oversized file fails instantly instead of after upload.
+const MAX_AVATAR_BYTES = 8 * 1024 * 1024;
+
+export function UserAvatarEditor({
+  principal,
+  onUploadImage,
+  onRemoveImage,
+}: {
+  principal: Principal;
+  onUploadImage: (file: File) => Promise<void> | void;
+  onRemoveImage: () => Promise<void> | void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const run = async (action: () => Promise<void> | void) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update photo.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onFilePicked = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = ''; // allow re-picking the same file
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setError('Please choose an image file.');
+      return;
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      setError('Image must be under 8MB.');
+      return;
+    }
+    await run(() => onUploadImage(file));
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      {busy ? (
+        <span className="inline-flex size-14 items-center justify-center rounded-full bg-muted">
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        </span>
+      ) : (
+        <PrincipalAvatar principal={principal} size="lg" />
+      )}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <ImagePlus className="mr-2 size-3.5" />
+            {principal.avatarImageUri ? 'Change photo' : 'Upload photo'}
+          </Button>
+          {principal.avatarImageUri && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={busy}
+              onClick={() => void run(onRemoveImage)}
+            >
+              <Trash2 className="mr-2 size-3.5" />
+              Remove
+            </Button>
+          )}
+        </div>
+        <p className={error ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}>
+          {error ?? 'PNG, JPEG, WebP or GIF, up to 8MB. Shown wherever you appear.'}
+        </p>
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        hidden
+        onChange={(e) => void onFilePicked(e)}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/ui/principal-avatar.tsx
+++ b/apps/web/components/ui/principal-avatar.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * PrincipalAvatar — the ONE way an identity is drawn (collaboration P0).
+ *
+ * Three principal types (user, team, agent) share one component and one
+ * fallback chain, so a person looks the same in the sidebar, on a task, in a
+ * share dialog and on a public share page:
+ *
+ *   1. the stored image, served from our own storage through the authed proxy;
+ *   2. initials on the deterministic paseo hash-palette color (`lib/principals`);
+ *   3. a generic per-type glyph, when there is no name to make initials from.
+ *
+ * Nothing else should render an avatar `<img>`: hot-linking an identity
+ * provider's CDN leaks a viewer's IP to it, and hashed-email services like
+ * avatar.vercel.sh / gravatar put an email on the wire. On a shared or public
+ * surface a principal may show a display name and a picture, never an email —
+ * see the `name` prop on `Principal`.
+ */
+
+import { Bot, User as UserIcon, Users } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import {
+  type Principal,
+  type PrincipalType,
+  principalAvatarSrc,
+  principalColor,
+  principalInitials,
+} from '@/lib/principals';
+
+export type PrincipalAvatarSize = 'xs' | 'sm' | 'md' | 'lg';
+
+// Box size, plus the type size the initials need to sit right inside it.
+const SIZES: Record<PrincipalAvatarSize, { box: string; text: string; glyph: string }> = {
+  xs: { box: 'size-4', text: 'text-[8px]', glyph: 'size-2.5' },
+  sm: { box: 'size-6', text: 'text-[10px]', glyph: 'size-3.5' },
+  md: { box: 'size-8', text: 'text-xs', glyph: 'size-4' },
+  lg: { box: 'size-14', text: 'text-lg', glyph: 'size-7' },
+};
+
+// A team is a bag of people; an agent is not a person at all. Only the user
+// falls back to the single-person glyph.
+const GLYPHS: Record<PrincipalType, typeof UserIcon> = {
+  user: UserIcon,
+  team: Users,
+  agent: Bot,
+};
+
+export function PrincipalAvatar({
+  principal,
+  size = 'md',
+  className,
+  title,
+}: {
+  principal: Principal;
+  size?: PrincipalAvatarSize;
+  className?: string;
+  /** Tooltip text. Defaults to `principal.name`. */
+  title?: string;
+}) {
+  const dims = SIZES[size];
+  // Agents are square-ish (they are a thing, not a face); people and teams are round.
+  const shape = principal.type === 'agent' ? 'rounded-md' : 'rounded-full';
+  const box = cn('shrink-0 overflow-hidden', dims.box, shape, className);
+  const label = title ?? principal.name ?? undefined;
+
+  const src = principalAvatarSrc(principal);
+  if (src) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- authed proxy stream, not a static asset
+      <img
+        src={src}
+        alt=""
+        aria-hidden="true"
+        title={label}
+        className={cn('object-cover', box)}
+      />
+    );
+  }
+
+  const initials = principalInitials(principal.name);
+  if (initials) {
+    return (
+      <span
+        title={label}
+        aria-hidden="true"
+        style={{ backgroundColor: principalColor(principal) }}
+        className={cn(
+          'inline-flex items-center justify-center font-semibold leading-none text-white uppercase',
+          dims.text,
+          box,
+        )}
+      >
+        {initials}
+      </span>
+    );
+  }
+
+  const Glyph = GLYPHS[principal.type];
+  return (
+    <span
+      title={label}
+      aria-hidden="true"
+      className={cn('inline-flex items-center justify-center bg-muted text-muted-foreground', box)}
+    >
+      <Glyph className={dims.glyph} />
+    </span>
+  );
+}

--- a/apps/web/components/ui/principal-avatar.tsx
+++ b/apps/web/components/ui/principal-avatar.tsx
@@ -29,7 +29,7 @@ import {
   principalInitials,
 } from '@/lib/principals';
 
-export type PrincipalAvatarSize = 'xs' | 'sm' | 'md' | 'lg';
+export type PrincipalAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 // Box size, plus the type size the initials need to sit right inside it.
 const SIZES: Record<PrincipalAvatarSize, { box: string; text: string; glyph: string }> = {
@@ -37,6 +37,8 @@ const SIZES: Record<PrincipalAvatarSize, { box: string; text: string; glyph: str
   sm: { box: 'size-6', text: 'text-[10px]', glyph: 'size-3.5' },
   md: { box: 'size-8', text: 'text-xs', glyph: 'size-4' },
   lg: { box: 'size-14', text: 'text-lg', glyph: 'size-7' },
+  // Profile pages, where the avatar is the page's subject rather than a label.
+  xl: { box: 'size-20', text: 'text-2xl', glyph: 'size-9' },
 };
 
 // A team is a bag of people; an agent is not a person at all. Only the user

--- a/apps/web/components/ui/principal-avatar.tsx
+++ b/apps/web/components/ui/principal-avatar.tsx
@@ -26,19 +26,22 @@ import {
   type PrincipalType,
   principalAvatarSrc,
   principalColor,
-  principalInitials,
+  principalInitial,
 } from '@/lib/principals';
 
 export type PrincipalAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-// Box size, plus the type size the initials need to sit right inside it.
+// Box size, plus the type size the initial needs to sit right inside it.
+// The letter runs ~0.25-0.30 of the box (it climbs at the small end only
+// because 16px has a legibility floor): a monogram wants to read as a mark
+// inside the circle, not fill it. Keep the Flutter twin's table in step.
 const SIZES: Record<PrincipalAvatarSize, { box: string; text: string; glyph: string }> = {
   xs: { box: 'size-4', text: 'text-[8px]', glyph: 'size-2.5' },
-  sm: { box: 'size-6', text: 'text-[10px]', glyph: 'size-3.5' },
-  md: { box: 'size-8', text: 'text-xs', glyph: 'size-4' },
-  lg: { box: 'size-14', text: 'text-lg', glyph: 'size-7' },
+  sm: { box: 'size-6', text: 'text-[9px]', glyph: 'size-3.5' },
+  md: { box: 'size-8', text: 'text-[11px]', glyph: 'size-4' },
+  lg: { box: 'size-14', text: 'text-base', glyph: 'size-7' },
   // Profile pages, where the avatar is the page's subject rather than a label.
-  xl: { box: 'size-20', text: 'text-2xl', glyph: 'size-9' },
+  xl: { box: 'size-20', text: 'text-xl', glyph: 'size-9' },
 };
 
 // A team is a bag of people; an agent is not a person at all. Only the user
@@ -81,20 +84,20 @@ export function PrincipalAvatar({
     );
   }
 
-  const initials = principalInitials(principal.name);
-  if (initials) {
+  const initial = principalInitial(principal.name);
+  if (initial) {
     return (
       <span
         title={label}
         aria-hidden="true"
         style={{ backgroundColor: principalColor(principal) }}
         className={cn(
-          'inline-flex items-center justify-center font-semibold leading-none text-white uppercase',
+          'inline-flex items-center justify-center font-normal leading-none text-white uppercase',
           dims.text,
           box,
         )}
       >
-        {initials}
+        {initial}
       </span>
     );
   }

--- a/apps/web/components/unified-user-menu.tsx
+++ b/apps/web/components/unified-user-menu.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
 import { signOutBrowser } from '@/lib/auth/sign-out';
 import { useRouter } from 'next/navigation';
 import type { AuthUser } from '@/lib/auth/user';
@@ -69,11 +69,6 @@ export function UnifiedUserMenu({ variant = 'avatar' }: UnifiedUserMenuProps) {
     return user?.email || user?.name || 'User';
   };
 
-  const getUserInitials = (user: any) => {
-    const name = getUserDisplayName(user);
-    return name.split(' ').map((n: string) => n[0]).join('').substring(0, 2).toUpperCase();
-  };
-
   if (variant === 'button') {
     return (
       <Button asChild variant="outline" className="rounded-full h-10">
@@ -85,15 +80,23 @@ export function UnifiedUserMenu({ variant = 'avatar' }: UnifiedUserMenuProps) {
   return (
     <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
       <DropdownMenuTrigger asChild>
-        <Avatar className="cursor-pointer size-9">
-          <AvatarImage 
-            src={`https://avatar.vercel.sh/${user.email}`} 
-            alt={getUserDisplayName(user)} 
+        {/* PrincipalAvatar renders a bare <img>/<span>, so the trigger needs a
+            real button for asChild to attach to. One avatar component
+            everywhere: the old avatar.vercel.sh source put the user's email in a
+            third-party URL on every page load. */}
+        <button type="button" aria-label="Account menu" className="cursor-pointer">
+          <PrincipalAvatar
+            principal={{
+              type: 'user',
+              id: user.id,
+              name: user.name || user.email,
+              avatarImageUri: user.avatarImageUri,
+              updatedAt: user.updatedAt,
+            }}
+            size="md"
+            className="size-9"
           />
-          <AvatarFallback>
-            {getUserInitials(user)}
-          </AvatarFallback>
-        </Avatar>
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="flex flex-col gap-1">
         <div className="px-2 py-1.5 text-sm text-muted-foreground border-b">

--- a/apps/web/lib/auth/user.ts
+++ b/apps/web/lib/auth/user.ts
@@ -9,4 +9,8 @@ export type AuthUser = {
   name?: string | null;
   createdAt?: string;
   role?: string;
+  /** Backend `users.avatar_image_uri` — null when the user has no stored image. */
+  avatarImageUri?: string | null;
+  /** Backend `users.updated_at` — cache-buster for the stable avatar URL. */
+  updatedAt?: string | null;
 };

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -30,6 +30,21 @@ export interface UserProfile {
   id: string;
   email: string;
   display_name: string | null;
+  /** Served by us (/api/v1/users/{id}/avatar); render via `<PrincipalAvatar>`. */
+  avatar_image_uri?: string | null;
+  avatar_source?: string | null;
+  /** Cache-buster for the stable avatar URL (see lib/principals.ts). */
+  updated_at?: string | null;
+}
+
+/** The avatar endpoints' payload. Deliberately carries no email — an avatar is
+ *  the one identity field a shared surface renders. */
+export interface UserAvatar {
+  id: string;
+  display_name: string | null;
+  avatar_image_uri: string | null;
+  avatar_source: string | null;
+  updated_at: string;
 }
 
 export interface APIKeyResponse {
@@ -726,6 +741,36 @@ class BackendAPI {
 
   async deleteUserAccount() {
     return this.request('/api/v1/auth/me', { method: 'DELETE' });
+  }
+
+  /** Set the caller's avatar. 'user' wins over any later OAuth re-seed. */
+  async uploadMyAvatar(file: File | Blob): Promise<UserAvatar> {
+    const headers = await this.getHeaders();
+    // Let the browser set the multipart boundary; a fixed JSON type breaks it.
+    delete headers['Content-Type'];
+    const form = new FormData();
+    form.append('file', file);
+    const response = await fetch(`${this.config.baseUrl}/api/v1/me/avatar`, {
+      method: 'PUT',
+      headers,
+      body: form,
+    });
+    if (!response.ok) {
+      let message = `Backend API error: ${response.status} ${response.statusText}`;
+      try {
+        const body = await response.json();
+        if (typeof body?.detail === 'string' && body.detail.trim()) message = body.detail;
+      } catch {
+        // fall back to the generic HTTP error
+      }
+      throw Object.assign(new Error(message), { status: response.status });
+    }
+    return response.json();
+  }
+
+  /** Drop the caller's avatar image → generated initials. */
+  async deleteMyAvatar(): Promise<UserAvatar> {
+    return this.request<UserAvatar>('/api/v1/me/avatar', { method: 'DELETE' });
   }
 
   // API Key management

--- a/apps/web/lib/principals.test.ts
+++ b/apps/web/lib/principals.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { principalAvatarSrc, principalColor, principalInitials } from './principals';
+import { projectAvatarColor } from './project-icons';
+
+describe('principalAvatarSrc', () => {
+  it('points at the same-origin authed proxy, cache-busted by updated_at', () => {
+    expect(
+      principalAvatarSrc({
+        type: 'user',
+        id: 'u1',
+        avatarImageUri: '/api/v1/users/u1/avatar',
+        updatedAt: '2026-09-08T00:00:00+00:00',
+      }),
+    ).toBe('/api/users/u1/avatar?v=2026-09-08T00%3A00%3A00%2B00%3A00');
+  });
+
+  it('is null without a stored image, so the caller falls back to initials', () => {
+    expect(principalAvatarSrc({ type: 'user', id: 'u1', avatarImageUri: null })).toBeNull();
+    expect(principalAvatarSrc(null)).toBeNull();
+  });
+
+  it('never hot-links the identity provider even if the URI is absolute', () => {
+    const src = principalAvatarSrc({
+      type: 'user',
+      id: 'u1',
+      avatarImageUri: 'https://lh3.googleusercontent.com/a/x',
+    });
+    expect(src).toBe('/api/users/u1/avatar');
+  });
+
+  it('has no image for teams or agents yet (P1/P3)', () => {
+    expect(
+      principalAvatarSrc({ type: 'team', id: 't1', avatarImageUri: '/api/v1/users/t1/avatar' }),
+    ).toBeNull();
+  });
+});
+
+describe('principalColor', () => {
+  it('is deterministic and shares the project-icon palette', () => {
+    const principal = { type: 'user' as const, id: 'u1', name: 'Ada' };
+    expect(principalColor(principal)).toBe(principalColor(principal));
+    expect(principalColor(principal)).toBe(projectAvatarColor('u1'));
+  });
+
+  it('seeds by name when there is no id', () => {
+    expect(principalColor({ type: 'team', name: 'Platform' })).toBe(
+      projectAvatarColor('Platform'),
+    );
+  });
+});
+
+describe('principalInitials', () => {
+  it('takes two initials from a full name, one from a single word', () => {
+    expect(principalInitials('Ada Lovelace')).toBe('AL');
+    expect(principalInitials('  ada   lovelace  king ')).toBe('AL');
+    expect(principalInitials('ada')).toBe('A');
+  });
+
+  it('handles non-ASCII names by code point, not byte', () => {
+    expect(principalInitials('Émile Borel')).toBe('ÉB');
+    expect(principalInitials('张伟')).toBe('张');
+  });
+
+  it('is null with no name, so the caller falls through to the glyph', () => {
+    expect(principalInitials('')).toBeNull();
+    expect(principalInitials('   ')).toBeNull();
+    expect(principalInitials(null)).toBeNull();
+  });
+});

--- a/apps/web/lib/principals.test.ts
+++ b/apps/web/lib/principals.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { principalAvatarSrc, principalColor, principalInitials } from './principals';
+import { principalAvatarSrc, principalColor, principalInitial } from './principals';
 import { projectAvatarColor } from './project-icons';
 
 describe('principalAvatarSrc', () => {
@@ -50,21 +50,23 @@ describe('principalColor', () => {
   });
 });
 
-describe('principalInitials', () => {
-  it('takes two initials from a full name, one from a single word', () => {
-    expect(principalInitials('Ada Lovelace')).toBe('AL');
-    expect(principalInitials('  ada   lovelace  king ')).toBe('AL');
-    expect(principalInitials('ada')).toBe('A');
+describe('principalInitial', () => {
+  it('is one letter, whatever the name is made of', () => {
+    expect(principalInitial('Ada Lovelace')).toBe('A');
+    expect(principalInitial('  ada   lovelace  king ')).toBe('A');
+    expect(principalInitial('ada')).toBe('A');
   });
 
   it('handles non-ASCII names by code point, not byte', () => {
-    expect(principalInitials('Émile Borel')).toBe('ÉB');
-    expect(principalInitials('张伟')).toBe('张');
+    expect(principalInitial('Émile Borel')).toBe('É');
+    expect(principalInitial('张伟')).toBe('张');
+    // A surrogate pair must not be sliced in half into a replacement glyph.
+    expect(principalInitial('🙂 nick')).toBe('🙂');
   });
 
   it('is null with no name, so the caller falls through to the glyph', () => {
-    expect(principalInitials('')).toBeNull();
-    expect(principalInitials('   ')).toBeNull();
-    expect(principalInitials(null)).toBeNull();
+    expect(principalInitial('')).toBeNull();
+    expect(principalInitial('   ')).toBeNull();
+    expect(principalInitial(null)).toBeNull();
   });
 });

--- a/apps/web/lib/principals.ts
+++ b/apps/web/lib/principals.ts
@@ -50,13 +50,16 @@ export function principalColor(principal: Principal): string {
   return projectAvatarColor(principal.id || principal.name || principal.type);
 }
 
-/** Up to two initials from a display name — `null` when there is no name. */
-export function principalInitials(name: string | null | undefined): string | null {
+/**
+ * A principal's single initial — `null` when there is no name.
+ *
+ * One letter, not two: a monogram reads as a mark at any size, while "AL" in a
+ * 24px circle is two shapes fighting for the same space and starts to look like
+ * a label. Same rule the project icons already follow (`projectInitial`); the
+ * wrapper exists because they render `·` for an empty name and this has to
+ * return null so the caller can fall through to the glyph.
+ */
+export function principalInitial(name: string | null | undefined): string | null {
   const trimmed = (name ?? '').trim();
-  if (!trimmed) return null;
-  const words = trimmed.split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return (projectInitial(words[0]) + projectInitial(words[1])).slice(0, 2);
-  }
-  return projectInitial(trimmed);
+  return trimmed ? projectInitial(trimmed) : null;
 }

--- a/apps/web/lib/principals.ts
+++ b/apps/web/lib/principals.ts
@@ -1,0 +1,62 @@
+/**
+ * Principal identity helpers — the data half of `<PrincipalAvatar>`.
+ *
+ * Collaboration has three principals (user, team, agent) and they all render
+ * the same way, so the fallback chain lives in one place: stored image →
+ * initials on a deterministic palette color → a generic glyph. The palette and
+ * hash are the ones project icons already use (`lib/project-icons.ts`), so a
+ * principal and a project seeded from the same id get the same color.
+ */
+
+import { projectAvatarColor, projectInitial } from './project-icons';
+
+export type PrincipalType = 'user' | 'team' | 'agent';
+
+export type Principal = {
+  type: PrincipalType;
+  /** Stable id — seeds the fallback color and addresses the stored image. */
+  id?: string | null;
+  /**
+   * Display name — the seed for initials and the default tooltip.
+   *
+   * On a shared or public surface this must be a display name and nothing
+   * else: an email may never appear there (P0 privacy rule). In the signed-in
+   * user's own chrome, falling back to their own email for an initial is fine
+   * — it is already on screen next to the avatar.
+   */
+  name?: string | null;
+  /** Backend-relative served URL (e.g. `users.avatar_image_uri`), or null. */
+  avatarImageUri?: string | null;
+  /** Cache-buster — the row's `updated_at`; the avatar URL itself is stable. */
+  updatedAt?: string | null;
+};
+
+/**
+ * <img src> for a principal's stored avatar, or null (→ initials/glyph).
+ *
+ * Like project icons, an <img> can't send the backend bearer, so this points at
+ * the web's own same-origin cookie-authed proxy rather than at the backend or —
+ * never — at the identity provider's CDN.
+ */
+export function principalAvatarSrc(principal: Principal | null | undefined): string | null {
+  if (!principal?.id || !principal.avatarImageUri) return null;
+  if (principal.type !== 'user') return null; // teams/agents get images in P3/P1
+  const version = principal.updatedAt ? `?v=${encodeURIComponent(principal.updatedAt)}` : '';
+  return `/api/users/${principal.id}/avatar${version}`;
+}
+
+/** Deterministic palette color for a principal (seeded by id, then name). */
+export function principalColor(principal: Principal): string {
+  return projectAvatarColor(principal.id || principal.name || principal.type);
+}
+
+/** Up to two initials from a display name — `null` when there is no name. */
+export function principalInitials(name: string | null | undefined): string | null {
+  const trimmed = (name ?? '').trim();
+  if (!trimmed) return null;
+  const words = trimmed.split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return (projectInitial(words[0]) + projectInitial(words[1])).slice(0, 2);
+  }
+  return projectInitial(trimmed);
+}

--- a/backend/src/backend/api/users.py
+++ b/backend/src/backend/api/users.py
@@ -1,0 +1,150 @@
+"""User identity API: the avatar bytes behind ``<PrincipalAvatar>`` (collab P0).
+
+Deliberately the mirror of the project-icon endpoints in :mod:`backend.api.tasks`
+— same upload validation, same storage key shape, same served-URL indirection —
+because a user and a project are two of the three principals the avatar
+component renders, and they should not drift.
+
+Privacy: an avatar is the one piece of identity that shows up on a shared
+surface, so nothing here ever returns an email. ``GET /users/{id}/avatar``
+answers image bytes or 404, nothing else.
+"""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import Response
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from shared import avatars, storage
+from shared.database.models import User
+from shared.database.session import get_db
+from shared.images import InvalidImageError, process_image
+
+from ..auth.dependencies import get_current_user
+from ..db import user_queries
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["users"])
+
+# Bounds the request body; decode memory is bounded separately by
+# shared.images.MAX_PIXELS.
+MAX_AVATAR_UPLOAD_BYTES = 8 * 1024 * 1024
+# The raster types process_image emits — served inline; anything else is a bug.
+_INLINE_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
+
+
+class UserAvatarResponse(BaseModel):
+    """Just the avatar fields — never the email (see the module docstring)."""
+
+    id: str
+    display_name: str | None
+    avatar_image_uri: str | None
+    avatar_source: str | None
+    updated_at: str
+
+
+def _avatar_response(user: User) -> UserAvatarResponse:
+    return UserAvatarResponse(
+        id=str(user.id),
+        display_name=user.display_name,
+        avatar_image_uri=user.avatar_image_uri,
+        avatar_source=user.avatar_source,
+        updated_at=user.updated_at.isoformat(),
+    )
+
+
+@router.put("/me/avatar", response_model=UserAvatarResponse)
+def upload_my_avatar(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserAvatarResponse:
+    """Set the caller's avatar from an upload. 'user' beats any OAuth re-seed."""
+    raw = file.file.read(MAX_AVATAR_UPLOAD_BYTES + 1)
+    if len(raw) > MAX_AVATAR_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Image exceeds {MAX_AVATAR_UPLOAD_BYTES // (1024 * 1024)}MB limit",
+        )
+    if not raw:
+        raise HTTPException(status_code=400, detail="File is empty")
+    try:
+        processed = process_image(raw)
+    except InvalidImageError as exc:
+        raise HTTPException(
+            status_code=400, detail="Not a valid image in a supported format"
+        ) from exc
+
+    try:
+        storage.upload_attachment(
+            storage.user_avatar_key(str(current_user.id)),
+            processed.data,
+            processed.mime_type,
+        )
+    except Exception as exc:
+        logger.exception("avatar upload to S3 failed")
+        raise HTTPException(status_code=502, detail="Failed to store image") from exc
+
+    updated = user_queries.set_user_avatar(
+        db, current_user, avatar_image_uri=avatars.avatar_served_url(current_user.id)
+    )
+    return _avatar_response(updated)
+
+
+@router.delete("/me/avatar", response_model=UserAvatarResponse)
+def delete_my_avatar(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserAvatarResponse:
+    """Drop the image and fall back to generated initials."""
+    if current_user.avatar_image_uri:
+        try:
+            storage.delete_object(storage.user_avatar_key(str(current_user.id)))
+        except Exception:
+            # Orphaned S3 object is harmless; never fail the reset on it.
+            logger.warning("avatar S3 delete failed for %s", current_user.id)
+    return _avatar_response(user_queries.clear_user_avatar(db, current_user))
+
+
+@router.get("/users/{user_id}/avatar")
+def get_user_avatar(
+    user_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> Response:
+    """Serve a user's avatar bytes (uploaded or OAuth-seeded).
+
+    Authenticated but not grant-scoped: an avatar is the least sensitive field a
+    principal has, it is exactly what a shared surface is meant to show, and the
+    id has to be known already to ask. When ``shared/access.py`` lands (P3) this
+    is where a visibility check would go; until then a uniform 404 is the only
+    signal, and no email or name is reachable through it.
+    """
+    user = db.get(User, user_id)
+    if user is None or not user.avatar_image_uri:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Avatar not found"
+        )
+    try:
+        data, content_type = storage.download_object(
+            storage.user_avatar_key(str(user_id))
+        )
+    except Exception as exc:
+        logger.exception("avatar download from S3 failed")
+        raise HTTPException(status_code=502, detail="Failed to fetch image") from exc
+    if content_type not in _INLINE_IMAGE_TYPES:
+        content_type = "application/octet-stream"
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={
+            # Short-lived: the URL is stable across replacements, so clients
+            # cache-bust with the user's updated_at instead of relying on this.
+            "Cache-Control": "private, max-age=300",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/backend/src/backend/auth/dependencies.py
+++ b/backend/src/backend/auth/dependencies.py
@@ -114,23 +114,39 @@ def _schedule_user_created_hooks(background_tasks: BackgroundTasks, user: User) 
 
 
 def _schedule_signup_side_effects(
-    background_tasks: BackgroundTasks, user: User, avatar_url: str | None = None
+    background_tasks: BackgroundTasks, user: User
 ) -> None:
     """Everything that happens once, the moment a user's local row appears.
 
-    Most of it runs via the open core's ``on_user_created`` hooks — the overlay
+    All of it runs via the open core's ``on_user_created`` hooks — the overlay
     registers the welcome email and the marketing-list subscribe there. The open
     core carries no such wiring; each hook is isolated
     (``run_user_created_hooks``), so one failing cannot stop the others.
-
-    The avatar seed is core, not a hook: it needs the IdP's ``avatar_url``
-    claim, which only exists on this request. It is best-effort and stamps
-    ``avatar_source`` even when it misses, so it never runs twice for the same
-    user — including for the built-in provider, which has no avatar to offer and
-    passes None.
     """
     _schedule_user_created_hooks(background_tasks, user)
-    background_tasks.add_task(seed_user_avatar, user.id, avatar_url)
+
+
+def _maybe_seed_avatar(
+    background_tasks: BackgroundTasks, user: User, avatar_url: str | None
+) -> None:
+    """Queue the one-shot IdP avatar seed when this user still has none.
+
+    Checked on EVERY authenticated request, not only at signup: the column is
+    newer than almost every account, so a signup-only seed would leave the
+    entire existing userbase blank forever. Supabase republishes
+    ``user_metadata.avatar_url`` on every token, so the backfill costs one
+    fetch per user, the first time they load anything after this ships.
+
+    Cheap enough to sit on the hot path — three in-memory attribute reads, no
+    query. It converges because ``seed_user_avatar`` stamps ``avatar_source`` on
+    hit *and* miss; a user whose IdP publishes no picture (Apple, and the
+    built-in provider) never enqueues at all, so their source stays NULL and
+    they become eligible for free if they later link an account that has one.
+    Concurrent enqueues are safe: the task re-checks eligibility in its own
+    session.
+    """
+    if avatar_url and user.avatar_source is None and not user.avatar_image_uri:
+        background_tasks.add_task(seed_user_avatar, user.id, avatar_url)
 
 
 async def get_current_user(
@@ -143,7 +159,8 @@ async def get_current_user(
     if user is None:
         raise AuthError("User not found")
     if created:
-        _schedule_signup_side_effects(background_tasks, user, claims.avatar_url)
+        _schedule_signup_side_effects(background_tasks, user)
+    _maybe_seed_avatar(background_tasks, user, claims.avatar_url)
     return user
 
 
@@ -165,6 +182,8 @@ async def get_optional_current_user(
     except Exception:
         return None
 
-    if user is not None and created:
-        _schedule_signup_side_effects(background_tasks, user, claims.avatar_url)
+    if user is not None:
+        if created:
+            _schedule_signup_side_effects(background_tasks, user)
+        _maybe_seed_avatar(background_tasks, user, claims.avatar_url)
     return user

--- a/backend/src/backend/auth/dependencies.py
+++ b/backend/src/backend/auth/dependencies.py
@@ -14,6 +14,7 @@ from shared.database.users import ensure_local_user
 from sqlalchemy.orm import Session
 
 from shared.auth import Principal, verify_user_token
+from shared.avatars import seed_user_avatar
 from shared.hooks import run_user_created_hooks
 
 logger = logging.getLogger(__name__)
@@ -113,16 +114,23 @@ def _schedule_user_created_hooks(background_tasks: BackgroundTasks, user: User) 
 
 
 def _schedule_signup_side_effects(
-    background_tasks: BackgroundTasks, user: User
+    background_tasks: BackgroundTasks, user: User, avatar_url: str | None = None
 ) -> None:
     """Everything that happens once, the moment a user's local row appears.
 
-    All of it runs via the open core's ``on_user_created`` hooks — the overlay
+    Most of it runs via the open core's ``on_user_created`` hooks — the overlay
     registers the welcome email and the marketing-list subscribe there. The open
     core carries no such wiring; each hook is isolated
     (``run_user_created_hooks``), so one failing cannot stop the others.
+
+    The avatar seed is core, not a hook: it needs the IdP's ``avatar_url``
+    claim, which only exists on this request. It is best-effort and stamps
+    ``avatar_source`` even when it misses, so it never runs twice for the same
+    user — including for the built-in provider, which has no avatar to offer and
+    passes None.
     """
     _schedule_user_created_hooks(background_tasks, user)
+    background_tasks.add_task(seed_user_avatar, user.id, avatar_url)
 
 
 async def get_current_user(
@@ -135,7 +143,7 @@ async def get_current_user(
     if user is None:
         raise AuthError("User not found")
     if created:
-        _schedule_signup_side_effects(background_tasks, user)
+        _schedule_signup_side_effects(background_tasks, user, claims.avatar_url)
     return user
 
 
@@ -158,5 +166,5 @@ async def get_optional_current_user(
         return None
 
     if user is not None and created:
-        _schedule_signup_side_effects(background_tasks, user)
+        _schedule_signup_side_effects(background_tasks, user, claims.avatar_url)
     return user

--- a/backend/src/backend/auth/routes.py
+++ b/backend/src/backend/auth/routes.py
@@ -43,6 +43,12 @@ class UserProfile(BaseModel):
     email: str
     display_name: str | None
     created_at: str
+    # Identity (collaboration P0). ``avatar_image_uri`` is served by us
+    # (/api/v1/users/{id}/avatar) and is stable across replacements, so clients
+    # cache-bust with ``updated_at``.
+    avatar_image_uri: str | None = None
+    avatar_source: str | None = None
+    updated_at: str | None = None
 
 
 class UpdateProfileRequest(BaseModel):
@@ -133,6 +139,9 @@ async def get_session(user: User | None = Depends(get_optional_current_user)):
             email=user.email,
             display_name=user.display_name,
             created_at=user.created_at.isoformat(),
+            avatar_image_uri=user.avatar_image_uri,
+            avatar_source=user.avatar_source,
+            updated_at=user.updated_at.isoformat(),
         )
     else:
         raise HTTPException(status_code=401, detail="Not authenticated")
@@ -146,6 +155,9 @@ async def get_current_user_profile(current_user: User = Depends(get_current_user
         email=current_user.email,
         display_name=current_user.display_name,
         created_at=current_user.created_at.isoformat(),
+        avatar_image_uri=current_user.avatar_image_uri,
+        avatar_source=current_user.avatar_source,
+        updated_at=current_user.updated_at.isoformat(),
     )
 
 
@@ -163,6 +175,9 @@ async def update_current_user_profile(
         email=updated_user.email,
         display_name=updated_user.display_name,
         created_at=updated_user.created_at.isoformat(),
+        avatar_image_uri=updated_user.avatar_image_uri,
+        avatar_source=updated_user.avatar_source,
+        updated_at=updated_user.updated_at.isoformat(),
     )
 
 

--- a/backend/src/backend/db/user_queries.py
+++ b/backend/src/backend/db/user_queries.py
@@ -1,0 +1,35 @@
+"""Writes against the caller's own ``users`` row (collaboration P0).
+
+Mirrors ``task_queries.set_project_icon`` / ``reset_project_icon``: the router
+validates and stores the bytes, the query layer owns the transaction. Keeping
+the commit here (rather than in ``backend/api/``) is also what keeps
+``scripts/check_websocket_freeze.py`` happy.
+"""
+
+from sqlalchemy.orm import Session
+
+from shared.database.models import User
+
+
+def set_user_avatar(db: Session, user: User, *, avatar_image_uri: str) -> User:
+    """Point a user at their uploaded avatar. ``'user'`` beats any OAuth seed."""
+    user.avatar_image_uri = avatar_image_uri
+    user.avatar_source = "user"
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def clear_user_avatar(db: Session, user: User) -> User:
+    """Drop the image so the user renders as generated initials.
+
+    ``avatar_source`` is pinned to ``'user'`` rather than NULL on purpose: NULL
+    would make the account seed-eligible again, so the next sign-in would
+    silently restore the OAuth picture the user just removed — the same trap
+    ``reset_project_icon`` documents for the git seed.
+    """
+    user.avatar_image_uri = None
+    user.avatar_source = "user"
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -35,6 +35,7 @@ from .api import (
     tasks,
     automations,
     search,
+    users,
 )
 from shared.auth import resolve_auth_provider_name
 from .auth import routes as auth_routes
@@ -173,6 +174,7 @@ app.include_router(support.router, prefix=settings.api_v1_prefix)
 app.include_router(tasks.router, prefix=settings.api_v1_prefix)
 app.include_router(automations.router, prefix=settings.api_v1_prefix)
 app.include_router(search.router, prefix=settings.api_v1_prefix)
+app.include_router(users.router, prefix=settings.api_v1_prefix)
 
 # Sign-up / sign-in endpoints only exist when this deployment *is* the identity
 # provider. Mounting them against a Supabase-backed deployment would add a

--- a/backend/src/backend/tests/test_user_avatars.py
+++ b/backend/src/backend/tests/test_user_avatars.py
@@ -1,0 +1,259 @@
+"""User avatars: upload/serve/delete, the OAuth seed, and re-seed precedence.
+
+The sibling of test_project_icons.py — same pipeline, same invariant that a
+'user' upload is never clobbered by a re-seed.
+"""
+
+from datetime import datetime, timezone
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from PIL import Image
+
+import shared.avatars as avatars
+import shared.storage as storage_module
+from shared.database.models import User
+
+
+def _png_bytes(width: int = 64, height: int = 64, color=(20, 120, 200)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (width, height), color=color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _seed_uses_test_engine(test_db, monkeypatch):
+    """Bind the seed's own-session factory to the test container's engine.
+
+    seed_user_avatar() opens ``SessionLocal`` (module-level, bound to the
+    settings DB) because it runs as a background task; point it at the test DB.
+    """
+    from sqlalchemy.orm import sessionmaker
+
+    local = sessionmaker(bind=test_db.get_bind(), autoflush=False, autocommit=False)
+    monkeypatch.setattr(avatars, "SessionLocal", local)
+
+
+@pytest.fixture
+def fake_avatar_storage(monkeypatch):
+    """In-memory stand-in for the S3 object store."""
+    store: dict[str, tuple[bytes, str]] = {}
+
+    def upload(key, data, mime_type):
+        store[key] = (data, mime_type)
+
+    def download_object(key):
+        return store[key]
+
+    def delete_object(key):
+        store.pop(key, None)
+
+    monkeypatch.setattr(storage_module, "upload_attachment", upload)
+    monkeypatch.setattr(storage_module, "download_object", download_object)
+    monkeypatch.setattr(storage_module, "delete_object", delete_object)
+    return store
+
+
+class TestAllowedAvatarUrl:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://lh3.googleusercontent.com/a/ACg8ocK=s96-c",
+            "https://avatars.githubusercontent.com/u/12345?v=4",
+            "https://secure.gravatar.com/avatar/abc",
+        ],
+    )
+    def test_allowlisted_hosts_pass_through(self, url):
+        assert avatars.allowed_avatar_url(url) == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            None,
+            "",
+            "http://lh3.googleusercontent.com/a/x",  # not https
+            "https://evil.example/a.png",  # unknown host
+            "https://lh3.googleusercontent.com.evil.example/a.png",  # suffix trick
+            # userinfo trick: the real host is evil.example, not the allowlisted one
+            "https://lh3.googleusercontent.com@evil.example/a.png",
+            "file:///etc/passwd",
+            "https://127.0.0.1/a.png",
+            "https://[::1]/a.png",
+        ],
+    )
+    def test_everything_else_is_refused(self, url):
+        assert avatars.allowed_avatar_url(url) is None
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    def __init__(self, content):
+        self._content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def get(self, url):
+        return _FakeResp(self._content)
+
+
+GOOGLE_AVATAR = "https://lh3.googleusercontent.com/a/ACg8ocK=s96-c"
+
+
+class TestOAuthSeed:
+    def test_seed_from_google_sets_oauth_source(
+        self, test_db, test_user, fake_avatar_storage, monkeypatch
+    ):
+        monkeypatch.setattr(
+            avatars.httpx, "Client", lambda *a, **k: _FakeClient(_png_bytes())
+        )
+        avatars.seed_user_avatar(test_user.id, GOOGLE_AVATAR)
+        test_db.expire_all()
+        refreshed = test_db.get(User, test_user.id)
+        assert refreshed.avatar_source == "oauth"
+        assert refreshed.avatar_image_uri == f"/api/v1/users/{test_user.id}/avatar"
+        assert storage_module.user_avatar_key(str(test_user.id)) in fake_avatar_storage
+
+    def test_seed_without_a_url_marks_attempted(
+        self, test_db, test_user, fake_avatar_storage
+    ):
+        # Apple sign-in publishes no picture at all — the common case.
+        avatars.seed_user_avatar(test_user.id, None)
+        test_db.expire_all()
+        refreshed = test_db.get(User, test_user.id)
+        assert refreshed.avatar_source == "oauth"  # attempted → won't retry
+        assert refreshed.avatar_image_uri is None
+
+    def test_disallowed_host_is_never_fetched(
+        self, test_db, test_user, fake_avatar_storage, monkeypatch
+    ):
+        def explode(*a, **k):
+            raise AssertionError("must not fetch a non-allowlisted host")
+
+        monkeypatch.setattr(avatars.httpx, "Client", explode)
+        avatars.seed_user_avatar(test_user.id, "https://evil.example/a.png")
+        test_db.expire_all()
+        assert test_db.get(User, test_user.id).avatar_image_uri is None
+
+    def test_seed_never_clobbers_a_user_upload(
+        self, test_db, test_user, fake_avatar_storage, monkeypatch
+    ):
+        test_user.avatar_source = "user"
+        test_user.avatar_image_uri = f"/api/v1/users/{test_user.id}/avatar"
+        test_db.commit()
+        monkeypatch.setattr(
+            avatars.httpx, "Client", lambda *a, **k: _FakeClient(_png_bytes())
+        )
+        avatars.seed_user_avatar(test_user.id, GOOGLE_AVATAR)
+        test_db.expire_all()
+        refreshed = test_db.get(User, test_user.id)
+        assert refreshed.avatar_source == "user"
+        assert refreshed.avatar_image_uri == f"/api/v1/users/{test_user.id}/avatar"
+
+    def test_failed_fetch_marks_attempted_and_leaves_no_image(
+        self, test_db, test_user, fake_avatar_storage, monkeypatch
+    ):
+        class _Boom(_FakeClient):
+            def get(self, url):
+                raise avatars.httpx.ConnectError("nope")
+
+        monkeypatch.setattr(avatars.httpx, "Client", lambda *a, **k: _Boom(b""))
+        avatars.seed_user_avatar(test_user.id, GOOGLE_AVATAR)
+        test_db.expire_all()
+        refreshed = test_db.get(User, test_user.id)
+        assert refreshed.avatar_source == "oauth"
+        assert refreshed.avatar_image_uri is None
+
+    def test_non_image_bytes_are_rejected(
+        self, test_db, test_user, fake_avatar_storage, monkeypatch
+    ):
+        monkeypatch.setattr(
+            avatars.httpx, "Client", lambda *a, **k: _FakeClient(b"not an image")
+        )
+        avatars.seed_user_avatar(test_user.id, GOOGLE_AVATAR)
+        test_db.expire_all()
+        assert test_db.get(User, test_user.id).avatar_image_uri is None
+        assert not fake_avatar_storage
+
+
+class TestAvatarEndpoints:
+    def test_upload_get_delete_roundtrip(
+        self, authenticated_client, test_user, fake_avatar_storage
+    ):
+        resp = authenticated_client.put(
+            "/api/v1/me/avatar",
+            files={"file": ("me.png", _png_bytes(), "image/png")},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["avatar_source"] == "user"
+        assert body["avatar_image_uri"] == f"/api/v1/users/{test_user.id}/avatar"
+        # The avatar payload must never carry an email (privacy, plan P0).
+        assert "email" not in body
+
+        got = authenticated_client.get(f"/api/v1/users/{test_user.id}/avatar")
+        assert got.status_code == 200
+        assert got.headers["content-type"] in ("image/jpeg", "image/png")
+
+        deleted = authenticated_client.delete("/api/v1/me/avatar")
+        assert deleted.status_code == 200
+        assert deleted.json()["avatar_image_uri"] is None
+        # Pinned, so the next sign-in does not restore the OAuth picture.
+        assert deleted.json()["avatar_source"] == "user"
+        assert (
+            authenticated_client.get(f"/api/v1/users/{test_user.id}/avatar").status_code
+            == 404
+        )
+
+    def test_upload_rejects_non_image(self, authenticated_client, fake_avatar_storage):
+        resp = authenticated_client.put(
+            "/api/v1/me/avatar",
+            files={"file": ("x.txt", b"not an image", "text/plain")},
+        )
+        assert resp.status_code == 400
+        assert not fake_avatar_storage
+
+    def test_avatar_appears_on_the_profile_endpoint(
+        self, authenticated_client, fake_avatar_storage
+    ):
+        authenticated_client.put(
+            "/api/v1/me/avatar",
+            files={"file": ("me.png", _png_bytes(), "image/png")},
+        )
+        profile = authenticated_client.get("/api/v1/auth/me").json()
+        assert profile["avatar_source"] == "user"
+        assert profile["avatar_image_uri"].endswith("/avatar")
+        # updated_at is the client's cache-buster for the stable avatar URL.
+        assert profile["updated_at"]
+
+    def test_missing_avatar_and_unknown_user_are_both_404(
+        self, authenticated_client, test_db, fake_avatar_storage
+    ):
+        other = User(
+            id=uuid4(),
+            email="other-avatar@example.com",
+            display_name="Other",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        test_db.add(other)
+        test_db.commit()
+        assert (
+            authenticated_client.get(f"/api/v1/users/{other.id}/avatar").status_code
+            == 404
+        )
+        assert (
+            authenticated_client.get(f"/api/v1/users/{uuid4()}/avatar").status_code
+            == 404
+        )

--- a/backend/src/backend/tests/test_user_avatars.py
+++ b/backend/src/backend/tests/test_user_avatars.py
@@ -187,6 +187,51 @@ class TestOAuthSeed:
         assert not fake_avatar_storage
 
 
+class TestLazyBackfill:
+    """The seed must reach accounts that predate the column, not only signups."""
+
+    def _principal(self, user, avatar_url):
+        from shared.auth.tokens import TokenClaims
+
+        return TokenClaims(
+            user_id=user.id,
+            email=user.email,
+            display_name=user.display_name,
+            avatar_url=avatar_url,
+        )
+
+    def _queued(self, user, avatar_url):
+        """The (task, args) `get_current_user` would enqueue for these claims."""
+        from fastapi import BackgroundTasks
+
+        from backend.auth.dependencies import _maybe_seed_avatar
+
+        tasks = BackgroundTasks()
+        _maybe_seed_avatar(tasks, user, self._principal(user, avatar_url).avatar_url)
+        return [(t.func, t.args) for t in tasks.tasks]
+
+    def test_existing_user_with_no_avatar_is_backfilled(self, test_user):
+        queued = self._queued(test_user, GOOGLE_AVATAR)
+        assert queued == [(avatars.seed_user_avatar, (test_user.id, GOOGLE_AVATAR))]
+
+    def test_already_attempted_user_never_retries(self, test_user, test_db):
+        test_user.avatar_source = "oauth"  # fetched, or tried and missed
+        test_db.commit()
+        assert self._queued(test_user, GOOGLE_AVATAR) == []
+
+    def test_user_upload_is_not_backfilled_over(self, test_user, test_db):
+        test_user.avatar_source = "user"
+        test_user.avatar_image_uri = f"/api/v1/users/{test_user.id}/avatar"
+        test_db.commit()
+        assert self._queued(test_user, GOOGLE_AVATAR) == []
+
+    def test_provider_without_a_picture_never_enqueues(self, test_user):
+        # Apple and the built-in provider publish none; staying NULL keeps the
+        # account eligible if they later link one that does.
+        assert self._queued(test_user, None) == []
+        assert test_user.avatar_source is None
+
+
 class TestAvatarEndpoints:
     def test_upload_get_delete_roundtrip(
         self, authenticated_client, test_user, fake_avatar_storage

--- a/backend/src/shared/alembic/versions/c9e4b7d13f28_add_user_avatar_columns.py
+++ b/backend/src/shared/alembic/versions/c9e4b7d13f28_add_user_avatar_columns.py
@@ -1,0 +1,35 @@
+"""add user avatar columns
+
+Identity foundation for collaboration (P0). Mirrors the project-icon columns:
+``avatar_image_uri`` is a served URL into our own storage (never an external
+hot-link) and ``avatar_source`` is 'user' | 'oauth' | NULL, which is what makes
+the OAuth seed safe to re-run — only a NULL source is eligible, so a user's own
+upload is never clobbered.
+
+Revision ID: c9e4b7d13f28
+Revises: f4a7c2e9b1d3
+Create Date: 2026-09-08 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "c9e4b7d13f28"
+down_revision: Union[str, None] = "f4a7c2e9b1d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("avatar_image_uri", sa.Text(), nullable=True))
+    op.add_column(
+        "users", sa.Column("avatar_source", sa.String(length=16), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "avatar_source")
+    op.drop_column("users", "avatar_image_uri")

--- a/backend/src/shared/auth/base.py
+++ b/backend/src/shared/auth/base.py
@@ -48,6 +48,10 @@ class Principal:
     kind: PrincipalKind = "user"
     email: str | None = None
     display_name: str | None = None
+    # The IdP's avatar URL, when it publishes one (OAuth sign-ins). Only ever
+    # used once, to seed our own copy at signup (:mod:`shared.avatars`) — it is
+    # never stored or rendered, so no client is pointed at the provider's CDN.
+    avatar_url: str | None = None
 
 
 @dataclass(slots=True)

--- a/backend/src/shared/auth/supabase_provider.py
+++ b/backend/src/shared/auth/supabase_provider.py
@@ -257,11 +257,13 @@ def _principal_from_claims(claims: dict[str, Any]) -> Principal:
     except (ValueError, TypeError) as exc:
         raise TokenVerificationError("Token missing valid subject") from exc
 
+    metadata = claims.get("user_metadata") or {}
     return Principal(
         user_id=user_id,
         kind="user",
         email=claims.get("email"),
-        display_name=_display_name(claims.get("user_metadata") or {}),
+        display_name=_display_name(metadata),
+        avatar_url=_avatar_url(metadata),
     )
 
 
@@ -271,6 +273,18 @@ def _display_name(metadata: dict[str, Any]) -> str | None:
         or metadata.get("full_name")
         or metadata.get("name")
     )
+
+
+def _avatar_url(metadata: dict[str, Any]) -> str | None:
+    """The OAuth avatar Supabase copies into user_metadata.
+
+    Google/GitHub sign-ins land as ``avatar_url``; ``picture`` is the raw OIDC
+    claim name some flows pass through. Apple publishes neither. The value is
+    still untrusted here — :func:`shared.avatars.allowed_avatar_url` is what
+    decides whether it is fetched.
+    """
+    value = metadata.get("avatar_url") or metadata.get("picture")
+    return value if isinstance(value, str) and value.strip() else None
 
 
 def _find_key(jwks: dict[str, Any], kid: str | None) -> dict[str, Any] | None:

--- a/backend/src/shared/avatars.py
+++ b/backend/src/shared/avatars.py
@@ -1,0 +1,125 @@
+"""User-avatar seeding from the identity provider (collaboration P0).
+
+The sibling of :mod:`shared.project_icons`, and deliberately the same shape: a
+best-effort background pass that fetches an avatar *server-side* from an
+allowlisted host, normalizes it through the same image pipeline as user uploads,
+stores it in OUR S3, and points the user row at a URL we serve.
+
+Constraints baked in:
+  * The OAuth ``avatar_url`` claim is attacker-influenced in principle (it is
+    whatever the IdP put in ``user_metadata``), so it is *not* fetched as given:
+    only ``https`` on an allowlisted avatar host is followed, and redirects are
+    off. The SSRF surface is those hosts alone.
+  * The S3 object is keyed by ``user_id`` (``storage.user_avatar_key``) with no
+    extension; the Content-Type comes from the stored object.
+  * ``avatar_source`` is stamped ``'oauth'`` on every attempt (success *or*
+    miss), so a failed lookup is never retried; only a NULL ``avatar_source`` is
+    eligible, which also means a user upload ('user') is never clobbered.
+  * We re-host rather than store the IdP URL: an <img> pointed at the IdP's CDN
+    would leak a viewer's IP to Google on every shared surface, and those URLs
+    rot when the identity changes.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+
+from shared import storage
+from shared.database.models import User
+from shared.database.session import SessionLocal
+from shared.images import InvalidImageError, process_image
+
+logger = logging.getLogger(__name__)
+
+# Hosts whose public avatar URLs we are willing to fetch. Google and Apple are
+# the two providers Vicoa ships; Apple returns no avatar at all, so in practice
+# this is Google, plus the hosts a self-hosted deployment gets for free by
+# pointing its own Supabase project at GitHub/GitLab.
+_ALLOWED_AVATAR_HOSTS = frozenset(
+    {
+        "lh3.googleusercontent.com",
+        "lh4.googleusercontent.com",
+        "lh5.googleusercontent.com",
+        "lh6.googleusercontent.com",
+        "avatars.githubusercontent.com",
+        "secure.gravatar.com",
+    }
+)
+
+# Avatars are tiny; anything larger is not one, and bounds the fetch.
+MAX_AVATAR_BYTES = 8 * 1024 * 1024
+_FETCH_TIMEOUT_S = 8.0
+
+
+def allowed_avatar_url(raw: str | None) -> str | None:
+    """The claim's URL if it is one we will fetch server-side, else None."""
+    if not raw:
+        return None
+    try:
+        parts = urlsplit(raw.strip())
+    except ValueError:
+        return None
+    if parts.scheme != "https":
+        return None
+    # hostname lowercases and strips any :port / userinfo, so an
+    # "https://lh3.googleusercontent.com@evil.example/" style URL cannot match.
+    if parts.hostname not in _ALLOWED_AVATAR_HOSTS:
+        return None
+    return raw.strip()
+
+
+def avatar_served_url(user_id: UUID | str) -> str:
+    """Backend-relative URL clients render (stored in ``users.avatar_image_uri``)."""
+    return f"/api/v1/users/{user_id}/avatar"
+
+
+def seed_user_avatar(user_id: UUID, avatar_url: str | None) -> None:
+    """Background task: seed a new user's avatar from their IdP (best-effort).
+
+    Runs in its own DB session (invoked via FastAPI ``BackgroundTasks``),
+    re-checks eligibility to stay idempotent under concurrent enqueues, and
+    never raises.
+    """
+    with SessionLocal() as db:
+        user = db.get(User, user_id)
+        if user is None:
+            return
+        # Only NULL avatar_source is eligible: 'oauth' = already attempted,
+        # 'user' = uploaded / explicitly cleared (must win).
+        if user.avatar_source is not None or user.avatar_image_uri:
+            return
+        url = allowed_avatar_url(avatar_url)
+        if url is None:
+            user.avatar_source = "oauth"  # mark attempted so we don't retry
+            db.commit()
+            return
+        try:
+            # follow_redirects stays off: a redirect is how an allowlisted host
+            # would otherwise become an arbitrary one.
+            with httpx.Client(
+                timeout=_FETCH_TIMEOUT_S, follow_redirects=False
+            ) as client:
+                resp = client.get(url)
+            resp.raise_for_status()
+            data = resp.content
+            if len(data) > MAX_AVATAR_BYTES:
+                raise ValueError(f"avatar too large: {len(data)} bytes")
+            processed = process_image(data)
+            storage.upload_attachment(
+                storage.user_avatar_key(str(user_id)),
+                processed.data,
+                processed.mime_type,
+            )
+            user.avatar_image_uri = avatar_served_url(user_id)
+            user.avatar_source = "oauth"
+        except (httpx.HTTPError, InvalidImageError, ValueError, OSError) as exc:
+            logger.info("oauth avatar seed skipped for %s: %s", user_id, exc)
+            user.avatar_source = "oauth"  # attempted; leave uri NULL → initials
+        except Exception:  # noqa: BLE001 — seeding must never break signup
+            logger.warning("oauth avatar seed errored for %s", user_id, exc_info=True)
+            user.avatar_source = "oauth"
+        db.commit()

--- a/backend/src/shared/database/models.py
+++ b/backend/src/shared/database/models.py
@@ -27,6 +27,13 @@ class User(Base):
     )  # Matches Supabase auth.users.id
     email: Mapped[str] = mapped_column(String(255), unique=True)
     display_name: Mapped[str | None] = mapped_column(String(255), default=None)
+    # Identity (collaboration P0). ``avatar_image_uri`` is a *served* URL into our
+    # own storage (``/api/v1/users/{id}/avatar``), never an external hot-link, so
+    # a shared surface never leaks a request to the IdP's CDN. ``avatar_source``
+    # is 'user' | 'oauth' | NULL and governs re-seed safety exactly like
+    # ``projects.icon_source``: a 'user' upload is never clobbered.
+    avatar_image_uri: Mapped[str | None] = mapped_column(Text, default=None)
+    avatar_source: Mapped[str | None] = mapped_column(String(16), default=None)
     created_at: Mapped[datetime] = mapped_column(
         default=lambda: datetime.now(timezone.utc)
     )

--- a/backend/src/shared/storage.py
+++ b/backend/src/shared/storage.py
@@ -39,6 +39,14 @@ def project_icon_key(project_id: str) -> str:
     return f"project-icons/{project_id}"
 
 
+def user_avatar_key(user_id: str) -> str:
+    # Same shape as project_icon_key: keyed by id alone, no extension — the
+    # served Content-Type comes from the stored object's own metadata
+    # (download_object), so one deterministic key survives png<->jpeg re-encodes
+    # across uploads and re-seeds.
+    return f"avatars/{user_id}"
+
+
 def _client():
     kwargs: dict[str, Any] = {}
     if settings.aws_access_key_id and settings.aws_secret_access_key:


### PR DESCRIPTION
Collaboration **P0** — the identity foundation later phases render. Adds `users.avatar_image_uri` / `avatar_source`, the endpoints behind them, and the single component that draws every principal, so shared sessions, task assignees and teams have an identity to show.

## Migration

**Yes — `c9e4b7d13f28` (`users` += `avatar_image_uri TEXT`, `avatar_source VARCHAR(16)`).**

**Run `alembic upgrade head` BEFORE deploying this backend** (plan §10.10). The columns are additive and nullable, but that does not make the order free: they are mapped on the `User` model, so every `db.query(User)` enumerates them in its SELECT. Code without the migration means `UndefinedColumn` on every query that touches `users` — a whole-backend outage, not a degraded feature.

Verified `alembic upgrade head` and `downgrade -1` against a throwaway PG. No new env vars; S3 reuses the existing `aws_*` settings and the `vicoa` bucket.

## Storage — reuses the project-icon pipeline, does not grow a second one

`shared/avatars.py` is the sibling of `shared/project_icons.py`: allowlisted server-side fetch → `process_image` → our S3 → a URL we serve. The key `avatars/{user_id}` mirrors `project_icon_key` — no extension, Content-Type read back off the stored object, so one deterministic key survives png↔jpeg re-encodes and the URL stays stable (clients cache-bust on `updated_at`).

The OAuth seed is **stricter** than the git-remote one, because an IdP claim is more attacker-influenced than a git remote: https only, host matched on `urlsplit().hostname` against an allowlist, and `follow_redirects=False` — a redirect is how an allowlisted host would otherwise become an arbitrary one.

We re-host rather than store the IdP URL. An `<img>` pointed at Google's CDN would leak a viewer's IP to Google on every shared surface (which is exactly what P4's public share pages are), and those URLs rot when the identity changes.

## The invariant that matters

`avatar_source` carries the same contract as `projects.icon_source` — stamped on hit **and** miss, so a miss never retries and a user upload is never clobbered. Three layers enforce it: the eligibility check before enqueue, a re-check inside the task's own session (race-safe against a concurrent upload), and `DELETE` pinning `'user'` rather than NULL — NULL would make the account seed-eligible again, so the next sign-in would silently restore the picture the user just removed.

The seed runs on **every** authenticated request, not just signup. It originally hung off the JIT user-row create, which would have left the entire existing userbase blank forever — the column is newer than every account. Supabase republishes `user_metadata.avatar_url` on every token, so the check costs three in-memory attribute reads and no query, and converges after one fetch per user. A provider that publishes no picture (Apple, the built-in provider) never enqueues, which leaves that account eligible for free if it later links one that does.

## Clients

`<PrincipalAvatar>` — 3 principal types, 3 fallback levels (stored image → single initial on the paseo hash-palette → per-type glyph), sizes `xs|sm|md|lg|xl`. It replaces the `avatar.vercel.sh/${user.email}` image in the user menu, which put the user's email in a third-party URL on every page load, and a hand-rolled initials circle on the desktop profile page that never showed an uploaded photo at all.

Upload is the avatar itself: click to pick a file, camera badge as the affordance, remove as an X badge that only exists once there is something to remove. Web settings uses `lg`, desktop profile `xl`; local-mode desktop renders read-only (no cloud account to attach a photo to).

Flutter ships the twin with the palette and 32-bit-masked hash copied verbatim so colours match across platforms. Mobile can display but not upload — deferred deliberately, tracked as a backlog task, best done with P2 when assignee avatars first put other people's faces on a mobile screen.

## Privacy

The avatar endpoints carry **no email at all** (asserted in a test). `GET /users/{id}/avatar` is authenticated but not grant-scoped: `shared/access.py` does not exist until P3, an avatar is the least sensitive field a principal has, and the endpoint answers image bytes or a uniform 404 — no name, no email. The spot where P3's visibility check goes is marked in the code.

## Checks

Backend 208 tests (26 new), web 781 (9 new), `make lint` + `pnpm lint` + `pnpm build` green, `flutter analyze` clean on the new files, migration verified up and down.

