### PR TITLE
Mobile: save automations in the device's real timezone

### DIFF
--- a/apps/mobile/lib/custom_code/utils/automation_utils.dart
+++ b/apps/mobile/lib/custom_code/utils/automation_utils.dart
@@ -3,6 +3,8 @@
 // truth for next_run_at — the app only edits the stored schedule shape and
 // renders summaries.
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
@@ -373,13 +375,46 @@ AutomationScheduleDraft automationToDraft(dynamic a) {
 bool _tzInitialized = false;
 String? _cachedDeviceZone;
 
+/// Ask the platform for the device's IANA timezone and cache it, so the
+/// synchronous [deviceIanaTimezone] can hand out the real name afterwards.
+/// Call this before building a schedule draft; it is a no-op once resolved.
+///
+/// The OS is the only source of the *actual* zone (`Asia/Shanghai`), which is
+/// what the server needs to turn a schedule's wall-clock times into fire times
+/// — the offset scan in [deviceIanaTimezone] can only pick some zone that
+/// happens to share today's offsets, and its answer can drift from the user's
+/// real zone at a future DST change. Falls back to that scan when the platform
+/// channel is unavailable or returns something that isn't an IANA name (e.g.
+/// Android's "GMT+08:00" for a manually-set offset).
+Future<String> loadDeviceIanaTimezone() async {
+  final cached = _cachedDeviceZone;
+  if (cached != null) return cached;
+  try {
+    final name = (await FlutterTimezone.getLocalTimezone()).identifier;
+    // Every zone the OS reports for a real region is 'Area/Location'; 'UTC' is
+    // the one bare name worth honouring.
+    if (name.contains('/') || name == 'UTC') {
+      return _cachedDeviceZone = name;
+    }
+  } catch (_) {
+    // No platform implementation, or the call failed — fall through to the scan.
+  }
+  return deviceIanaTimezone();
+}
+
+/// Drop the cached zone so the next [loadDeviceIanaTimezone] queries the
+/// platform again.
+@visibleForTesting
+void resetDeviceIanaTimezoneCache() => _cachedDeviceZone = null;
+
 /// Best-effort IANA name for the device's timezone, e.g. `Asia/Shanghai`.
 ///
-/// Dart has no direct API for this (DateTime.timeZoneName is an abbreviation),
-/// so match the device's UTC offset at four points across the year against the
-/// bundled tz database and take the first zone that agrees at all of them. A
-/// functionally equivalent zone (same rules, different name) is fine — the
-/// server only uses the name to compute wall-clock fire times. Falls back to
+/// Fallback for [loadDeviceIanaTimezone], which should be preferred: Dart has
+/// no direct API for this (DateTime.timeZoneName is an abbreviation), so match
+/// the device's UTC offset at four points across the year against the bundled
+/// tz database and take the first zone that agrees at all of them. That yields
+/// a zone with the same offsets *today* but an arbitrary name (a UTC+8 device
+/// resolves to 'Antarctica/Casey'), so it is only a stand-in. Falls back to
 /// 'UTC' if nothing matches.
 String deviceIanaTimezone() {
   final cached = _cachedDeviceZone;

--- a/apps/mobile/lib/pages/automations/automation_edit_sheet.dart
+++ b/apps/mobile/lib/pages/automations/automation_edit_sheet.dart
@@ -35,7 +35,13 @@ Future<Map<String, dynamic>?> showAutomationEditSheet({
   required List<dynamic> machines,
   required AgentCatalog catalog,
   ValueChanged<String>? onOpenInstance,
-}) {
+}) async {
+  // Resolve the device's real IANA zone (cached after the first call) before the
+  // sheet builds its draft: every time in the editor is wall-clock in that zone,
+  // so a new automation must carry the user's own — not the stand-in the offset
+  // scan would pick.
+  await autils.loadDeviceIanaTimezone();
+  if (!context.mounted) return null;
   return showModalBottomSheet<Map<String, dynamic>>(
     context: context,
     isScrollControlled: true,

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -899,6 +899,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "869677426fde92dbe170fb7d2d4929f2a8343c2f5f62f08b0bb64f908630b073"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_web_plugins:
     dependency: "direct main"
     description: flutter

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -169,6 +169,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0
+  flutter_timezone: ^5.1.0
 
 dependency_overrides:
   http: 1.4.0

--- a/apps/mobile/test/custom_code/automation_timezone_test.dart
+++ b/apps/mobile/test/custom_code/automation_timezone_test.dart
@@ -1,0 +1,64 @@
+// The zone an automation is saved with decides how the server turns its
+// wall-clock times (daily time, "from 9:00 to 17:00" window) into fire times,
+// so it has to be the device's real one — like the web dashboard's
+// Intl.DateTimeFormat().resolvedOptions().timeZone.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vicoa/custom_code/utils/automation_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('flutter_timezone');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  var calls = 0;
+
+  void mockPlatformZone(Object? Function() reply) {
+    calls = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls++;
+      return reply();
+    });
+  }
+
+  setUp(resetDeviceIanaTimezoneCache);
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    resetDeviceIanaTimezoneCache();
+  });
+
+  test('uses the IANA zone the platform reports', () async {
+    mockPlatformZone(() => 'Asia/Shanghai');
+    expect(await loadDeviceIanaTimezone(), 'Asia/Shanghai');
+    // And a fresh draft carries it, since that is what reaches the API.
+    expect(AutomationScheduleDraft().timezone, 'Asia/Shanghai');
+  });
+
+  test('caches the platform answer', () async {
+    mockPlatformZone(() => 'Europe/Berlin');
+    await loadDeviceIanaTimezone();
+    await loadDeviceIanaTimezone();
+    expect(calls, 1);
+  });
+
+  test('falls back to the offset scan for a bare GMT offset', () async {
+    // Android reports this shape when the device has a manually-set offset;
+    // the server can't resolve it and would silently schedule in UTC.
+    mockPlatformZone(() => 'GMT+08:00');
+    final zone = await loadDeviceIanaTimezone();
+    expect(zone, isNot('GMT+08:00'));
+    expect(zone == 'UTC' || zone.contains('/'), isTrue);
+  });
+
+  test('falls back to the offset scan when the platform channel is absent',
+      () async {
+    messenger.setMockMethodCallHandler(channel, null);
+    final zone = await loadDeviceIanaTimezone();
+    expect(zone, deviceIanaTimezone());
+    expect(zone == 'UTC' || zone.contains('/'), isTrue);
+  });
+}


### PR DESCRIPTION
An automation's times are wall-clock — "daily at 13:00", "every 2 hours between 09:00 and 17:00" — and the `timezone` it is stored with is what the server uses to turn them into fire times. The web dashboard sends the real zone (`Intl.DateTimeFormat().resolvedOptions().timeZone`); the app guessed one.

`deviceIanaTimezone()` matched the device's UTC offset at five instants against the bundled tz database and took the first zone that agreed, alphabetically. That is not the user's zone, it is *a* zone with today's offsets:

| device | resolved to | |
|---|---|---|
| `Asia/Shanghai` / `Asia/Singapore` | `Antarctica/Casey` | same offset today |
| `Europe/Berlin` | `Africa/Ceuta` | same offset today |
| `America/Los_Angeles` | `America/Ensenada` | same offset today |
| `Asia/Jerusalem` | `Asia/Beirut` | **diverges 2026-10-24** — Beirut's DST ends a week earlier, so those schedules fire an hour off for that week |

The names also drift over time: the app's bundled tz database and the server's tzdata are updated independently, and `Antarctica/Casey` in particular has changed offset eight times.

## Change

- Ask the OS via `flutter_timezone` (new dependency; iOS/Android/web/desktop), cache the answer, and resolve it before the edit sheet builds its draft.
- Keep the offset scan as the fallback for when there is no platform implementation (web) or the answer isn't an IANA name — Android reports `GMT+08:00` for a manually-set offset, which the server can't resolve and would silently schedule in UTC.
- Existing automations keep the zone they were stored with, same as the web dashboard.

## Testing

- New `test/custom_code/automation_timezone_test.dart`: uses the platform's zone, caches it, falls back for a bare GMT offset, falls back when the channel is absent. All pass.
- `flutter analyze` clean on the touched files.
- Needs a mobile build to ship; adds a CocoaPods/Gradle dependency, so the first iOS build after this pulls a new pod.