### PR TITLE
Codex: never drop a large JSONL frame

### DIFF
--- a/.vicoa/config.json
+++ b/.vicoa/config.json
@@ -11,6 +11,8 @@
       "cp \"$VICOA_ROOT_PATH/apps/mobile/env.json\" \"$VICOA_WORKTREE_PATH/apps/mobile/env.json\" && echo 'copied apps/mobile/env.json'",
       "echo '--- pnpm install (apps/web) ---'",
       "cd \"$VICOA_WORKTREE_PATH/apps/web\" && pnpm install",
+      "echo '--- backend venv (python 3.11) ---'",
+      "cd \"$VICOA_WORKTREE_PATH/backend\" && { [ -d .venv ] || \"$(command -v python3.11 || command -v python3)\" -m venv .venv; } && ./.venv/bin/python -m pip install -q --upgrade pip && ./.venv/bin/python -m pip install -q -r src/backend/requirements.txt -r src/servers/requirements.txt -r requirements-dev.txt && echo 'backend venv ready'",
       "echo '--- linking backend/postgres-data -> main (shared dev DB) ---'",
       "[ -d \"$VICOA_ROOT_PATH/backend/postgres-data\" ] && ln -sfn \"$VICOA_ROOT_PATH/backend/postgres-data\" \"$VICOA_WORKTREE_PATH/backend/postgres-data\" && echo 'linked postgres-data -> main' || echo 'skip: main DB not initialized yet'",
       "echo '=== vicoa worktree setup done ==='"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -56,7 +56,7 @@ build/
 # Database
 *.db
 *.sqlite3
-postgres-data/
+postgres-data
 
 # Logs
 logs/

--- a/backend/scripts/codex_frame_probe.py
+++ b/backend/scripts/codex_frame_probe.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Manual acceptance probe for issue #33, against the *real* ``codex app-server``.
+
+The automated tests drive a scripted stand-in. This one drives the real binary
+and measures every inbound frame, so "codex never sends anything big enough to
+matter" stops being a guess and becomes a number.
+
+    cd backend
+    python3 scripts/codex_frame_probe.py                  # with the fix
+    python3 scripts/codex_frame_probe.py --reader raw     # what shipped before
+
+``--reader raw`` restores the pre-fix wiring exactly: the transport reading the
+child's ``stdout`` directly, capped by asyncio's ``limit`` (64 KiB by default,
+i.e. issue #33 as reported; pass ``--raw-limit`` to try the "just raise it"
+fix). Run the same workload both ways — the framed run must deliver every
+frame; the raw run dies or silently drops one as soon as the workload clears
+the cap.
+
+Runs codex with ``approvalPolicy=never`` and a **read-only** sandbox, in a
+throwaway directory, and auto-accepts anything it still asks for so the probe
+is unattended. It does spend real model tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from integrations.headless.codex.spawn import (  # noqa: E402
+    CodexSubprocess,
+    spawn_codex_app_server,
+)
+from integrations.headless.codex.transport import CodexTransport  # noqa: E402
+from integrations.headless.jsonl_stream import (  # noqa: E402
+    CODEX_MAX_LINE_BYTES,
+    STREAM_READ_AHEAD_BYTES,
+    JsonlLineReader,
+)
+
+
+_METHOD_RE = re.compile(rb'"method"\s*:\s*"([^"]+)"')
+_KIB = 1024
+_MIB = 1024 * 1024
+
+
+class RecordingReader:
+    """Pass-through reader that records the size of every physical line."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.frames: List[Tuple[int, str]] = []
+
+    async def readline(self) -> bytes:
+        line = await self._inner.readline()
+        if line:
+            match = _METHOD_RE.search(line[:400])
+            method = match.group(1).decode() if match else "<response>"
+            self.frames.append((len(line), method))
+        return line
+
+
+async def _build(
+    args: argparse.Namespace, cwd: str
+) -> Tuple[CodexTransport, RecordingReader, Any]:
+    """Wire a transport the way production does, or the way it used to."""
+    if args.reader == "framed":
+        spawned: CodexSubprocess = await spawn_codex_app_server(cwd=cwd)
+        recorder = RecordingReader(spawned.transport._reader)  # noqa: SLF001
+        spawned.transport._reader = recorder  # noqa: SLF001
+        return spawned.transport, recorder, spawned
+
+    process = await asyncio.create_subprocess_exec(
+        "codex",
+        "app-server",
+        cwd=cwd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        limit=args.raw_limit,
+    )
+    assert process.stdout is not None and process.stdin is not None
+    recorder = RecordingReader(process.stdout)
+
+    async def drain() -> None:
+        assert process.stderr is not None
+        while await process.stderr.readline():
+            pass
+
+    asyncio.create_task(drain())
+    return CodexTransport(reader=recorder, writer=process.stdin), recorder, process
+
+
+async def _teardown(handle: Any) -> None:
+    if isinstance(handle, CodexSubprocess):
+        await handle.aclose()
+        return
+    handle.kill()
+    try:
+        # A StreamReader that paused its transport (buffer over ``limit``, which
+        # is the whole point of ``--reader raw``) can keep ``wait`` from ever
+        # seeing EOF. Production bounds this the same way, in
+        # ``CodexSubprocess.aclose``.
+        await asyncio.wait_for(handle.wait(), timeout=5)
+    except asyncio.TimeoutError:
+        pass
+
+
+def _biggest_local_thread() -> Tuple[str, int]:
+    """Pick the fattest rollout on this machine — the fattest resume frame."""
+    sessions = Path.home() / ".codex" / "sessions"
+    rollouts = sorted(
+        sessions.rglob("rollout-*.jsonl"), key=lambda p: p.stat().st_size, reverse=True
+    )
+    if not rollouts:
+        sys.exit(
+            f"no codex threads under {sessions}; use --thread-id or --workload exec"
+        )
+    # rollout-<ISO timestamp>-<thread uuid>.jsonl; the uuid is the last 5 groups
+    return "-".join(rollouts[0].stem.split("-")[-5:]), rollouts[0].stat().st_size
+
+
+def _prompt(args: argparse.Namespace, cwd: Path) -> str:
+    if args.workload == "custom":
+        if not args.prompt:
+            sys.exit("--workload custom needs --prompt")
+        return args.prompt
+    if args.workload == "read":
+        blob = cwd / "blob.txt"
+        blob.write_text("A" * args.size + "\n")
+        return (
+            f"Read {blob.name} in this directory in full, then reply with only "
+            "the number of characters it contains. Do not summarise it."
+        )
+    if args.workload == "lines":
+        # Same volume, spread over many lines — some truncation logic counts
+        # lines rather than bytes, so it is worth trying both shapes.
+        rows = max(1, args.size // 75)
+        return (
+            "Run exactly this command, then reply with only the word DONE. Do "
+            "not summarise or comment on the output.\n\n"
+            f"  python3 -c \"[print('line %06d ' % i + 'x'*60) for i in range({rows})]\""
+        )
+    return (
+        "Run exactly this command, then reply with only the word DONE. Do not "
+        "summarise or comment on the output.\n\n"
+        f"  python3 -c \"print('A'*{args.size})\""
+    )
+
+
+def _report(frames: List[Tuple[int, str]], reason: Optional[str]) -> int:
+    if not frames:
+        print("\nNo frames recorded at all — codex never spoke.")
+        return 1
+    sizes = sorted(frames, reverse=True)
+    total = sum(size for size, _ in frames)
+    print(f"\n{'=' * 66}\nframes: {len(frames)}   bytes: {total:,}")
+    print(f"largest: {sizes[0][0]:,} bytes  ({sizes[0][1]})")
+    print("\ntop 8 frames:")
+    for size, method in sizes[:8]:
+        print(f"  {size:>12,}  {method}")
+    print("\nover threshold:")
+    for label, threshold in (
+        ("64 KiB (asyncio default)", 64 * _KIB),
+        ("1 MiB", _MIB),
+        ("2 MiB (a plausible 'just raise the limit')", 2 * _MIB),
+        ("64 MiB (CODEX_MAX_LINE_BYTES)", CODEX_MAX_LINE_BYTES),
+    ):
+        count = sum(1 for size, _ in frames if size > threshold)
+        print(f"  > {label}: {count}")
+    if reason:
+        print(f"\nTRANSPORT DIED: {reason}")
+        return 1
+    print("\nTransport survived; every frame above was delivered whole.")
+    return 0
+
+
+async def run(args: argparse.Namespace) -> int:
+    workdir = Path(tempfile.mkdtemp(prefix="codex-frame-probe-"))
+    prompt = "" if args.workload == "resume" else _prompt(args, workdir)
+    transport, recorder, handle = await _build(args, str(workdir))
+
+    done = asyncio.Event()
+    died: List[str] = []
+
+    async def on_notification(method: str, params: Dict[str, Any]) -> None:
+        if method in ("turn/completed", "turn/failed", "error"):
+            if method != "turn/completed":
+                print(f"  ! {method}: {json.dumps(params)[:300]}")
+            done.set()
+
+    def on_close(reason: str) -> None:
+        died.append(reason)
+        done.set()
+
+    async def approve(params: Dict[str, Any]) -> Dict[str, Any]:
+        return {"decision": "accept"}
+
+    async def grant(params: Dict[str, Any]) -> Dict[str, Any]:
+        return {"grants": {}, "scope": "turn"}
+
+    async def cancel(params: Dict[str, Any]) -> Dict[str, Any]:
+        return {"decision": "cancel"}
+
+    transport.on_notification = on_notification
+    transport.on_close = on_close
+    transport.register_request_handler("item/commandExecution/requestApproval", approve)
+    transport.register_request_handler("item/fileChange/requestApproval", approve)
+    transport.register_request_handler("item/permissions/requestApproval", grant)
+    transport.register_request_handler("item/tool/requestUserInput", cancel)
+
+    started = time.monotonic()
+    try:
+        await transport.start()
+        await transport.send_request(
+            "initialize",
+            {
+                "clientInfo": {"name": "vicoa-frame-probe", "version": "0"},
+                "capabilities": {"experimentalApi": True},
+            },
+            timeout=30,
+        )
+        transport.notify("initialized", {})
+        if args.workload == "resume":
+            thread_id, rollout_bytes = (
+                (args.thread_id, 0) if args.thread_id else _biggest_local_thread()
+            )
+            print(f"cwd:      {workdir}")
+            print(f"reader:   {args.reader}", end="")
+            print(
+                f" (limit {args.raw_limit:,} B)"
+                if args.reader == "raw"
+                else f" (read-ahead {STREAM_READ_AHEAD_BYTES:,} B, "
+                f"ceiling {CODEX_MAX_LINE_BYTES:,} B)"
+            )
+            print(f"resuming: {thread_id} (rollout {rollout_bytes:,} B on disk)")
+            resumed = await transport.send_request(
+                "thread/resume",
+                {"threadId": thread_id, "cwd": str(workdir)},
+                timeout=args.timeout,
+            )
+            turns = resumed.get("thread", {}).get("turns", [])
+            print(f"resumed:  {len(turns)} turns")
+            done.set()
+        else:
+            thread = await transport.send_request(
+                "thread/start", {"cwd": str(workdir)}, timeout=60
+            )
+            params: Dict[str, Any] = {
+                "threadId": thread["thread"]["id"],
+                "input": [{"type": "text", "text": prompt}],
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"type": "readOnly"},
+            }
+            if args.model:
+                params["model"] = args.model
+            print(f"cwd:      {workdir}")
+            print(f"reader:   {args.reader}", end="")
+            print(
+                f" (limit {args.raw_limit:,} B)"
+                if args.reader == "raw"
+                else f" (read-ahead {STREAM_READ_AHEAD_BYTES:,} B, "
+                f"ceiling {CODEX_MAX_LINE_BYTES:,} B)"
+            )
+            print(f"prompt:   {prompt.splitlines()[0]}")
+            print("waiting for the turn to complete...")
+            await transport.send_request("turn/start", params, timeout=120)
+        await asyncio.wait_for(done.wait(), timeout=args.timeout)
+    except Exception as exc:  # noqa: BLE001 - a probe reports, it doesn't raise
+        print(f"\nFAILED: {type(exc).__name__}: {exc}")
+        if not died:
+            died.append(f"{type(exc).__name__}: {exc}")
+    finally:
+        elapsed = time.monotonic() - started
+        await transport.aclose()
+        await _teardown(handle)
+    print(f"\nturn took {elapsed:.1f}s")
+    return _report(recorder.frames, died[0] if died else None)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workload",
+        choices=("resume", "exec", "lines", "read", "custom"),
+        default="resume",
+    )
+    parser.add_argument(
+        "--thread-id",
+        help="thread to resume; default is the largest rollout in ~/.codex/sessions",
+    )
+    parser.add_argument("--size", type=int, default=3_000_000)
+    parser.add_argument("--prompt")
+    parser.add_argument("--model")
+    parser.add_argument("--reader", choices=("framed", "raw"), default="framed")
+    parser.add_argument("--raw-limit", type=int, default=64 * _KIB)
+    parser.add_argument("--timeout", type=float, default=300.0)
+    args = parser.parse_args()
+    if JsonlLineReader is None:  # pragma: no cover - import sanity
+        return 1
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/src/integrations/headless/codex/spawn.py
+++ b/backend/src/integrations/headless/codex/spawn.py
@@ -18,6 +18,11 @@ from dataclasses import dataclass, field
 from typing import Deque, Dict, List, Optional
 
 from integrations.headless.codex.transport import CodexTransport
+from integrations.headless.jsonl_stream import (
+    CODEX_MAX_LINE_BYTES,
+    STREAM_READ_AHEAD_BYTES,
+    JsonlLineReader,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -109,6 +114,9 @@ async def spawn_codex_app_server(
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        # Read-ahead window, not a frame cap — framing is JsonlLineReader's
+        # job. See STREAM_READ_AHEAD_BYTES.
+        limit=STREAM_READ_AHEAD_BYTES,
     )
     if process.stdin is None or process.stdout is None:
         raise RuntimeError("subprocess pipes did not materialize")
@@ -124,7 +132,14 @@ async def spawn_codex_app_server(
         stderr_task = asyncio.create_task(_drain_stderr(process.stderr, stderr_lines))
 
     transport = CodexTransport(
-        reader=process.stdout,
+        # Frame the child's stdout ourselves: a codex notification carrying a
+        # large tool result runs past any StreamReader limit we could pick, and
+        # dropping one costs a message or hangs a turn (issue #33).
+        reader=JsonlLineReader(
+            process.stdout,
+            max_line_bytes=CODEX_MAX_LINE_BYTES,
+            label="codex app-server",
+        ),
         writer=process.stdin,
         stderr_tail=lambda: _format_stderr_tail(stderr_lines),
     )
@@ -148,6 +163,12 @@ async def _drain_stderr(stream: asyncio.StreamReader, buffer: "Deque[str]") -> N
             line = await stream.readline()
         except asyncio.CancelledError:
             raise
+        except ValueError:
+            # One stderr line overran the read buffer. Dropping the drain here
+            # would let the OS pipe fill and block the child on its next write
+            # — exactly the hang this function exists to prevent — so skip the
+            # line and keep draining.
+            continue
         except Exception:
             return
         if not line:

--- a/backend/src/integrations/headless/codex/transport.py
+++ b/backend/src/integrations/headless/codex/transport.py
@@ -223,6 +223,20 @@ class CodexTransport:
                     line = await self._reader.readline()
                 except asyncio.CancelledError:
                     raise
+                except ValueError as exc:
+                    # A single line ran past the reader's ceiling — either
+                    # ``JsonlLineReader``'s runaway guard (``OversizedFrameError``,
+                    # which subclasses ``ValueError``) or, for an injected raw
+                    # ``StreamReader``, its ``limit``. Both resync at the next
+                    # newline, so this costs one frame, not the session. It
+                    # should not happen against a healthy codex: see
+                    # ``CODEX_MAX_LINE_BYTES``.
+                    logger.error(
+                        "codex transport: frame exceeded the read ceiling, "
+                        "dropping it: %s",
+                        exc,
+                    )
+                    continue
                 except Exception as exc:
                     logger.exception("codex transport: read failed")
                     reason = f"codex app-server read error: {exc}"

--- a/backend/src/integrations/headless/jsonl_stream.py
+++ b/backend/src/integrations/headless/jsonl_stream.py
@@ -1,0 +1,148 @@
+"""Line framing for the JSONL-over-stdio agent transports.
+
+Both the codex ``app-server`` transport and the Pi-family transport read
+newline-delimited JSON off a subprocess pipe, so the framing lives here rather
+than in either one.
+
+Why not ``asyncio.StreamReader.readline``: it refuses any line longer than the
+reader's ``limit`` (64 KiB by default) — issue #33, where a single large codex
+notification took down the session. Raising that limit only moves the cliff,
+and a frame dropped at the cliff is *silent* to the user: a lost notification
+is a missing message, a lost response is a turn that hangs until it times out.
+Node's ``readline`` — what the same integrations use in ``paseo`` — has no
+line-length cap at all, which is why codex never hit this there. So we do the
+framing ourselves and match that: no cap on a legal frame.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+#: How much we ask the OS pipe for per read. Only a syscall-batching knob.
+_READ_CHUNK_BYTES = 64 * 1024
+
+#: Read-ahead window handed to a child's ``StreamReader`` via
+#: ``create_subprocess_exec(..., limit=...)``.
+#:
+#: Since framing no longer goes through ``StreamReader.readline``, this is pure
+#: flow control — how far the child may run ahead of us before asyncio pauses
+#: reading its pipe — **not** a ceiling on a frame. Kept explicit (rather than
+#: left at asyncio's 64 KiB) so a big frame arrives in a few reads instead of
+#: dozens, and so anything that reverts to ``readline`` doesn't silently
+#: reintroduce issue #33.
+STREAM_READ_AHEAD_BYTES = 2 * 1024 * 1024
+
+#: Ceiling on a single physical line for codex. Codex publishes no frame size
+#: limit, so this is a runaway guard, not a protocol rule: it exists only to
+#: bound memory if the child goes berserk. Deliberately far above anything
+#: codex has been observed to send, because dropping a frame it *meant* to send
+#: is the failure this module exists to prevent.
+CODEX_MAX_LINE_BYTES = 64 * 1024 * 1024
+
+#: Ceiling on a single physical line for the Pi family. This one *is* a
+#: protocol rule: pi/omp cap a physical frame at 1 MiB
+#: (``MAX_RPC_FRAME_BYTES``) and split anything larger into ``rpc_chunk``
+#: envelopes, so a longer line is a spec violation rather than a big message.
+PI_MAX_LINE_BYTES = 2 * 1024 * 1024
+
+
+class OversizedFrameError(ValueError):
+    """A single line ran past the reader's ceiling and was dropped.
+
+    Subclasses ``ValueError`` so a read loop that already handles
+    ``StreamReader.readline``'s overrun handles this too. The reader resyncs
+    itself at the next newline, so a caller should log and keep reading.
+    """
+
+
+class _ByteStream(Protocol):
+    async def read(self, n: int) -> bytes: ...
+
+
+class JsonlLineReader:
+    """Split a byte stream into LF-terminated lines, with no cap on a legal one.
+
+    Returns each line *including* its trailing newline (matching
+    ``StreamReader.readline``), a final unterminated line at EOF, and ``b""``
+    once the stream is exhausted.
+
+    A line past ``max_line_bytes`` raises :class:`OversizedFrameError` and puts
+    the reader into discard mode: the rest of that line is consumed and thrown
+    away, so the *next* call resumes cleanly at the following frame. The stream
+    never desyncs and memory stays bounded.
+    """
+
+    def __init__(
+        self,
+        stream: _ByteStream,
+        *,
+        max_line_bytes: int,
+        label: str = "agent",
+    ) -> None:
+        self._stream = stream
+        self._max_line_bytes = max_line_bytes
+        self._label = label
+        self._buf = bytearray()
+        # Where the next newline scan starts. Without it, re-scanning the whole
+        # buffer on every chunk makes assembling a large frame quadratic.
+        self._scanned = 0
+        self._eof = False
+        self._discarding = False
+
+    async def readline(self) -> bytes:
+        while True:
+            newline = self._buf.find(b"\n", self._scanned)
+            if newline != -1:
+                line = bytes(self._buf[: newline + 1])
+                del self._buf[: newline + 1]
+                self._scanned = 0
+                return line
+            self._scanned = len(self._buf)
+            if self._eof:
+                if not self._buf:
+                    return b""
+                line = bytes(self._buf)
+                self._buf.clear()
+                self._scanned = 0
+                return line
+            chunk = await self._stream.read(_READ_CHUNK_BYTES)
+            if not chunk:
+                self._eof = True
+                continue
+            self._buf += chunk
+            if self._discarding:
+                self._drop_through_newline()
+                continue
+            if len(self._buf) > self._max_line_bytes:
+                dropped = len(self._buf)
+                self._buf.clear()
+                self._scanned = 0
+                self._discarding = True
+                raise OversizedFrameError(
+                    f"{self._label}: frame exceeded {self._max_line_bytes} bytes "
+                    f"({dropped} buffered so far); dropping it"
+                )
+
+    def _drop_through_newline(self) -> None:
+        """Throw away buffered bytes belonging to a frame already refused."""
+        newline = self._buf.find(b"\n")
+        if newline == -1:
+            self._buf.clear()
+        else:
+            del self._buf[: newline + 1]
+            self._discarding = False
+        self._scanned = 0
+
+
+__all__ = [
+    "CODEX_MAX_LINE_BYTES",
+    "JsonlLineReader",
+    "OversizedFrameError",
+    "PI_MAX_LINE_BYTES",
+    "STREAM_READ_AHEAD_BYTES",
+]

--- a/backend/src/integrations/headless/pi_family/spawn.py
+++ b/backend/src/integrations/headless/pi_family/spawn.py
@@ -25,6 +25,11 @@ import os
 from dataclasses import dataclass, field
 from typing import Deque, Dict, List, Optional
 
+from integrations.headless.jsonl_stream import (
+    PI_MAX_LINE_BYTES,
+    STREAM_READ_AHEAD_BYTES,
+    JsonlLineReader,
+)
 from integrations.headless.pi_family.transport import PiTransport
 
 
@@ -33,22 +38,6 @@ logger = logging.getLogger(__name__)
 
 _STDERR_TAIL_MAX_LINES = 200
 
-#: Buffer ceiling for one physical JSONL line, handed to the child's
-#: ``StreamReader``.
-#:
-#: **Load-bearing.** ``asyncio``'s default is 64 KiB, and a ``StreamReader``
-#: whose ``readline`` overruns it raises ``LimitOverrunError`` *and leaves the
-#: data in the buffer*, so the read loop cannot recover — the transport simply
-#: dies. This is not hypothetical: it was hit on the very first live bring-up,
-#: where omp's ``get_available_models`` response (dozens of models with full
-#: capability blocks) is comfortably over 64 KiB.
-#:
-#: The protocol's own ceiling for a physical line is 1 MiB
-#: (``MAX_RPC_FRAME_BYTES``); anything larger is split into ``rpc_chunk``
-#: frames, which are smaller still. 2 MiB therefore covers every legal frame
-#: with room to spare, and a line past it is a protocol violation rather than
-#: something to tolerate.
-STREAM_READER_LIMIT = 2 * 1024 * 1024
 #: Char budget for the surfaced tail — enough for a stack trace without
 #: dumping the whole rolling buffer into a chat error.
 _STDERR_TAIL_MAX_CHARS = 4000
@@ -126,9 +115,9 @@ async def spawn_pi_agent(
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        # See STREAM_READER_LIMIT — the default 64 KiB is far below this
-        # protocol's frame size and kills the transport unrecoverably.
-        limit=STREAM_READER_LIMIT,
+        # Read-ahead window, not a frame cap — framing is JsonlLineReader's
+        # job. See STREAM_READ_AHEAD_BYTES.
+        limit=STREAM_READ_AHEAD_BYTES,
         # Own process group so a stop can reach the whole tree (both CLIs
         # spawn helpers — LSP servers, PTY bash, subagents).
         start_new_session=os.name != "nt",
@@ -142,7 +131,11 @@ async def spawn_pi_agent(
         stderr_task = asyncio.create_task(_drain_stderr(process.stderr, stderr_lines))
 
     transport = PiTransport(
-        reader=process.stdout,
+        reader=JsonlLineReader(
+            process.stdout,
+            max_line_bytes=PI_MAX_LINE_BYTES,
+            label=agent_label,
+        ),
         writer=process.stdin,
         stderr_tail=lambda: _format_stderr_tail(stderr_lines),
         agent_label=agent_label,
@@ -167,6 +160,12 @@ async def _drain_stderr(stream: asyncio.StreamReader, buffer: "Deque[str]") -> N
             line = await stream.readline()
         except asyncio.CancelledError:
             raise
+        except ValueError:
+            # One stderr line overran the read buffer. Dropping the drain here
+            # would let the OS pipe fill and block the child on its next write
+            # — exactly the hang this function exists to prevent — so skip the
+            # line and keep draining.
+            continue
         except Exception:
             return
         if not line:
@@ -180,4 +179,4 @@ def _format_stderr_tail(buffer: "Deque[str]") -> str:
     return "\n".join(buffer)[-_STDERR_TAIL_MAX_CHARS:]
 
 
-__all__ = ["STREAM_READER_LIMIT", "PiSubprocess", "spawn_pi_agent"]
+__all__ = ["PiSubprocess", "spawn_pi_agent"]

--- a/backend/src/integrations/headless/pi_family/transport.py
+++ b/backend/src/integrations/headless/pi_family/transport.py
@@ -358,20 +358,18 @@ class PiTransport:
                 except asyncio.CancelledError:
                     raise
                 except ValueError as exc:
-                    # ``StreamReader.readline`` overran its buffer limit and
-                    # left the data in place, so retrying would spin forever.
-                    # Fatal, but say what it actually is — see
-                    # ``spawn.STREAM_READER_LIMIT``.
+                    # A physical line ran past ``PI_MAX_LINE_BYTES``, which for
+                    # this protocol means a spec violation (frames over 1 MiB
+                    # are supposed to arrive as ``rpc_chunk`` envelopes). The
+                    # reader resyncs at the next newline, so drop the frame —
+                    # and let the reassembler reject the now-broken chunk
+                    # sequence — rather than killing the transport.
                     logger.error(
-                        "%s transport: frame exceeded the read buffer: %s",
+                        "%s transport: frame exceeded the read ceiling, dropping it: %s",
                         self._label,
                         exc,
                     )
-                    reason = (
-                        f"{self._label} sent a frame larger than the read "
-                        f"buffer ({exc})"
-                    )
-                    break
+                    continue
                 except Exception as exc:
                     logger.exception("%s transport: read failed", self._label)
                     reason = f"{self._label} read error: {exc}"

--- a/backend/src/integrations/headless/tests/test_codex_oversized_frame.py
+++ b/backend/src/integrations/headless/tests/test_codex_oversized_frame.py
@@ -1,0 +1,201 @@
+"""Regression tests for issue #33 — a large codex frame used to kill the
+transport for the rest of the session.
+
+The rule under test is "a frame codex meant to send is always delivered".
+``asyncio.StreamReader.readline`` cannot honour that: it refuses any line past
+its ``limit``, and *every* choice of limit is a cliff a real tool result can
+run past. So framing goes through :class:`JsonlLineReader`, which has no cap on
+a legal line — the same guarantee Node's ``readline`` gives the equivalent
+integrations in ``paseo``, which is why codex never hit this there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from integrations.headless.codex.spawn import spawn_codex_app_server
+from integrations.headless.codex.transport import CodexTransport
+from integrations.headless.jsonl_stream import JsonlLineReader, OversizedFrameError
+
+
+# ---------------------------------------------------------------------------
+# End to end, over a real subprocess pipe
+# ---------------------------------------------------------------------------
+
+# Emits one big notification, then behaves like ``_fake_codex.py``.
+_FAKE_CODEX_BIG_FRAME = """
+import json, sys
+
+size = int(sys.argv[1])
+sys.stdout.write(json.dumps({
+    "jsonrpc": "2.0",
+    "method": "codex/event",
+    "params": {"msg": "A" * size},
+}) + "\\n")
+sys.stdout.flush()
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if msg.get("method") == "initialize" and msg.get("id") is not None:
+        sys.stdout.write(json.dumps({
+            "jsonrpc": "2.0", "id": msg["id"], "result": {"ok": True},
+        }) + "\\n")
+        sys.stdout.flush()
+"""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="asyncio subprocess on Windows needs ProactorEventLoop; not in scope",
+)
+@pytest.mark.parametrize(
+    "size",
+    [
+        # Past asyncio's 64 KiB default — the reporter's case.
+        pytest.param(200_000, id="200KiB"),
+        # Past 2 MiB, i.e. past any ceiling we would plausibly have picked for
+        # a StreamReader. A codex tool result really can be this big, and
+        # dropping it costs a message or hangs a turn.
+        pytest.param(3 * 1024 * 1024, id="3MiB"),
+    ],
+)
+async def test_big_notification_is_delivered_whole(size: int):
+    spawned = await spawn_codex_app_server(
+        command=[sys.executable, "-c", _FAKE_CODEX_BIG_FRAME, str(size)],
+    )
+    seen: List[Tuple[str, Dict[str, Any]]] = []
+    received = asyncio.Event()
+
+    async def on_notification(method: str, params: Dict[str, Any]) -> None:
+        seen.append((method, params))
+        received.set()
+
+    spawned.transport.on_notification = on_notification
+    try:
+        await spawned.transport.start()
+        await asyncio.wait_for(received.wait(), timeout=10.0)
+        assert seen[0][0] == "codex/event"
+        assert seen[0][1]["msg"] == "A" * size
+
+        # The session survives the big frame: a normal request still works.
+        result = await asyncio.wait_for(
+            spawned.transport.send_request("initialize", {"capabilities": {}}),
+            timeout=10.0,
+        )
+        assert result == {"ok": True}
+    finally:
+        await spawned.aclose()
+
+
+# ---------------------------------------------------------------------------
+# JsonlLineReader
+# ---------------------------------------------------------------------------
+
+
+class _ByteFeed:
+    """A byte stream that hands out at most ``n`` bytes per read, then EOF."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self, n: int) -> bytes:
+        chunk, self._data = self._data[:n], self._data[n:]
+        return chunk
+
+
+def _reader(data: bytes, *, max_line_bytes: int = 1 << 30) -> JsonlLineReader:
+    return JsonlLineReader(_ByteFeed(data), max_line_bytes=max_line_bytes, label="test")
+
+
+async def test_reader_assembles_a_line_spanning_many_reads():
+    line = b"x" * (5 * 1024 * 1024)
+    reader = _reader(line + b"\n")
+    assert await reader.readline() == line + b"\n"
+    assert await reader.readline() == b""
+
+
+async def test_reader_splits_several_lines_out_of_one_read():
+    reader = _reader(b"a\nb\nc\n")
+    assert [await reader.readline() for _ in range(3)] == [b"a\n", b"b\n", b"c\n"]
+    assert await reader.readline() == b""
+
+
+async def test_reader_returns_a_trailing_line_without_a_newline():
+    reader = _reader(b"a\ntail")
+    assert await reader.readline() == b"a\n"
+    assert await reader.readline() == b"tail"
+    assert await reader.readline() == b""
+
+
+async def test_reader_drops_a_runaway_line_and_resyncs():
+    """The ceiling costs exactly one frame, and the stream stays in sync."""
+    runaway = b"R" * (300 * 1024)
+    reader = _reader(runaway + b"\n" + b"after\n", max_line_bytes=64 * 1024)
+    with pytest.raises(OversizedFrameError):
+        await reader.readline()
+    assert await reader.readline() == b"after\n"
+    assert await reader.readline() == b""
+
+
+async def test_reader_reports_eof_when_a_runaway_line_never_ends():
+    reader = _reader(b"R" * (300 * 1024), max_line_bytes=64 * 1024)
+    with pytest.raises(OversizedFrameError):
+        await reader.readline()
+    assert await reader.readline() == b""
+
+
+# ---------------------------------------------------------------------------
+# Transport read loop
+# ---------------------------------------------------------------------------
+
+
+class _NullWriter:
+    def write(self, data: bytes) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def drain(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+async def test_transport_survives_a_frame_past_the_ceiling():
+    """Even the runaway guard must not take the session down."""
+    ceiling = 64 * 1024
+    stream = asyncio.StreamReader()
+    transport = CodexTransport(
+        reader=JsonlLineReader(stream, max_line_bytes=ceiling, label="codex"),
+        writer=_NullWriter(),
+    )
+
+    delivered: List[str] = []
+    arrived = asyncio.Event()
+
+    async def on_notification(method: str, params: Dict[str, Any]) -> None:
+        delivered.append(method)
+        arrived.set()
+
+    transport.on_notification = on_notification
+    await transport.start()
+
+    runaway = json.dumps(
+        {"jsonrpc": "2.0", "method": "too/big", "params": {"msg": "A" * ceiling * 3}}
+    )
+    ok = json.dumps({"jsonrpc": "2.0", "method": "still/alive", "params": {}})
+    stream.feed_data((runaway + "\n" + ok + "\n").encode("utf-8"))
+
+    try:
+        await asyncio.wait_for(arrived.wait(), timeout=5.0)
+        assert delivered == ["still/alive"]
+        assert not transport.is_closed
+    finally:
+        await transport.aclose()


### PR DESCRIPTION
Fixes #33.

## The bug

`asyncio.StreamReader.readline` refuses any line past its `limit` — 64 KiB by default. One `codex app-server` notification carrying a big tool result raised `ValueError`, the read loop's generic `except Exception` treated it as fatal, and the session stayed dead:

```
File ".../codex/transport.py", line 223, in _read_loop
    line = await self._reader.readline()
ValueError: Separator is found, but chunk is longer than limit
```

The reporter's diagnosis was right on every point; reproduced through the production path.

## Why not just raise the limit

That was my first patch, and it's wrong. Every limit is a cliff, and a frame dropped at the cliff is **silent** — a lost notification is a missing message, a lost response is a turn that hangs until it times out. Measured against the real binary, 2 MiB limit vs a 3 MiB notification: the frame never arrives and the follow-up request times out.

`paseo` integrates the same `codex app-server` and never hit this — not because it chunks frames, but because Node's `readline` has no line-length cap at all. (Its `rpc_chunk` protocol is for omp, where the 1 MiB ceiling sits on omp's own side.)

## What this does

`backend/src/integrations/headless/jsonl_stream.py` does the framing itself: `JsonlLineReader` reads the pipe in 64 KiB chunks and splits on LF with **no cap on a legal line**, so a frame codex meant to send is always delivered. The one ceiling left (`CODEX_MAX_LINE_BYTES`, 64 MiB) is a runaway-memory guard, not a protocol rule — it drops that frame, resyncs at the next newline, and leaves the session alive.

The `limit=` on `create_subprocess_exec` stays, but it is now a read-ahead window for flow control, renamed `STREAM_READ_AHEAD_BYTES` so nobody reads it as a frame cap again.

Alongside:

* **pi_family** shares the reader, keeping its spec-derived 2 MiB ceiling (frames over 1 MiB are supposed to arrive as `rpc_chunk` envelopes). Its read loop had this branch already but it was fatal; now it drops the frame. Its old comment claimed `readline` "leaves the data in place, so retrying would spin forever" — not true, `readline` clears the offending line before raising, verified on CPython 3.13.
* Both **stderr drains** survive an oversized line. Returning there let the OS pipe fill and block the child — the exact hang the drain exists to prevent.

## Tests

8 new tests in `test_codex_oversized_frame.py`: 200 KiB and 3 MiB notifications delivered whole over a real subprocess pipe, reader unit tests (5 MiB line across many reads, multi-line chunk, unterminated tail, oversize → drop → resync, EOF mid-drop), and a transport test that an over-ceiling frame does not close the session. Reverting either production change turns them red with the traceback above.

687 headless tests and `make lint` (ruff + pyright + WebSocket freeze) pass.

## Manual acceptance

`backend/scripts/codex_frame_probe.py` drives the **real** `codex app-server` through the production path and reports the largest frame it sends. `--reader raw` restores the pre-fix wiring for an A/B on the same workload. Verified today against codex-cli 0.147.0: `thread/resume` delivers its 12,707-byte response and the transport survives; the same run with `--reader raw --raw-limit 8192` loses that frame entirely and times out.

Not yet exercised: a genuinely >64 KiB frame from a real turn — that needs model quota this account does not have until Sep 16. `--workload exec --size 3000000` is wired up and waiting.

## Two unrelated chore commits

`chore(worktree)` adds the backend venv to `.vicoa/config.json` setup (worktrees were running the backend on whatever Python was on PATH — 3.13 here vs 3.11.15 in the main checkout), and `chore(git)` fixes the `postgres-data` ignore rule so the symlink that setup creates stops showing as untracked. Happy to split either out.
