### PR TITLE
fix: stop Claude background sub-agents on interrupt

### DIFF
--- a/backend/src/integrations/headless/claude_code.py
+++ b/backend/src/integrations/headless/claude_code.py
@@ -88,6 +88,8 @@ try:
         RateLimitInfo,
         TaskStartedMessage,
         TaskNotificationMessage,
+        TaskUpdatedMessage,
+        TERMINAL_TASK_STATUSES,
     )
 except ImportError as e:
     print(
@@ -120,6 +122,22 @@ _CLAUDE_LIMITS_FETCH_INTERVAL = 60.0
 # closes the turn can't wedge the session. The stream reader itself keeps
 # running either way — this only bounds how long the run loop stays parked.
 _INTERRUPT_RESULT_TIMEOUT = 15.0
+
+# Task types the CLI reports through ``task_started`` that mean delegated
+# *agent* work — a Task-tool sub-agent or a workflow. Those are the ones a Stop
+# has to reach and the ones whose completion wakes the parent for a follow-up
+# turn. A background shell (``Bash(run_in_background=True)`` on a dev server)
+# rides the same frames but may never reach a terminal status, so tracking one
+# would defer the awaiting-input settle forever — and a Stop would kill the
+# user's dev server. Mirrors the SDK's own ``DEFERRING_TASK_TYPES``. A missing
+# ``task_type`` (older CLI) stays tracked, i.e. the previous behaviour.
+_AGENT_TASK_TYPES = frozenset({"local_agent", "local_workflow"})
+
+# Overall budget for the ``stop_task`` sweep an interrupt fires at the
+# background sub-agents. Each stop is a control round-trip to the CLI; they go
+# out concurrently and the sweep as a whole is bounded so a wedged CLI can't
+# leave it hanging.
+_STOP_TASKS_TIMEOUT = 10.0
 
 # Status-only watchdog (``_run_status_watchdog``): when autonomous work
 # (background sub-agents, CLI-initiated turns) goes silent for this long with
@@ -552,6 +570,9 @@ class HeadlessClaudeRunner:
         # own turn without waiting — the awaiting-input settle is then
         # deferred to the autonomous close (``_settle_after_autonomous_turn``).
         self._pending_background_tasks: set[str] = set()
+        # Keeps the interrupt's ``stop_task`` sweep referenced so the
+        # background task isn't GC'd mid-flight.
+        self._stop_tasks_task: "Optional[asyncio.Task[None]]" = None
 
         # ------------------------------------------------------------------
         # Session-lifetime stream reader + event-derived turn state.
@@ -569,6 +590,14 @@ class HeadlessClaudeRunner:
         # Modeled on Paseo's ``runQueryPump`` / autonomous-turn design.
         # ------------------------------------------------------------------
         self._open_turns: deque[str] = deque()
+        # How many of the open turns an interrupt is still unwinding: set from
+        # the FIFO's depth when the Stop lands, decremented by each close.
+        # Forwarding is suppressed while it is non-zero — and ONLY while:
+        # ``interrupt_requested`` stays set until the next user turn, so gating
+        # suppression on it swallowed every later autonomous turn (a background
+        # sub-agent reporting after the Stop) too. Session 4c77b787-…: content
+        # from ~7 minutes of post-Stop work never reached the dashboard.
+        self._interrupt_unwind_turns: int = 0
         # Set by the reader when it closes the current foreground turn;
         # ``run_conversation_turn`` parks on it instead of reading the stream.
         self._foreground_turn_done: Optional[asyncio.Event] = None
@@ -1325,16 +1354,32 @@ class HeadlessClaudeRunner:
     def _track_task_lifecycle(self, message) -> None:
         """Maintain ``_pending_background_tasks`` from the CLI's task events.
 
-        ``task_started`` fires when any sub-agent launches; ``task_notification``
-        fires once it settles (``completed`` / ``failed`` / ``stopped``). For a
-        *foreground* sub-agent both land before the turn's ``ResultMessage``, so
-        the set is empty by then and nothing changes. For a background one the
-        notification arrives *after* it.
+        ``task_started`` fires when a sub-agent launches; it settles on a
+        ``task_notification`` (``completed`` / ``failed`` / ``stopped``) *or* on
+        a ``task_updated`` patch carrying a terminal status. Both are handled
+        because a background task's terminal state can arrive as either — one
+        stopped via ``TaskStop`` (or by our own ``stop_task`` sweep) reports
+        ``killed`` through ``task_updated`` and the matching notification is
+        sometimes suppressed. Tracking only the notification leaked those ids,
+        and a leaked id defers the awaiting-input settle indefinitely.
+
+        Only delegated agent work is tracked (``_AGENT_TASK_TYPES``); a
+        background shell rides the same frames but may never settle.
+
+        For a *foreground* sub-agent both frames land before the turn's
+        ``ResultMessage``, so the set is empty by then and nothing changes. For
+        a background one the terminal frame arrives *after* it.
         """
         if isinstance(message, TaskStartedMessage):
+            task_type = getattr(message, "task_type", None)
+            if task_type is not None and task_type not in _AGENT_TASK_TYPES:
+                return
             self._pending_background_tasks.add(message.task_id)
         elif isinstance(message, TaskNotificationMessage):
             self._pending_background_tasks.discard(message.task_id)
+        elif isinstance(message, TaskUpdatedMessage):
+            if getattr(message, "status", None) in TERMINAL_TASK_STATUSES:
+                self._pending_background_tasks.discard(message.task_id)
 
     # ------------------------------------------------------------------
     # Session-lifetime stream reader (Paseo's "query pump") + turn state
@@ -1482,6 +1527,7 @@ class HeadlessClaudeRunner:
         """Drop all turn state and unblock the run loop (stream loss/reconnect)."""
         self._open_turns.clear()
         self._pending_background_tasks.clear()
+        self._interrupt_unwind_turns = 0
         event = self._foreground_turn_done
         if event is not None and not event.is_set():
             event.set()
@@ -1525,6 +1571,11 @@ class HeadlessClaudeRunner:
             self.logger.info("ResultMessage with no open turn; dropping as stale")
             return
         kind = self._open_turns.popleft()
+        # Was this close part of an interrupt unwind? Snapshot before the
+        # decrement — the settle below branches on it.
+        unwinding = self._interrupt_unwind_turns > 0
+        if unwinding:
+            self._interrupt_unwind_turns -= 1
         if kind == "foreground":
             # Snapshot the deferral decision NOW — by the time the run loop
             # wakes, this reader may already have consumed the notifications
@@ -1536,15 +1587,21 @@ class HeadlessClaudeRunner:
                 event.set()
             return
         self.logger.info("Autonomous turn completed")
-        await self._settle_after_autonomous_turn()
+        await self._settle_after_autonomous_turn(interrupted=unwinding)
 
-    async def _settle_after_autonomous_turn(self) -> None:
-        """Decide whether an autonomous close should settle the session."""
+    async def _settle_after_autonomous_turn(self, interrupted: bool = False) -> None:
+        """Decide whether an autonomous close should settle the session.
+
+        ``interrupted`` marks a turn the Stop aborted, whose output was
+        suppressed. A turn that merely *started after* the Stop (a background
+        sub-agent that outlived it, reporting in) is not one of those: it
+        settles normally, so its content is announced like any other.
+        """
         if self._open_turns:
             # A foreground turn is queued behind this one; its own close
             # settles the session.
             return
-        if self.interrupt_requested:
+        if interrupted:
             # The interrupt path already posted its notice; just re-assert
             # the idle status it wrote (a racing agent POST re-opens ACTIVE).
             await self._settle_awaiting_input_after_interrupt()
@@ -1696,8 +1753,10 @@ class HeadlessClaudeRunner:
         # Mirror the old drain-and-discard: while an interrupt is unwinding
         # (Stop pressed, closing ResultMessage not yet seen) nothing is
         # forwarded — anything worth showing already streamed before the
-        # Stop. ResultMessages still close turns and bank usage below.
-        suppressing = self.interrupt_requested and bool(self._open_turns)
+        # Stop. ResultMessages still close turns and bank usage below. Scoped
+        # to the turns that were open when the Stop landed, so work that
+        # outlived it still renders (see ``_interrupt_unwind_turns``).
+        suppressing = self._interrupt_unwind_turns > 0
 
         if (
             not self._open_turns
@@ -1923,11 +1982,24 @@ class HeadlessClaudeRunner:
            ``receive_response`` loop and ``_wait_for_user_input`` poll.
         2. ``claude_client.interrupt()`` — SDK-level cancel of the
            in-flight response stream.
-        3. ``cancel_all()`` on the AUQ + permission registries — needed
+        3. ``stop_task()`` for every tracked in-flight sub-agent —
+           ``interrupt()`` aborts the *turn*, and a background sub-agent
+           (``Task`` with ``run_in_background``) outlives it: the CLI only
+           stops one on an explicit ``stop_task`` control request. Without
+           this a Stop left them running, each report waking the parent for
+           another turn — session 4c77b787-… kept 20 sub-agents working for
+           7 minutes after the Stop, with no way to stop them.
+        4. ``cancel_all()`` on the AUQ + permission registries — needed
            because ``claude_client.interrupt()`` alone can't reach a
            runner that's blocked inside ``can_use_tool`` awaiting a
            pending permission/AUQ reply. Without this, an interrupt
            sent while a permission prompt was open did nothing.
+
+        Re-entrant while anything is still running: ``interrupt_requested``
+        stays set until the next user turn, so the old "already requested"
+        early-return made every later Stop a no-op — exactly when the user
+        was pressing it again because work was still going. A repeat press
+        re-sends the stop; only the notice is posted once per episode.
 
         The user-facing feedback message goes out BEFORE the status
         write, and the status write is repeated by ``run_conversation_turn``
@@ -1945,10 +2017,15 @@ class HeadlessClaudeRunner:
         them is noise. ``update_agent_instance_status`` is a pure DB
         field write.
         """
-        if self.interrupt_requested:
+        stoppable = bool(self._open_turns) or bool(self._pending_background_tasks)
+        if self.interrupt_requested and not stoppable:
             return
 
+        first_press = not self.interrupt_requested
         self.interrupt_requested = True
+        # Only the turns open right now are being unwound; anything that
+        # outlives this Stop reports normally afterwards.
+        self._interrupt_unwind_turns = len(self._open_turns)
         self.logger.info("Interrupt command received; stopping current task")
 
         if self.claude_client:
@@ -1958,13 +2035,76 @@ class HeadlessClaudeRunner:
             except Exception as exc:
                 self.logger.error(f"Failed to interrupt Claude client: {exc}")
 
+        self._schedule_background_task_stop()
+
         self._auq_registry.cancel_all()
         self._permission_registry.cancel_all()
 
-        await self._send_feedback_message(
-            "Interrupted · What should Claude do instead?"
-        )
+        if first_press:
+            await self._send_feedback_message(
+                "Interrupted · What should Claude do instead?"
+            )
         await self._settle_awaiting_input_after_interrupt()
+
+    def _schedule_background_task_stop(self) -> None:
+        """Ask the CLI to stop every sub-agent we know is still in flight.
+
+        Non-blocking on purpose: an interrupt runs inline on the WS routing
+        path (see ``_maybe_route_control_command``) and each stop is a control
+        round-trip to the CLI, so the sweep goes to a background task rather
+        than delaying the Stop's own feedback message.
+
+        The ids are taken off ``_pending_background_tasks`` here: the CLI
+        confirms each stop with a terminal ``task_updated`` / ``task_notification``
+        anyway, and a task we asked to stop must not keep the session pinned
+        ACTIVE if that frame never lands.
+        """
+        task_ids = sorted(self._pending_background_tasks)
+        if not task_ids:
+            return
+        self._pending_background_tasks.clear()
+        if self.claude_client is None:
+            return
+        if getattr(self.claude_client, "stop_task", None) is None:
+            # Older SDK without per-task stop; the turn-level interrupt is all
+            # we have.
+            self.logger.warning(
+                "Claude SDK has no stop_task(); %d background sub-agent(s) may "
+                "keep running after the interrupt",
+                len(task_ids),
+            )
+            return
+        self._stop_tasks_task = asyncio.create_task(
+            self._stop_background_tasks(task_ids)
+        )
+
+    async def _stop_background_tasks(self, task_ids: List[str]) -> None:
+        """Send ``stop_task`` for each id, concurrently and time-boxed."""
+        stop = getattr(self.claude_client, "stop_task", None)
+        if stop is None:
+            return
+
+        async def _stop_one(task_id: str) -> None:
+            try:
+                await stop(task_id)
+                self.logger.info("Stopped background sub-agent %s", task_id)
+            except Exception as exc:
+                # Usually the task settled between us reading the set and the
+                # request landing — the CLI answers ``invalid_task_id``.
+                self.logger.info("stop_task(%s) did not apply: %s", task_id, exc)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(_stop_one(task_id) for task_id in task_ids)),
+                timeout=_STOP_TASKS_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            self.logger.warning(
+                "stop_task sweep for %d background sub-agent(s) did not finish "
+                "within %.0fs",
+                len(task_ids),
+                _STOP_TASKS_TIMEOUT,
+            )
 
     async def _settle_awaiting_input_after_interrupt(self) -> None:
         """Write status=AWAITING_INPUT so the dashboard shows the runner idle.
@@ -3136,11 +3276,13 @@ class HeadlessClaudeRunner:
                 self.logger.info(
                     "Skipping input request because current task was interrupted"
                 )
-                # Background sub-agents from the aborted turn are abandoned
-                # with it. Re-assert AWAITING_INPUT — any message POSTed
-                # between the Stop and the closing Result set the row back
-                # to ACTIVE.
-                self._pending_background_tasks.clear()
+                # The unwind is over. Anything the CLI still has running
+                # outlived the Stop (``_handle_interrupt`` already asked it to
+                # stop those sub-agents), so its output must render normally
+                # instead of staying suppressed behind a force-closed turn.
+                self._interrupt_unwind_turns = 0
+                # Re-assert AWAITING_INPUT — any message POSTed between the
+                # Stop and the closing Result set the row back to ACTIVE.
                 await self._settle_awaiting_input_after_interrupt()
                 return None
 

--- a/backend/src/integrations/headless/tests/conftest.py
+++ b/backend/src/integrations/headless/tests/conftest.py
@@ -92,10 +92,16 @@ def _build_runner(
     # Sub-agents announced but not yet settled; defers the awaiting-input
     # settle while background (``run_in_background: true``) sub-agents run.
     runner._pending_background_tasks = set()
+    # Interrupt's per-task stop sweep (``_schedule_background_task_stop``)
+    # parks its handle here so the background task isn't GC'd.
+    runner._stop_tasks_task = None
     # Session-lifetime stream reader + event-derived turn state (see
     # ``HeadlessClaudeRunner.__init__``). The reader task is started lazily
     # by ``run_conversation_turn`` via ``_ensure_stream_reader``.
     runner._open_turns = deque()
+    # How many open turns an interrupt is still unwinding (drives forwarding
+    # suppression). See ``HeadlessClaudeRunner.__init__``.
+    runner._interrupt_unwind_turns = 0
     runner._foreground_turn_done = None
     runner._foreground_settle_deferred = False
     runner._stream_reader_task = None

--- a/backend/src/integrations/headless/tests/test_interrupt_behavior.py
+++ b/backend/src/integrations/headless/tests/test_interrupt_behavior.py
@@ -72,6 +72,9 @@ class _StatefulFakeClaudeClient:
         self._park_when_exhausted = park_when_exhausted
         self.queries: List[Any] = []
         self.interrupts = 0
+        # ``stop_task`` ids, in call order — the per-sub-agent stop an
+        # interrupt fires at background Task work.
+        self.stopped_tasks: List[str] = []
         # Optional hook fired on every ``query()`` — lets a test model the
         # CLI *responding* to a prompt (extend the script causally, the way
         # the real CLI only answers after being asked).
@@ -88,6 +91,9 @@ class _StatefulFakeClaudeClient:
 
     async def interrupt(self) -> None:
         self.interrupts += 1
+
+    async def stop_task(self, task_id: str) -> None:
+        self.stopped_tasks.append(task_id)
 
     async def receive_messages(self):
         while True:
@@ -307,3 +313,110 @@ async def test_message_after_interrupt_gets_its_own_reply(make_runner):
     assert forwarded[1:] == ["answer to turn two"]
     assert "What would you like me to do next?" not in forwarded
     await runner._stop_stream_reader()
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 - Stop left background sub-agents running.
+#
+# ``interrupt()`` aborts the *turn*; a sub-agent launched with
+# ``run_in_background`` outlives it and the CLI only stops one on an explicit
+# ``stop_task``. Session 4c77b787-… (2026-09-09 09:13): the Stop landed with 20
+# sub-agents in flight and they kept reporting for another 7 minutes, each
+# report waking the parent for a follow-up turn. Worse, the second Stop the
+# user pressed was swallowed by the "already requested" early-return, and the
+# post-Stop turns were suppressed as if they were the aborted one - so the work
+# was neither stopped nor shown.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interrupt_stops_running_background_subagents(make_runner):
+    """Stop must reach each in-flight sub-agent, not just the turn."""
+    fake = FakeAsyncVicoaClient()
+    runner = make_runner(vicoa_client=fake)
+    client = _StatefulFakeClaudeClient([])
+    runner.claude_client = client
+    runner._pending_background_tasks = {"task-1", "task-2"}
+
+    await runner._handle_interrupt()
+    await asyncio.wait_for(runner._stop_tasks_task, timeout=5)
+
+    assert client.interrupts == 1
+    assert sorted(client.stopped_tasks) == ["task-1", "task-2"]
+    # Dropped from the ledger: a task we asked to stop must not keep the
+    # session pinned ACTIVE if its terminal frame never lands.
+    assert runner._pending_background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_repeat_stop_reaches_the_cli_while_work_survives(make_runner):
+    """A second Stop must act when something is still running.
+
+    ``interrupt_requested`` stays set until the next user turn, so the old
+    early-return made every later press a no-op — exactly when the user was
+    pressing again *because* sub-agents were still going.
+    """
+    fake = FakeAsyncVicoaClient()
+    runner = make_runner(vicoa_client=fake)
+    client = _StatefulFakeClaudeClient([])
+    runner.claude_client = client
+
+    await runner._handle_interrupt()
+    # Nothing was running, so a double tap is still a no-op.
+    await runner._handle_interrupt()
+    assert client.interrupts == 1
+
+    # A background sub-agent outlived the Stop and is reporting in.
+    runner._pending_background_tasks = {"task-9"}
+    runner._open_turns.append("autonomous")
+
+    await runner._handle_interrupt()
+    await asyncio.wait_for(runner._stop_tasks_task, timeout=5)
+
+    assert client.interrupts == 2
+    assert client.stopped_tasks == ["task-9"]
+    # One notice per interrupt episode — the repeat presses stop work, they
+    # don't spam the chat.
+    assert len(fake.sent_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_work_that_outlived_the_stop_is_still_forwarded(make_runner):
+    """Suppression covers the aborted turn, not everything after it.
+
+    Gated on ``interrupt_requested`` (never cleared until the next user turn),
+    a background sub-agent's report turn opened, was marked ACTIVE, and then
+    had every message silently dropped.
+    """
+    fake = FakeAsyncVicoaClient()
+    runner = make_runner(vicoa_client=fake)
+    _prime_for_turn(runner)
+    runner.claude_client = _StatefulFakeClaudeClient([])
+
+    forwarded: List[str] = []
+
+    async def _capture(content, message_metadata=None):
+        forwarded.append(content)
+
+    runner.send_to_vicoa = _capture  # type: ignore[assignment]
+
+    # A background sub-agent's report turn is open when the Stop lands.
+    runner._open_turns.append("autonomous")
+    await runner._handle_interrupt()
+
+    # Its tail is suppressed, and its result closes the unwind.
+    await runner._process_sdk_message(_assistant("cut off mid-report"))
+    await runner._process_sdk_message(_result())
+    assert forwarded == []
+    assert runner._interrupt_unwind_turns == 0
+
+    # A sub-agent that outlived the Stop reports afterwards: new autonomous
+    # turn, rendered normally. The whole turn, not just its first message —
+    # the old gate let the message that *opened* the turn through and then
+    # dropped every one after it, which is what made the dashboard flip to
+    # ACTIVE and show nothing.
+    await runner._process_sdk_message(_assistant("late sub-agent report"))
+    await runner._process_sdk_message(_assistant("and its conclusion"))
+
+    assert forwarded == ["late sub-agent report", "and its conclusion"]
+    assert list(runner._open_turns) == ["autonomous"]

--- a/backend/src/integrations/headless/tests/test_subagent.py
+++ b/backend/src/integrations/headless/tests/test_subagent.py
@@ -7,6 +7,7 @@ from claude_agent_sdk import (
     SystemMessage,
     TaskNotificationMessage,
     TaskStartedMessage,
+    TaskUpdatedMessage,
     TextBlock,
     ToolResultBlock,
     ToolUseBlock,
@@ -597,4 +598,59 @@ async def test_watchdog_defers_while_reply_pending(make_runner, monkeypatch):
         runner._auq_registry.cancel("req-1")
 
     assert fake_vicoa.mark_requires_input_calls == []
+    assert runner._pending_background_tasks == {"task-1"}
+
+
+# ---------------------------------------------------------------------------
+# Task ledger: what belongs in ``_pending_background_tasks``, and what clears it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminal_task_updated_clears_the_pending_task(make_runner):
+    """A background task's terminal state can arrive *only* as ``task_updated``.
+
+    A task stopped via ``TaskStop`` — or by the Stop button's own ``stop_task``
+    sweep — reports ``killed`` there and the matching ``task_notification`` is
+    sometimes suppressed. Tracking just the notification leaked the id, and a
+    leaked id defers the awaiting-input settle indefinitely.
+    """
+    runner = make_runner()
+    runner._track_task_lifecycle(_task_started("task-1", "tu-1"))
+    assert runner._pending_background_tasks == {"task-1"}
+
+    runner._track_task_lifecycle(
+        TaskUpdatedMessage(
+            subtype="task_updated",
+            data={},
+            task_id="task-1",
+            patch={"status": "killed"},
+            status="killed",
+            session_id="sdk-sess-1",
+            uuid="u-updated",
+        )
+    )
+
+    assert runner._pending_background_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_background_shell_is_not_tracked_as_a_subagent(make_runner):
+    """Only delegated agent work counts.
+
+    A background shell (``Bash(run_in_background=True)`` on a dev server) rides
+    the same task frames but may never reach a terminal status, so tracking one
+    would defer the settle forever — and the Stop button's sweep would kill the
+    user's dev server.
+    """
+    runner = make_runner()
+
+    shell = _task_started("shell-1", "tu-1")
+    shell.task_type = "local_bash"
+    runner._track_task_lifecycle(shell)
+    assert runner._pending_background_tasks == set()
+
+    agent = _task_started("task-1", "tu-2")
+    agent.task_type = "local_agent"
+    runner._track_task_lifecycle(agent)
     assert runner._pending_background_tasks == {"task-1"}


### PR DESCRIPTION
## The bug

Pressing **Stop** on a Claude Code session only aborted the *turn*. Sub-agents launched with `run_in_background` outlive it, and the CLI stops one only on an explicit `stop_task` control request — which this wrapper never sent.

Straight from a real session log (`4c77b787-…`, 2026-09-09 09:13):

```
09:13:18  Autonomous turn closed with 20 background task(s) outstanding; staying ACTIVE
09:13:20  Interrupt command received; stopping current task
09:13:20  Sent interrupt to Claude client
09:13:39  TaskNotificationMessage → opening an autonomous turn
09:13:57 / 09:14:22 / 09:14:41 / 09:17:40 … through 09:20:24
```

20 sub-agents kept working for **7 minutes** after the Stop, each report waking the parent for another turn.

Two follow-on bugs made that both unrecoverable and invisible:

1. **The second Stop was a no-op.** `interrupt_requested` is only cleared at the next user turn, so `_handle_interrupt`'s `if self.interrupt_requested: return` swallowed every later press — exactly when the user pressed again *because* work was still running.
2. **Post-Stop output was silently dropped.** Suppression was gated on that same sticky flag: the message that *opened* a surviving sub-agent's autonomous turn got through, and every message after it was dropped. The dashboard flipped to ACTIVE and showed nothing.

## The fix

- `_handle_interrupt` now sweeps `stop_task` over every tracked in-flight sub-agent — concurrently, time-boxed (10s), and off the inline WS routing path so the Stop's own feedback isn't delayed.
- The interrupt is **re-entrant** while an open turn or a tracked task survives; a repeat press re-sends the stop. The notice is still posted once per episode, so no chat spam.
- Suppression is scoped to the turns that were open when the Stop landed (`_interrupt_unwind_turns`) instead of the sticky flag, so work that outlived the Stop renders and settles normally (notification included).
- The task ledger clears on a terminal `task_updated` — `TaskStop` and our own sweep report `killed` only there, and a leaked id defers the awaiting-input settle indefinitely — and tracks agent work only (`local_agent` / `local_workflow`). A background shell rides the same frames but may never settle, which deferred the settle forever and would have made Stop kill the user's dev server.

### Why `stop_task` and not just `interrupt()`

The CLI's initialize schema carries a `perTaskStopAffordance` capability: declared, an interrupt spares running background agents; absent, it is documented to fail closed and kill them. The SDK never declares it — yet real sessions show the sub-agents surviving anyway. Per-task `stop_task` is the only reliable stop.

## Scope

Claude-only. Codex, the ACP wrappers (opencode / gemini / generic) and pi/omp are strictly turn-scoped — their sub-agents live inside a prompt turn and the turn-level cancel covers them — and none of them has the sticky-flag guard.

## Testing

- 5 new regression tests (3 interrupt-path, 2 task-ledger), each verified **red** against the pre-fix code.
- `src/integrations/headless/tests`: 692 passed.
- `make lint` (ruff + pyright + WebSocket freeze check): clean.