### PR TITLE
Worktree setup: never type into a shell that isn't reading yet

### DIFF
--- a/apps/web/components/terminal-pane/initial-input.test.ts
+++ b/apps/web/components/terminal-pane/initial-input.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'vitest';
-import { chunkPtyInput, isLineEditorReady, PTY_INPUT_CHUNK_BYTES } from './initial-input';
+import {
+  chunkPtyInput,
+  isLineEditorReady,
+  prepareInitialInput,
+  PTY_INPUT_CHUNK_BYTES,
+} from './initial-input';
 
 const utf8Bytes = (text: string): number => new TextEncoder().encode(text).length;
 const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
@@ -65,5 +70,54 @@ describe('isLineEditorReady', () => {
 
   test('empty output is not ready', () => {
     expect(isLineEditorReady(new Uint8Array(0))).toBe(false);
+  });
+});
+
+describe('prepareInitialInput', () => {
+  const PASTE_START = '\x1b[200~';
+  const PASTE_END = '\x1b[201~';
+  const chain = `export VICOA_ROOT_PATH='/Users/x/vicoa' && ${Array.from(
+    { length: 12 },
+    (_, i) => `echo 'step ${i} ---------------------------------------------'`,
+  ).join(' && ')}`;
+
+  test('wraps the body in paste markers and submits with a separate CR', () => {
+    const writes = prepareInitialInput(`${chain}\r`, { bracketedPaste: true });
+    expect(writes[0].startsWith(PASTE_START)).toBe(true);
+    // The CR is its own write, AFTER the terminator: inside the paste it would
+    // be literal text and the chain would never run.
+    expect(writes[writes.length - 1]).toBe('\r');
+    expect(writes[writes.length - 2].endsWith(PASTE_END)).toBe(true);
+    expect(writes.join('')).toBe(`${PASTE_START}${chain}${PASTE_END}\r`);
+  });
+
+  test('no paste markers for a shell that never advertised bracketed paste', () => {
+    const writes = prepareInitialInput(`${chain}\r`, { bracketedPaste: false });
+    expect(writes.join('')).toBe(`${chain}\r`);
+    expect(writes.some((w) => w.includes(PASTE_START))).toBe(false);
+    expect(writes[writes.length - 1]).toBe('\r');
+  });
+
+  test('the body still goes out in queue-sized chunks', () => {
+    const writes = prepareInitialInput(`${chain}\r`, { bracketedPaste: true });
+    expect(writes.length).toBeGreaterThan(2);
+    // Only the marker overhead may push a write past the chunk budget.
+    for (const write of writes) {
+      const payload = write.replace(PASTE_START, '').replace(PASTE_END, '');
+      expect(new TextEncoder().encode(payload).length).toBeLessThanOrEqual(PTY_INPUT_CHUNK_BYTES);
+    }
+  });
+
+  test('input with no trailing CR is pasted without submitting it', () => {
+    const writes = prepareInitialInput('ls -la', { bracketedPaste: true });
+    expect(writes).toEqual([`${PASTE_START}ls -la${PASTE_END}`]);
+  });
+
+  test('empty input produces no writes', () => {
+    expect(prepareInitialInput('', { bracketedPaste: true })).toEqual([]);
+  });
+
+  test('a bare CR is not wrapped in markers', () => {
+    expect(prepareInitialInput('\r', { bracketedPaste: true })).toEqual(['\r']);
   });
 });

--- a/apps/web/components/terminal-pane/initial-input.ts
+++ b/apps/web/components/terminal-pane/initial-input.ts
@@ -9,10 +9,26 @@
 // at a half-typed command that never runs, e.g. `... && echo '--- ` with an
 // unclosed quote.
 //
-// Two guards, both needed: wait for the shell's line editor to be reading
-// (`isLineEditorReady`), then feed the input in sub-queue-sized chunks
-// (`chunkPtyInput`) so a shell that stalls mid-write can only ever have a
-// fraction of a queue outstanding.
+// Three guards, all needed:
+//  1. wait for the shell's line editor to be reading (`isLineEditorReady`);
+//  2. hand the text over as a BRACKETED PASTE (`prepareInitialInput`) — see
+//     below, this is what actually keeps the queue drained;
+//  3. feed it in sub-queue-sized chunks (`chunkPtyInput`) so a shell that
+//     stalls mid-write can only ever have a fraction of a queue outstanding.
+//
+// (2) is not cosmetic. Typed character-by-character, every byte runs the full
+// ZLE widget stack, and a stock oh-my-zsh has plenty on it: `url-quote-magic`
+// on self-insert, zsh-autosuggestions' history query, zsh-syntax-highlighting
+// re-highlighting the whole buffer on each redraw — O(n) work per character
+// over a growing line. On a 1.5KB setup chain that is far slower than a writer
+// pushing 256 bytes every 20ms, so the queue fills, the tail is dropped, and
+// the user is left at a `cmdsubst>` continuation prompt that never returns:
+// the "setup hangs" bug. Inside `ESC[200~ … ESC[201~` the shell's paste widget
+// instead slurps the whole run out of the tty in one go and inserts it as
+// literal text, no per-character widgets — the queue drains as fast as we can
+// write. The submitting CR must stay OUTSIDE the markers: inside a paste it is
+// literal text (a newline in the buffer), so the chain would sit there, typed
+// but never run.
 
 /** Per-write ceiling, well under the 1024-byte macOS tty input queue so a
  *  couple of un-drained chunks still can't overflow it. */
@@ -59,4 +75,39 @@ export function isLineEditorReady(bytes: Uint8Array): boolean {
     return true;
   }
   return false;
+}
+
+/** Bracketed-paste delimiters. A shell that emitted `ESC[?2004h` has told us it
+ *  understands these; anything else must be typed raw (the markers would land
+ *  in the command line as literal `[200~` garbage). */
+const PASTE_START = '\x1b[200~';
+const PASTE_END = '\x1b[201~';
+
+/** Split trailing CR/LF — what submits the command — from the text itself. */
+function splitSubmit(data: string): [body: string, submit: string] {
+  const match = /[\r\n]+$/.exec(data);
+  if (match === null) return [data, ''];
+  return [data.slice(0, match.index), match[0]];
+}
+
+/** The exact sequence of pty writes that types `data` into a live shell.
+ *
+ *  With `bracketedPaste` the body is wrapped in paste markers and the trailing
+ *  CR follows as its own write (a CR inside the markers is literal text, and
+ *  would leave the command typed but unexecuted). Without it — a shell that
+ *  never advertised bracketed paste — the same chunks go out raw, which is the
+ *  best we can do for a line editor that has no fast paste path.
+ */
+export function prepareInitialInput(
+  data: string,
+  { bracketedPaste }: { bracketedPaste: boolean },
+): string[] {
+  const [body, submit] = splitSubmit(data);
+  const chunks = chunkPtyInput(body);
+  if (bracketedPaste && chunks.length > 0) {
+    chunks[0] = PASTE_START + chunks[0];
+    chunks[chunks.length - 1] += PASTE_END;
+  }
+  if (submit !== '') chunks.push(submit);
+  return chunks;
 }

--- a/apps/web/components/terminal-pane/terminal-pane.tsx
+++ b/apps/web/components/terminal-pane/terminal-pane.tsx
@@ -23,7 +23,7 @@ import type { Terminal } from '@xterm/xterm';
 import type { PtyTransport } from './pty-transport';
 import { buildTerminalOptions, VICOA_TERMINAL_BACKGROUND } from './terminal-options';
 import { openTerminalLink, trackLinkModifier } from './terminal-links';
-import { chunkPtyInput, isLineEditorReady } from './initial-input';
+import { isLineEditorReady, prepareInitialInput } from './initial-input';
 import { RpcError } from '@/lib/ws-client';
 
 const RESIZE_DEBOUNCE_MS = 50;
@@ -59,11 +59,21 @@ export interface TerminalPaneProps {
 // `initialInput` may only be typed once the shell's line editor is reading —
 // input written while it's still sourcing rc files overflows the tty's small
 // input queue (1024 bytes on macOS) and the tail, CR included, is dropped. The
-// bracketed-paste-on sequence says so exactly (see ./initial-input); these
-// timers cover shells that never emit it: write once output has been quiet for
-// a beat, and no later than the ceiling even if the shell never stops printing.
+// bracketed-paste-on sequence says so exactly (see ./initial-input); seeing it
+// also means the shell takes a bracketed paste, which is how the text is then
+// handed over — a line editor loaded with per-keystroke widgets (oh-my-zsh +
+// syntax highlighting) cannot drain a typed 1.5KB chain fast enough to keep the
+// queue from overflowing either.
+//
+// Two fallbacks cover shells that never announce bracketed paste, and BOTH are
+// keyed off the shell having spoken at least once. A stock oh-my-zsh + starship
+// prints nothing at all for the first ~1.5s while it sources rc files: arming
+// the quiet timer at spawn (as this did) fired it into a shell that was not yet
+// reading, which is the 1024-byte-truncated setup chain. So: quiet only counts
+// after the first output, and the ceiling refuses to fire while the shell is
+// still silent (it waits another round instead).
 const INITIAL_INPUT_QUIET_MS = 300;
-const INITIAL_INPUT_MAX_WAIT_MS = 5000;
+const INITIAL_INPUT_MAX_WAIT_MS = 8000;
 // Gap between chunks, so the shell drains each one before the next lands.
 const INITIAL_INPUT_CHUNK_DELAY_MS = 20;
 
@@ -109,6 +119,14 @@ export function TerminalPane({
     // Worktree setup: one-shot input written once the shell is live, then
     // cleared so a manual restart (which reuses spawn/onData) never resends it.
     let pendingInitialInput = initialInputRef.current || null;
+    // Set once the shell advertises bracketed paste, so the input goes over as
+    // a paste rather than as 1.5KB of simulated keystrokes. Stays false for a
+    // shell that never says so (then only the timers below release the input).
+    let bracketedPasteOn = false;
+    // Whether the shell has printed a single byte yet. Until it has, it is
+    // still sourcing rc files and is not reading stdin, so nothing may be
+    // written to it — see releaseOnDeadline.
+    let sawOutput = false;
     let initialInputTimer: number | null = null;
     let initialInputDeadline: number | null = null;
     let chunkTimer: number | null = null;
@@ -124,9 +142,10 @@ export function TerminalPane({
     };
     // Fed in queue-sized bites rather than one write: a setup chain runs well
     // past the tty's 1024-byte input queue, and anything that doesn't fit while
-    // the shell isn't reading is dropped outright.
+    // the shell isn't reading is dropped outright. `prepareInitialInput` also
+    // frames it as a paste when the shell supports one.
     const writeChunked = (data: string): void => {
-      const chunks = chunkPtyInput(data);
+      const chunks = prepareInitialInput(data, { bracketedPaste: bracketedPasteOn });
       let next = 0;
       const step = (): void => {
         chunkTimer = null;
@@ -146,12 +165,28 @@ export function TerminalPane({
       pendingInitialInput = null;
       writeChunked(data);
     };
-    /** Re-arm the quiet timer on each burst of shell output; the deadline set
-     *  at spawn keeps a never-quiet shell from deferring setup forever. */
+    /** Arm (and re-arm) the quiet timer on each burst of shell output, so the
+     *  fallback only ever fires against a shell that has started talking; the
+     *  deadline below keeps a never-quiet shell from deferring setup forever. */
     const deferInitialInput = (): void => {
       if (pendingInitialInput === null || disposed) return;
       if (initialInputTimer !== null) window.clearTimeout(initialInputTimer);
       initialInputTimer = window.setTimeout(flushInitialInput, INITIAL_INPUT_QUIET_MS);
+    };
+    /** Last-resort release, for a shell that talks but never announces
+     *  bracketed paste and never pauses long enough for the quiet timer.
+     *  A shell that has printed NOTHING is a different case: it isn't reading
+     *  stdin either (a cold zsh can spend seconds in compinit), and writing
+     *  into that is exactly what drops the tail of the chain — so wait another
+     *  round instead, and let its first output drive the release. */
+    const releaseOnDeadline = (): void => {
+      initialInputDeadline = null;
+      if (pendingInitialInput === null || disposed) return;
+      if (!sawOutput) {
+        initialInputDeadline = window.setTimeout(releaseOnDeadline, INITIAL_INPUT_MAX_WAIT_MS);
+        return;
+      }
+      flushInitialInput();
     };
 
     // Armed synchronously (not inside the async import below) so the pane is
@@ -213,14 +248,16 @@ export function TerminalPane({
           if (!disposed) {
             setStatus({ kind: 'running' });
             term.focus();
-            // Arm both fallbacks now: the quiet timer covers a shell that
-            // prints nothing at all, the deadline one that never stops.
+            // Only the ceiling is armed here. The quiet timer starts on the
+            // shell's first output (see onData): a shell that hasn't printed
+            // anything yet is still sourcing rc files, not draining stdin, and
+            // 300ms of that silence is not a readiness signal — it's the window
+            // where written input gets dropped on the floor.
             if (pendingInitialInput !== null && initialInputDeadline === null) {
               initialInputDeadline = window.setTimeout(
-                flushInitialInput,
+                releaseOnDeadline,
                 INITIAL_INPUT_MAX_WAIT_MS,
               );
-              deferInitialInput();
             }
           }
         } catch (err) {
@@ -238,8 +275,11 @@ export function TerminalPane({
           // input: type setup right away. Otherwise wait out the quiet period —
           // first output alone only means the shell started, and it drops
           // anything past its input queue while it's still sourcing rc files.
-          if (isLineEditorReady(bytes)) flushInitialInput();
-          else deferInitialInput();
+          sawOutput = true;
+          if (isLineEditorReady(bytes)) {
+            bracketedPasteOn = true;
+            flushInitialInput();
+          } else deferInitialInput();
         }),
       );
       unsubs.push(

--- a/backend/src/integrations/cli_wrappers/claude_code/messaging/tests/test_slash_command_echo_wait.py
+++ b/backend/src/integrations/cli_wrappers/claude_code/messaging/tests/test_slash_command_echo_wait.py
@@ -193,7 +193,9 @@ def test_back_to_back_model_then_effort_waits_serially() -> None:
 
     pty_writes: List[bytes] = []
 
-    def _on_write(data: bytes) -> None:
+    def _on_write(data: bytes, timeout: float = 0.0) -> None:
+        # `timeout` mirrors PTYManager.write_to_pty's bounded-retry parameter;
+        # unused here, the fake never blocks.
         pty_writes.append(data)
         # Append the matching echo ~250ms after each write.
         if data.startswith(b"/model"):

--- a/backend/src/vicoa/terminal/pty_manager.py
+++ b/backend/src/vicoa/terminal/pty_manager.py
@@ -27,6 +27,12 @@ if _POSIX:
     import termios
     import tty
 
+# A write to the master blocks (EAGAIN, here) once the slave's input queue is
+# full — 1024 bytes on macOS, 4096 on Linux — and stays that way until the
+# foreground process reads. Bounded so one such write can't wedge the shared
+# ordered-input worker; ordinary keystrokes never come close to it.
+PTY_WRITE_TIMEOUT_S = 5.0
+
 
 class PTYManager:
     """Manages pseudo-terminal for Claude CLI interaction.
@@ -157,14 +163,17 @@ class PTYManager:
             except Exception as e:
                 self.log_func(f"[WARNING] Failed to restore terminal: {e}")
 
-    def write_to_pty(self, data: bytes) -> None:
+    def write_to_pty(self, data: bytes, timeout: float = PTY_WRITE_TIMEOUT_S) -> None:
         """Write data to the PTY master, handling partial writes.
 
         Args:
             data: Bytes to write to PTY
+            timeout: Seconds to keep retrying a tty that won't accept more
+                input before giving up on the remainder
 
         Raises:
             RuntimeError: If PTY is not initialized
+            TimeoutError: If the tty stayed full for ``timeout`` seconds
             OSError: If write fails (other than EAGAIN/EWOULDBLOCK)
         """
         if not data:
@@ -175,6 +184,7 @@ class PTYManager:
 
         view = memoryview(data)
         total_written = 0
+        deadline = time.monotonic() + timeout
 
         while total_written < len(view):
             try:
@@ -183,11 +193,22 @@ class PTYManager:
                     time.sleep(0.01)
                     continue
                 total_written += written
+                continue
             except OSError as e:
-                if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                    time.sleep(0.01)
-                    continue
-                raise
+                if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise
+            # The slave's input queue is full and its reader isn't draining it.
+            # Retry, but never forever: pty writes run on ONE ordered worker
+            # thread shared by every terminal on this machine (see
+            # PTY_ORDERED_METHODS), so a single wedged write freezes input for
+            # all of them. Losing the tail of one oversized write is the lesser
+            # failure, and it is what the tty itself does with the overflow.
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"pty write stalled: {total_written}/{len(view)} bytes "
+                    f"accepted in {timeout:g}s (tty input queue full)"
+                )
+            time.sleep(0.01)
 
     def read_from_pty(self, size: int = 4096) -> bytes:
         """Read data from PTY master (non-blocking).

--- a/backend/src/vicoa/terminal/rpc.py
+++ b/backend/src/vicoa/terminal/rpc.py
@@ -67,6 +67,11 @@ def handle_pty_rpc(
         return _pty_heartbeat(terminal, params)
     except KeyError as exc:
         return {"error": f"unknown pty_id: {exc.args[0] if exc.args else exc}"}
+    except TimeoutError as exc:
+        # A tty whose reader stopped draining (see PTY_WRITE_TIMEOUT_S). The
+        # remainder of that one write is lost; the worker stays free for the
+        # other terminals' input rather than blocking on it forever.
+        return {"error": str(exc)}
     except (ValueError, RuntimeError) as exc:
         return {"error": str(exc)}
 

--- a/backend/tests/test_pty_write_timeout.py
+++ b/backend/tests/test_pty_write_timeout.py
@@ -1,0 +1,65 @@
+"""A tty that stops draining must not wedge the daemon's pty writer.
+
+``pty-write`` runs on ONE ordered worker shared by every terminal on the
+machine, so an unbounded retry on a full input queue freezes input for all of
+them — the shape of the "worktree setup hangs" bug. The write is bounded
+instead: partial writes still complete, a permanently full queue times out.
+"""
+
+import errno
+import os
+from typing import Any
+
+import pytest
+from vicoa.terminal.pty_manager import PTYManager
+from vicoa.terminal.rpc import handle_pty_rpc
+
+
+def _manager() -> PTYManager:
+    manager = PTYManager(log_func=lambda _msg: None)
+    manager.master_fd = 999  # never written to — os.write is patched per test
+    return manager
+
+
+def test_partial_writes_are_resumed_until_everything_lands(monkeypatch: Any) -> None:
+    written = bytearray()
+
+    def fake_write(fd: int, data: memoryview) -> int:
+        chunk = bytes(data[:7])  # a stingy tty: 7 bytes at a time
+        written.extend(chunk)
+        return len(chunk)
+
+    monkeypatch.setattr(os, "write", fake_write)
+    _manager().write_to_pty(b"echo hello world" * 4)
+    assert bytes(written) == b"echo hello world" * 4
+
+
+def test_a_tty_that_never_drains_gives_up_instead_of_spinning(monkeypatch: Any) -> None:
+    accepted = 32
+
+    def fake_write(fd: int, data: memoryview) -> int:
+        nonlocal accepted
+        if accepted <= 0:
+            raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+        taken = min(accepted, len(data))
+        accepted -= taken
+        return taken
+
+    monkeypatch.setattr(os, "write", fake_write)
+    with pytest.raises(TimeoutError) as excinfo:
+        _manager().write_to_pty(b"x" * 128, timeout=0.05)
+    # The message names what got through, so a daemon log says how much was lost.
+    assert "32/128" in str(excinfo.value)
+
+
+def test_a_stalled_write_is_reported_as_an_rpc_error(monkeypatch: Any) -> None:
+    class StalledTerminal:
+        def write(self, pty_id: str, data: bytes) -> None:
+            raise TimeoutError("pty write stalled: 0/128 bytes accepted in 5s")
+
+    result = handle_pty_rpc(
+        StalledTerminal(),  # type: ignore[arg-type]
+        "pty-write",
+        {"pty_id": "p1", "data": "eA=="},
+    )
+    assert result is not None and "pty write stalled" in str(result.get("error"))


### PR DESCRIPTION
A worktree's setup chain is typed into the session's terminal tab as one line — for this repo's `.vicoa/config.json`, 1525 bytes. It arrived truncated and unexecuted, leaving the tab parked on a half-typed command (often at a `cmdsubst>` continuation prompt): the "setup hangs" report.

A tty's input queue is 1024 bytes on macOS (`TTYHOG`), 4096 on Linux, and whatever doesn't fit while the foreground process isn't reading is **discarded by the driver**, not backpressured to the writer. Two independent paths were feeding it more than that.

### 1. The pane wrote before the shell was reading

The 300ms "the shell went quiet, so it must be ready" fallback was armed **at spawn** — before the shell had emitted a single byte. A stock oh-my-zsh + starship prints nothing for the first ~1.4–1.7s while it sources rc files, so the timer fired into a shell that was not reading stdin at all, and the chain landed truncated at exactly 1024 bytes.

Silence is not readiness: the quiet timer now only arms on the shell's first output, and the ceiling (5s → 8s) refuses to release into a shell that still hasn't spoken, waiting another round instead — a cold zsh can sit in `compinit` for ~10s.

### 2. Typing 1.5KB character-by-character can't keep the queue drained

Even at a live prompt, every byte runs the whole ZLE widget stack — `url-quote-magic` on self-insert, zsh-autosuggestions' history query, zsh-syntax-highlighting re-highlighting the buffer on each redraw — O(n) work per character over a growing line, far behind a writer pushing 256 bytes every 20ms.

The text now goes over as a **bracketed paste** (`prepareInitialInput`) whenever the shell advertised support for one, which it does with the very `ESC[?2004h` the pane already watches for. The paste widget slurps the whole run out of the tty in one read and inserts it as literal text, no per-character widgets. The submitting CR stays **outside** the markers — inside a paste it is literal text, which would leave the chain typed but never run.

### 3. A stalled pty write no longer wedges every terminal

`write_to_pty` retried `EAGAIN` forever, and pty writes run on **one** ordered worker shared by every terminal on the machine (`PTY_ORDERED_METHODS`), so a single stalled write froze input for all of them — reproducible by hand-pasting any oversized blob into a terminal, not just by setup. It now gives up after 5s and surfaces as an rpc error; losing the tail of one oversized write is what the tty itself does with the overflow, and the worker stays free.

## Verification

Replayed against a real `/bin/zsh -l` with a stock oh-my-zsh + starship + zsh-autosuggestions + zsh-syntax-highlighting rc, feeding this repo's actual setup chain into a forked pty:

| policy | flushed at | chain ran |
|---|---|---|
| old | 0.30s (shell had printed nothing) | ❌ |
| new | 1.15 / 1.47 / 1.55 / 1.80s — 9.98s on a cold start | ✅ 4/4 |

Confirmed working in the app before this PR.

- web: 787 tests + `tsc` clean; 6 new tests for the paste framing
- backend: 2229 unit tests + `make lint` clean; 3 new tests for the bounded write

The renderer half ships with a desktop release, the daemon half with a CLI/daemon release.
