### PR TITLE
CI: don't mistake a desktop release tag for the previous CLI tag

### DIFF
--- a/.github/workflows/backend-build-macos-arm64.yml
+++ b/.github/workflows/backend-build-macos-arm64.yml
@@ -33,8 +33,10 @@ jobs:
         id: detect
         shell: bash
         run: |
-          # --match 'v*' keeps this off the desktop-v* tags in the shared namespace.
-          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' HEAD^ 2>/dev/null || echo "")
+          # --match 'v*' keeps this off the desktop-v* trigger tags; --exclude 'v0.*'
+          # keeps it off the bare v0.1.x tags the desktop GitHub releases hang on,
+          # which are usually nearer than the real CLI tag. See backend-release.yml.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' --exclude 'v0.*' HEAD^ 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
             if git diff --quiet "$LAST_TAG"..HEAD -- src/integrations/cli_wrappers/codex; then
               echo "changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/backend-release.yml
+++ b/.github/workflows/backend-release.yml
@@ -100,9 +100,17 @@ jobs:
         shell: bash
         run: |
           set -e
-          # --match 'v*' keeps this off the desktop-v* tags that now share the
-          # monorepo tag namespace.
-          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' HEAD^ 2>/dev/null || echo "")
+          # Resolve the previous CLI tag. Both filters are load-bearing:
+          # --match 'v*' skips the desktop-v* trigger tags, and --exclude 'v0.*'
+          # skips the tag the desktop GitHub RELEASE hangs on (trigger is
+          # desktop-v0.1.22, but electron-builder publishes the release itself on
+          # a bare v0.1.22, which also matches v* and is usually nearer than the
+          # real CLI tag). Without the exclude, LAST_TAG resolves to e.g. v0.1.22,
+          # PREV_VERSION becomes 0.1.22, and every reuse path below misses --
+          # PyPI 404s and npm ETARGETs -- so codex-rs rebuilds from source on all
+          # 3 platforms even when the submodule pin never moved: ~60 min instead
+          # of ~7. Hit v1.7.16, v1.7.17 and v1.7.19.
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' --exclude 'v0.*' HEAD^ 2>/dev/null || echo "")
           # Compare the codex SUBMODULE COMMIT, not a path diff. Tags cut before
           # the 2026-07-23 monorepo fold carry codex at the old repo-root path,
           # so a path diff across the fold boundary reports "changed" even when


### PR DESCRIPTION
## Problem

`Detect Codex changes` resolves the previous release with:

```bash
LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' HEAD^)
```

`--match 'v*'` was written to skip the `desktop-v*` **trigger** tags. But the desktop **GitHub release** hangs on a bare `v0.1.x` tag (electron-builder publishes it there, even though the trigger is `desktop-v0.1.22`) — that also matches `v*`, and it is usually *nearer* than the real CLI tag.

On the v1.7.19 release, all three jobs logged:

```
codex pin: v0.1.22=8ceb9680... HEAD=8ceb9680...      <- pin identical, but LAST_TAG is v0.1.22
Failed to fetch PyPI metadata: HTTP Error 404: Not Found
[npm-reuse] @vicoa/cli@0.1.22-linux-x64 not available: npm error code ETARGET
[npm-reuse] Rust build will run
```

`PREV_VERSION` became `0.1.22`, so both reuse paths missed — the PyPI Linux fast path 404s, the npm codex-binary pre-populate ETARGETs — and each falls through silently. codex-rs then rebuilt from source on all 3 platforms even though the submodule pin has not moved since `fc37fef init: open source vicoa`.

**Cost:** linux 46 min, darwin-arm64 58 min, darwin-x64 59 min — the `Release` run takes ~60 min instead of ~7.

| CLI tag | `describe` resolved | reuse |
|---|---|---|
| v1.7.16 | `v0.1.19` | ❌ full rebuild |
| v1.7.17 | `v0.1.20` | ❌ full rebuild |
| v1.7.18 | `v1.7.17` | ✅ (got lucky) |
| v1.7.19 | `v0.1.22` | ❌ full rebuild |

## Fix

Add `--exclude 'v0.*'`, in both workflows that do this lookup (`backend-release.yml` and `backend-build-macos-arm64.yml`), and correct the comment that only mentioned `desktop-v*`.

Verified locally against the tag this release actually cut:

```
$ git describe --tags --abbrev=0 --match 'v*'                 v1.7.19^   -> v0.1.22   (before)
$ git describe --tags --abbrev=0 --match 'v*' --exclude 'v0.*' v1.7.19^  -> v1.7.18   (after)
```

## Notes

- No effect on the wheels themselves — this only restores the reuse fast path, so the next CLI release should drop back to ~7 min.
- The silent fallthrough is intentional (the Rust build is the backstop), which is why this went unnoticed for three releases. Left as-is; this PR fixes the input rather than making the fallback loud.