### PR TITLE
Tasks: KEY-42 identifiers, comments, activity and reactions

### DIFF
--- a/apps/web/app/dashboard/tasks/[taskId]/comment-composer.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/comment-composer.tsx
@@ -14,6 +14,13 @@
 // What it deliberately does NOT inherit: attachments, slash commands, the
 // config chips and the usage ring. Those address an agent session; a comment
 // has no model, no permission mode and no rate limit.
+//
+// Two variants. `default` is the box at the foot of the page that starts a new
+// thread. `inline` is the "Leave a reply…" row that ends every thread card:
+// borderless, one line tall, and it takes an avatar — inside a thread the
+// avatar is not decoration, it holds the row on the same column as the comments
+// above it and marks the box as part of that conversation rather than a control
+// floating under it.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowUp, RefreshCw } from 'lucide-react';
@@ -22,6 +29,9 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 const MIN_HEIGHT = 36;
+// The inline reply row is one line tall at rest so a thread ends in a hint, not
+// in a second composer competing with the page's own.
+const INLINE_HEIGHT = 28;
 const MAX_HEIGHT = 200;
 
 export function CommentComposer({
@@ -29,12 +39,18 @@ export function CommentComposer({
   disabled = false,
   placeholder = 'Leave a comment…',
   autoFocus = false,
+  variant = 'default',
+  leading,
   className,
 }: {
   onSubmit: (body: string) => Promise<void>;
   disabled?: boolean;
   placeholder?: string;
   autoFocus?: boolean;
+  /** `inline` is the reply row inside a thread card; see the header comment. */
+  variant?: 'default' | 'inline';
+  /** Rendered left of the textarea — the viewer's avatar, on `inline`. */
+  leading?: React.ReactNode;
   className?: string;
 }) {
   const [value, setValue] = useState('');
@@ -52,9 +68,10 @@ export function CommentComposer({
       const el = textareaRef.current;
       if (!el) return;
       el.style.height = 'auto';
-      el.style.height = `${Math.max(MIN_HEIGHT, Math.min(el.scrollHeight, MAX_HEIGHT))}px`;
+      const floor = variant === 'inline' ? INLINE_HEIGHT : MIN_HEIGHT;
+      el.style.height = `${Math.max(floor, Math.min(el.scrollHeight, MAX_HEIGHT))}px`;
     });
-  }, []);
+  }, [variant]);
 
   useEffect(
     () => () => {
@@ -71,23 +88,32 @@ export function CommentComposer({
       await onSubmit(body);
       setValue('');
       const el = textareaRef.current;
-      if (el) el.style.height = `${MIN_HEIGHT}px`;
+      if (el) el.style.height = `${variant === 'inline' ? INLINE_HEIGHT : MIN_HEIGHT}px`;
     } finally {
       setSending(false);
     }
-  }, [value, sending, disabled, onSubmit]);
+  }, [value, sending, disabled, onSubmit, variant]);
+
+  const inline = variant === 'inline';
+  const empty = value.trim().length === 0;
 
   return (
     <div
       className={cn(
-        'relative w-full rounded-xl border border-border/50 bg-composer px-3 py-2.5 font-mono shadow-sm',
+        'relative w-full font-mono',
+        // The inline row has no edge of its own: the thread card is already a
+        // surface, and a second border inside it reads as a nested object.
+        inline
+          ? 'flex items-center gap-2'
+          : 'rounded-xl border border-border/50 bg-composer px-3 py-2.5 shadow-sm',
         className,
       )}
     >
-      {/* No author avatar. Every timeline row above needs one because it says
-          *who* — but there is only one person who can be typing here, and their
-          own face is not information. It was just an indent. */}
-      <div className="flex items-start gap-2">
+      {/* The page-bottom variant carries no avatar: only one person can be
+          typing there, and their own face is not information — it was just an
+          indent. Inside a thread it earns its place (see the header). */}
+      {inline && leading}
+      <div className={cn(inline ? 'min-w-0 flex-1' : 'flex items-start gap-2')}>
         <textarea
           ref={textareaRef}
           value={value}
@@ -111,23 +137,43 @@ export function CommentComposer({
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          style={{ height: MIN_HEIGHT, minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
-          className="custom-scrollbar w-full resize-none border-0 bg-transparent px-1 py-2 text-sm leading-5 placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+          style={{
+            height: inline ? INLINE_HEIGHT : MIN_HEIGHT,
+            minHeight: inline ? INLINE_HEIGHT : MIN_HEIGHT,
+            maxHeight: MAX_HEIGHT,
+          }}
+          className={cn(
+            // `block` is load-bearing, not tidiness: a textarea is inline-block
+            // by default, so inside the inline variant's plain wrapper it sits
+            // on a text baseline and leaves ~4px of descender space beneath
+            // itself. That makes the wrapper taller than the box, and the row's
+            // items-center then centres the *wrapper* — dropping the avatar a
+            // couple of pixels below the caret. (The default variant's wrapper
+            // is a flex container, which blockifies its children already.)
+            'custom-scrollbar block w-full resize-none border-0 bg-transparent text-sm leading-5 placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50',
+            inline ? 'py-1' : 'px-1 py-2',
+          )}
         />
       </div>
-      <div className="flex items-center justify-end">
+      <div className={cn('flex items-center justify-end', !inline && 'mt-0')}>
         <Button
           onClick={() => void send()}
-          aria-label="Post comment"
-          disabled={disabled || sending || value.trim().length === 0}
+          aria-label={inline ? 'Post reply' : 'Post comment'}
+          disabled={disabled || sending || empty}
           variant="default"
           size="icon"
-          className="h-7 w-7 shrink-0 rounded-full border-0 p-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+          className={cn(
+            'shrink-0 rounded-full border-0 p-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0',
+            // Ghosted until there is something to send, so an idle thread ends
+            // in an invitation rather than in a row of dead buttons.
+            inline ? 'h-6 w-6 transition-opacity' : 'h-7 w-7',
+            inline && empty && !sending && 'pointer-events-none opacity-30',
+          )}
         >
           {sending ? (
-            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+            <RefreshCw className={cn('animate-spin', inline ? 'h-3 w-3' : 'h-3.5 w-3.5')} />
           ) : (
-            <ArrowUp className="h-3.5 w-3.5" />
+            <ArrowUp className={cn(inline ? 'h-3 w-3' : 'h-3.5 w-3.5')} />
           )}
         </Button>
       </div>

--- a/apps/web/app/dashboard/tasks/[taskId]/comment-composer.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/comment-composer.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+// The task-detail comment box. Deliberately the same object as the session
+// composer (`components/chat-input.tsx`): same `bg-composer` surface, same
+// `border-border/50`, same auto-growing textarea, same round 28px send button
+// with an ArrowUp. Two boxes that take typed text and send it should not be two
+// different-looking controls in one product.
+//
+// It corners tighter than the chat composer (`rounded-xl`, not `rounded-3xl`).
+// The chat box is that page's primary affordance and sits alone above the
+// fold; this one ends a column of square-ish cards, where a pill silhouette
+// reads as a different kind of object than the things it is answering.
+//
+// What it deliberately does NOT inherit: attachments, slash commands, the
+// config chips and the usage ring. Those address an agent session; a comment
+// has no model, no permission mode and no rate limit.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowUp, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const MIN_HEIGHT = 36;
+const MAX_HEIGHT = 200;
+
+export function CommentComposer({
+  onSubmit,
+  disabled = false,
+  placeholder = 'Leave a comment…',
+  autoFocus = false,
+  className,
+}: {
+  onSubmit: (body: string) => Promise<void>;
+  disabled?: boolean;
+  placeholder?: string;
+  autoFocus?: boolean;
+  className?: string;
+}) {
+  const [value, setValue] = useState('');
+  const [sending, setSending] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Same rAF-coalesced auto-resize as the chat composer: reading scrollHeight
+  // after writing height='auto' forces a synchronous layout, so collapse a
+  // burst of keystrokes into one reflow per frame.
+  const frameRef = useRef<number | null>(null);
+  const autoResize = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      const el = textareaRef.current;
+      if (!el) return;
+      el.style.height = 'auto';
+      el.style.height = `${Math.max(MIN_HEIGHT, Math.min(el.scrollHeight, MAX_HEIGHT))}px`;
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    },
+    [],
+  );
+
+  const send = useCallback(async () => {
+    const body = value.trim();
+    if (!body || sending || disabled) return;
+    setSending(true);
+    try {
+      await onSubmit(body);
+      setValue('');
+      const el = textareaRef.current;
+      if (el) el.style.height = `${MIN_HEIGHT}px`;
+    } finally {
+      setSending(false);
+    }
+  }, [value, sending, disabled, onSubmit]);
+
+  return (
+    <div
+      className={cn(
+        'relative w-full rounded-xl border border-border/50 bg-composer px-3 py-2.5 font-mono shadow-sm',
+        className,
+      )}
+    >
+      {/* No author avatar. Every timeline row above needs one because it says
+          *who* — but there is only one person who can be typing here, and their
+          own face is not information. It was just an indent. */}
+      <div className="flex items-start gap-2">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          autoFocus={autoFocus}
+          onChange={(e) => {
+            setValue(e.target.value);
+            autoResize();
+          }}
+          onKeyDown={(e) => {
+            // Enter sends, Shift+Enter breaks the line — the same contract the
+            // session composer teaches.
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              void send();
+            }
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              textareaRef.current?.blur();
+            }
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          style={{ height: MIN_HEIGHT, minHeight: MIN_HEIGHT, maxHeight: MAX_HEIGHT }}
+          className="custom-scrollbar w-full resize-none border-0 bg-transparent px-1 py-2 text-sm leading-5 placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+      <div className="flex items-center justify-end">
+        <Button
+          onClick={() => void send()}
+          aria-label="Post comment"
+          disabled={disabled || sending || value.trim().length === 0}
+          variant="default"
+          size="icon"
+          className="h-7 w-7 shrink-0 rounded-full border-0 p-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+        >
+          {sending ? (
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <ArrowUp className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/tasks/[taskId]/inline-fields.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/inline-fields.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+// Click-to-edit title and description for the task page.
+//
+// The rule both fields follow: **the edit surface sits in exactly the same box
+// as the read surface**. Same size, weight, leading and offset; the textarea
+// only swaps the background. If clicking a title made it jump a pixel or change
+// leading, the page would flinch on every edit — which is what makes inline
+// editing feel worse than a dialog rather than better. (The description is the
+// honest exception: rendered markdown and its source can't occupy identical
+// space, so it matches on box and type size and accepts reflow on lists and
+// headings, the same as GitHub and Linear.)
+//
+// Saving is on blur, not on a button. A Save button in a properties column is a
+// second thing to aim at for a change the user has already finished making;
+// Linear, Notion and GitHub's title field all commit on blur. Escape reverts,
+// so the destructive-feeling case still has an undo that doesn't need a dialog.
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import { MessageMarkdown } from '@/components/ui/message-markdown';
+import { cn } from '@/lib/utils';
+
+// How tall a collapsed description is allowed to be — roughly eight lines at
+// this leading. Anything under it renders whole and grows no affordance; the
+// point is to stop a spec-length description from pushing the timeline off the
+// screen, not to put a "Show more" on every two-line note.
+const COLLAPSED_MAX_PX = 192;
+
+/** Grow a textarea to fit its content, coalesced into one reflow per frame. */
+function useAutoResize(value: string, enabled: boolean) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !enabled) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value, enabled]);
+  return ref;
+}
+
+export function EditableTitle({
+  value,
+  onSave,
+}: {
+  value: string;
+  onSave: (next: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const ref = useAutoResize(draft, editing);
+
+  // A background refresh can land while the field is closed; don't clobber a
+  // draft the user is in the middle of typing.
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  const commit = useCallback(() => {
+    setEditing(false);
+    const next = draft.trim();
+    // A task must have a title (the API enforces min_length 1), so an empty
+    // field reverts rather than erroring after the fact.
+    if (!next || next === value) {
+      setDraft(value);
+      return;
+    }
+    onSave(next);
+  }, [draft, value, onSave]);
+
+  const shared =
+    'w-full text-2xl font-semibold leading-tight tracking-[-0.01em]';
+
+  if (!editing) {
+    return (
+      <h1
+        role="textbox"
+        tabIndex={0}
+        onClick={() => setEditing(true)}
+        // Enter/Space, not focus: opening an editor merely because Tab passed
+        // through would ambush anyone navigating by keyboard.
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setEditing(true);
+          }
+        }}
+        className={cn(
+          shared,
+          'cursor-text rounded-md px-1 py-0.5 -mx-1 transition-colors hover:bg-accent/40',
+        )}
+      >
+        {value}
+      </h1>
+    );
+  }
+
+  return (
+    <textarea
+      ref={ref}
+      autoFocus
+      value={draft}
+      rows={1}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        // A title has no line breaks, so Enter is unambiguous: commit.
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commit();
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setDraft(value);
+          setEditing(false);
+        }
+      }}
+      className={cn(
+        shared,
+        'resize-none overflow-hidden rounded-md border-0 bg-accent/40 px-1 py-0.5 -mx-1',
+        'focus:outline-none focus:ring-0',
+      )}
+    />
+  );
+}
+
+export function EditableDescription({
+  value,
+  onSave,
+}: {
+  value: string | null;
+  onSave: (next: string | null) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? '');
+  const [expanded, setExpanded] = useState(false);
+  // Whether the rendered body is actually taller than the clamp. Measured, not
+  // guessed from length: markdown expands unpredictably — 200 characters with a
+  // code block is tall, 600 characters of prose is four lines.
+  const [overflowing, setOverflowing] = useState(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const ref = useAutoResize(draft, editing);
+
+  useEffect(() => {
+    if (!editing) setDraft(value ?? '');
+  }, [value, editing]);
+
+  useLayoutEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const measure = () => setOverflowing(el.scrollHeight > COLLAPSED_MAX_PX + 8);
+    measure();
+    // Markdown can reflow after mount (fonts, code highlighting, a container
+    // resize), so a single measurement at render time would be wrong as often
+    // as it was right.
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [value, editing]);
+
+  const commit = useCallback(() => {
+    setEditing(false);
+    const next = draft.trim();
+    if (next === (value ?? '').trim()) return;
+    // Unlike the title, empty is a legitimate value — clearing a description
+    // sends null so the column goes back to NULL rather than storing "".
+    onSave(next || null);
+  }, [draft, value, onSave]);
+
+  if (!editing) {
+    const clamped = overflowing && !expanded;
+    return (
+      // The toggle sits OUTSIDE the click-to-edit region rather than inside it
+      // with a stopPropagation: "show me the rest" and "let me rewrite it" are
+      // different intents, and one shouldn't have to defuse the other.
+      <div className="space-y-1">
+        <div
+          role="textbox"
+          tabIndex={0}
+          onClick={() => setEditing(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setEditing(true);
+            }
+          }}
+          className="relative -mx-2 cursor-text overflow-hidden rounded-md px-2 py-1.5 text-sm leading-relaxed transition-colors hover:bg-accent/40"
+          style={clamped ? { maxHeight: COLLAPSED_MAX_PX } : undefined}
+        >
+          <div ref={bodyRef}>
+            {value ? (
+              <MessageMarkdown>{value}</MessageMarkdown>
+            ) : (
+              <span className="text-muted-foreground/60">Add a description…</span>
+            )}
+          </div>
+          {/* A hard cut mid-sentence looks like a rendering bug; the fade says
+              "there is more" without needing to be read. */}
+          {clamped && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-b from-transparent to-background" />
+          )}
+        </div>
+        {overflowing && (
+          // Centred, and full-width rather than a floating link. The page holds
+          // a strict left column — avatars, comment bodies and rail rows all
+          // share one edge — so a left-aligned link here would read as another
+          // item in that column. This isn't an item; it's the seam of the block
+          // above it, which is also what the full-width fade is drawing. Making
+          // the control span the same width and centring its label says "the
+          // block continues" instead of "here is one more thing to read".
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="-mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center justify-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
+          >
+            <ChevronDown
+              className={cn('size-3 transition-transform', expanded && 'rotate-180')}
+            />
+            {expanded ? 'Show less' : 'Show more'}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <textarea
+      ref={ref}
+      autoFocus
+      value={draft}
+      rows={3}
+      placeholder="Add a description…"
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        // Enter breaks the line — this is markdown, and a description that
+        // couldn't hold a list would be a worse editor than the dialog's.
+        // ⌘/Ctrl+Enter is the explicit commit for anyone who doesn't want to
+        // click away.
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault();
+          e.currentTarget.blur();
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setDraft(value ?? '');
+          setEditing(false);
+        }
+      }}
+      className={cn(
+        '-mx-2 w-[calc(100%+1rem)] resize-none overflow-hidden rounded-md border-0 bg-accent/40 px-2 py-1.5',
+        'text-sm leading-relaxed focus:outline-none focus:ring-0',
+        'placeholder:text-muted-foreground/60',
+      )}
+    />
+  );
+}

--- a/apps/web/app/dashboard/tasks/[taskId]/inline-fields.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/inline-fields.tsx
@@ -22,11 +22,12 @@ import { ChevronDown } from 'lucide-react';
 import { MessageMarkdown } from '@/components/ui/message-markdown';
 import { cn } from '@/lib/utils';
 
-// How tall a collapsed description is allowed to be — roughly eight lines at
+// How tall a collapsed description is allowed to be — roughly fourteen lines at
 // this leading. Anything under it renders whole and grows no affordance; the
 // point is to stop a spec-length description from pushing the timeline off the
-// screen, not to put a "Show more" on every two-line note.
-const COLLAPSED_MAX_PX = 192;
+// screen, not to make people expand an ordinary paragraph. A clamp that fires
+// on a normal-sized description just adds a click to reading the task.
+const COLLAPSED_MAX_PX = 320;
 
 /** Grow a textarea to fit its content, coalesced into one reflow per frame. */
 function useAutoResize(value: string, enabled: boolean) {

--- a/apps/web/app/dashboard/tasks/[taskId]/page.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/page.tsx
@@ -288,6 +288,7 @@ export default function TaskDetailPage() {
             {/* The task itself is reactable, like an issue's opening post. */}
             <ReactionRow
               reactions={taskReactions}
+              viewer={viewer}
               onToggle={(emoji) => void toggleReaction('task', task.id, emoji)}
             />
           </div>

--- a/apps/web/app/dashboard/tasks/[taskId]/page.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/page.tsx
@@ -191,9 +191,12 @@ export default function TaskDetailPage() {
   );
 
   const postComment = useCallback(
-    async (body: string) => {
+    async (body: string, parentCommentId?: string) => {
       if (!api || !task) return;
-      const timeline = await api.createTaskComment(task.id, body);
+      const timeline = await api.createTaskComment(task.id, body, parentCommentId);
+      // The whole timeline comes back rather than the one new comment, so a
+      // reply lands already spliced under its root instead of the client having
+      // to guess where in the thread it goes.
       setComments(timeline.comments);
       setActivity(timeline.activity);
       setTaskReactions(timeline.reactions);
@@ -302,8 +305,11 @@ export default function TaskDetailPage() {
               onToggleCommentReaction={(commentId, emoji) =>
                 void toggleReaction('comment', commentId, emoji)
               }
+              onReply={(parentCommentId, body) => postComment(body, parentCommentId)}
             />
-            <CommentComposer onSubmit={postComment} />
+            {/* The bottom composer always starts a new thread; replying is
+                the affordance inside a thread. */}
+            <CommentComposer onSubmit={(body) => postComment(body)} />
           </div>
         </div>
 

--- a/apps/web/app/dashboard/tasks/[taskId]/page.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/page.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+// Task detail as a real route (collaboration §8.3), not a dialog: a markdown
+// description, a properties rail, and a timeline that interleaves comments,
+// generated activity and the agent sessions the task spawned.
+//
+// `task-dialog.tsx` stays — it is the fast create/edit path off the board. This
+// is the deep-link surface: it is what "VIC-42" resolves to, what a comment
+// cross-reference opens, and (in P4) what a shared board link lands on.
+//
+// No WebSocket channel, by decision (§9). The timeline revalidates on window
+// focus and on a slow interval; polling hits the stateless backend app, while
+// the relay is pinned to workers=1 and already carries every daemon socket.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Plus } from 'lucide-react';
+
+import {
+  AgentInstanceResponse,
+  AgentProfile,
+  ProjectResponse,
+  TaskActivityResponse,
+  TaskCommentResponse,
+  TaskLabelResponse,
+  TaskReactionSummary,
+  TaskResponse,
+  UpdateTaskRequest,
+  UserProfile,
+} from '@/lib/backend-api';
+import { useAgentDashboard } from '@/lib/contexts/agent-dashboard-context';
+import { EditableDescription, EditableTitle } from './inline-fields';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { Principal } from '@/lib/principals';
+import {
+  AssigneePickerPill,
+  DatePickerPill,
+  LabelPickerPill,
+  ParentPickerPill,
+  PriorityPickerPill,
+  ProjectPickerPill,
+  PropertyRows,
+  StatusPickerPill,
+  toDateOnly,
+  dateOnlyToLocalDate,
+} from '@/components/dashboard/task-ui';
+import { ReactionRow, TaskTimeline } from './task-timeline';
+import { CommentComposer } from './comment-composer';
+
+// Slow on purpose: this is a single-player backlog, and the point of the poll
+// is to catch an agent's comment landing while the tab sits open — not to
+// simulate realtime. Focus revalidation covers the "came back to the tab" case.
+const POLL_MS = 30_000;
+
+// Properties that stay out of the rail until they carry a value or the user
+// picks them from "Other properties". Status / priority / assignee / project /
+// labels are always shown — they are the ones you scan for.
+const OPTIONAL_PROPERTIES: {
+  key: string;
+  label: string;
+  isSet: (task: TaskResponse) => boolean;
+}[] = [
+  { key: 'due_date', label: 'Due date', isSet: (t) => t.due_date !== null },
+  { key: 'start_date', label: 'Start date', isSet: (t) => t.start_date !== null },
+  { key: 'parent', label: 'Parent task', isSet: (t) => t.parent_task_id !== null },
+];
+
+function RailGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <div className="px-2 text-xs text-muted-foreground/60">{label}</div>
+      <PropertyRows>{children}</PropertyRows>
+    </div>
+  );
+}
+
+export default function TaskDetailPage() {
+  const params = useParams<{ taskId: string }>();
+  const taskId = params?.taskId;
+  const router = useRouter();
+  const { api } = useAgentDashboard();
+
+  const [task, setTask] = useState<TaskResponse | null>(null);
+  const [projects, setProjects] = useState<ProjectResponse[]>([]);
+  const [comments, setComments] = useState<TaskCommentResponse[]>([]);
+  const [activity, setActivity] = useState<TaskActivityResponse[]>([]);
+  const [taskReactions, setTaskReactions] = useState<TaskReactionSummary[]>([]);
+  const [sessions, setSessions] = useState<AgentInstanceResponse[]>([]);
+  const [me, setMe] = useState<UserProfile | null>(null);
+  // The pickers need the same reference data the board dialog uses.
+  const [labels, setLabels] = useState<TaskLabelResponse[]>([]);
+  const [allTasks, setAllTasks] = useState<TaskResponse[]>([]);
+  const [agentProfiles, setAgentProfiles] = useState<AgentProfile[]>([]);
+  // Properties the user asked for that have no value yet. A property shows
+  // when it is set OR revealed — the rail stays short by default instead of
+  // being a wall of "Unassigned / None / None".
+  const [revealed, setRevealed] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // The whole page's data. Kept in one function so focus-revalidation and the
+  // interval can't drift apart from the initial load.
+  const load = useCallback(async () => {
+    if (!api || !taskId) return;
+    try {
+      const [taskRow, timeline, taskSessions, projectRows] = await Promise.all([
+        api.getTask(taskId),
+        api.getTaskTimeline(taskId),
+        api.listTaskSessions(taskId),
+        api.listProjects(),
+      ]);
+      setTask(taskRow);
+      setComments(timeline.comments);
+      setActivity(timeline.activity);
+      setTaskReactions(timeline.reactions);
+      setSessions(taskSessions);
+      setProjects(projectRows);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load task');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [api, taskId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!api) return;
+    void api.getCurrentUserProfile().then(setMe).catch(() => setMe(null));
+    // Reference data for the property pickers. Loaded once, and failing to load
+    // it degrades a picker to empty rather than breaking the page.
+    void api.listTaskLabels().then(setLabels).catch(() => setLabels([]));
+    void api.listTasks().then(setAllTasks).catch(() => setAllTasks([]));
+    void api
+      .listAgentProfiles()
+      .then(setAgentProfiles)
+      .catch(() => setAgentProfiles([]));
+  }, [api]);
+
+  // Refresh-on-focus + a slow interval, the §9 model for tasks.
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState === 'visible') void loadRef.current();
+    };
+    window.addEventListener('focus', refresh);
+    document.addEventListener('visibilitychange', refresh);
+    const timer = setInterval(refresh, POLL_MS);
+    return () => {
+      window.removeEventListener('focus', refresh);
+      document.removeEventListener('visibilitychange', refresh);
+      clearInterval(timer);
+    };
+  }, []);
+
+  const patchTask = useCallback(
+    async (patch: UpdateTaskRequest) => {
+      if (!api || !task) return;
+      const previous = task;
+      setTask({ ...task, ...patch } as TaskResponse);
+      try {
+        setTask(await api.updateTask(task.id, patch));
+        // A field change writes activity server-side, so the timeline is stale
+        // the moment the PATCH lands.
+        void load();
+      } catch {
+        setTask(previous);
+      }
+    },
+    [api, task, load],
+  );
+
+  // Mirrors the dialog's label affordance: type a name, get a label, attached.
+  const createLabelAndAttach = useCallback(
+    async (name: string) => {
+      if (!api || !task) return;
+      const label = await api.createTaskLabel({ name, color: '#6b7280' });
+      setLabels((prev) => [...prev, label]);
+      await patchTask({ label_ids: [...task.labels.map((l) => l.id), label.id] });
+    },
+    [api, task, patchTask],
+  );
+
+  const postComment = useCallback(
+    async (body: string) => {
+      if (!api || !task) return;
+      const timeline = await api.createTaskComment(task.id, body);
+      setComments(timeline.comments);
+      setActivity(timeline.activity);
+      setTaskReactions(timeline.reactions);
+    },
+    [api, task],
+  );
+
+  const toggleReaction = useCallback(
+    async (targetType: 'task' | 'comment', targetId: string, emoji: string) => {
+      if (!api || !task) return;
+      const timeline = await api.toggleTaskReaction(task.id, {
+        targetType,
+        targetId,
+        emoji,
+      });
+      setComments(timeline.comments);
+      setActivity(timeline.activity);
+      setTaskReactions(timeline.reactions);
+    },
+    [api, task],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-5xl px-6 py-8 text-sm text-muted-foreground">Loading…</div>
+    );
+  }
+
+  if (error || !task) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 px-6 py-8">
+        <p className="text-sm text-muted-foreground">{error ?? 'Task not found'}</p>
+        <button
+          type="button"
+          onClick={() => router.push('/dashboard/tasks')}
+          className="cursor-pointer text-sm underline underline-offset-4"
+        >
+          Back to tasks
+        </button>
+      </div>
+    );
+  }
+
+  const viewer: Principal | null = me
+    ? {
+        type: 'user',
+        id: me.id,
+        name: me.display_name ?? me.email,
+        avatarImageUri: me.avatar_image_uri,
+        emoji: me.avatar_emoji,
+        updatedAt: me.updated_at,
+      }
+    : null;
+
+  // A property earns a slot when it has a value or the user asked for it.
+  const isShown = (key: string) => revealed.has(key) || OPTIONAL_PROPERTIES.find((p) => p.key === key)?.isSet(task);
+  const hidden = OPTIONAL_PROPERTIES.filter((p) => !isShown(p.key));
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-8">
+      <button
+        type="button"
+        onClick={() => router.push('/dashboard/tasks')}
+        className="mb-4 flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="size-3.5" />
+        Tasks
+      </button>
+
+      <div className="flex gap-10">
+        <div className="min-w-0 flex-1 space-y-6">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {/* The identifier is absent for a task that predates the backfill
+                  or whose project has no key — render nothing rather than a
+                  placeholder that looks like a real reference. */}
+              {task.identifier && (
+                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] tracking-tight">
+                  {task.identifier}
+                </span>
+              )}
+              <span>{projects.find((p) => p.id === task.project_id)?.name ?? 'Inbox'}</span>
+            </div>
+            <EditableTitle
+              value={task.title}
+              onSave={(title) => void patchTask({ title })}
+            />
+            <EditableDescription
+              value={task.description}
+              onSave={(description) => void patchTask({ description })}
+            />
+            {/* The task itself is reactable, like an issue's opening post. */}
+            <ReactionRow
+              reactions={taskReactions}
+              onToggle={(emoji) => void toggleReaction('task', task.id, emoji)}
+            />
+          </div>
+
+          <div className="space-y-3 border-t pt-6">
+            <TaskTimeline
+              comments={comments}
+              activity={activity}
+              sessions={sessions}
+              viewer={viewer}
+              onToggleCommentReaction={(commentId, emoji) =>
+                void toggleReaction('comment', commentId, emoji)
+              }
+            />
+            <CommentComposer onSubmit={postComment} />
+          </div>
+        </div>
+
+        <aside className="w-60 shrink-0 space-y-5">
+          {/* Grouped, not labelled per field: one heading over a column of
+              icon + value rows reads as a property list, whereas an uppercase
+              caption above every single pill is eight captions to skip past.
+              The row shape comes from <PropertyRows>. */}
+          <RailGroup label="Properties">
+            <StatusPickerPill
+              status={task.status}
+              onSelect={(status) => void patchTask({ status })}
+            />
+            <PriorityPickerPill
+              priority={task.priority}
+              onSelect={(priority) => void patchTask({ priority })}
+            />
+            <AssigneePickerPill
+              assignee={task.assignee}
+              viewer={viewer}
+              agentProfiles={agentProfiles}
+              onSelect={(next) =>
+                void patchTask({
+                  assignee_type: next?.type ?? null,
+                  assignee_id: next?.id ?? null,
+                })
+              }
+            />
+            {isShown('due_date') && (
+              <DatePickerPill
+                label="Due date"
+                value={task.due_date ? toDateOnly(new Date(task.due_date)) : ''}
+                onChange={(value) =>
+                  void patchTask({
+                    due_date: value ? dateOnlyToLocalDate(value)?.toISOString() ?? null : null,
+                  })
+                }
+              />
+            )}
+            {isShown('start_date') && (
+              <DatePickerPill
+                label="Start date"
+                icon="start"
+                value={task.start_date ? toDateOnly(new Date(task.start_date)) : ''}
+                onChange={(value) =>
+                  void patchTask({
+                    start_date: value
+                      ? dateOnlyToLocalDate(value)?.toISOString() ?? null
+                      : null,
+                  })
+                }
+              />
+            )}
+            {isShown('parent') && (
+              <ParentPickerPill
+                tasks={allTasks}
+                currentTaskId={task.id}
+                parentId={task.parent_task_id}
+                onSelect={(parentId) => void patchTask({ parent_task_id: parentId })}
+              />
+            )}
+            {hidden.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+                  >
+                    <Plus className="size-3.5" />
+                    Other properties
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-44">
+                  {hidden.map((property) => (
+                    <DropdownMenuItem
+                      key={property.key}
+                      className="cursor-pointer"
+                      onSelect={() =>
+                        setRevealed((prev) => new Set(prev).add(property.key))
+                      }
+                    >
+                      {property.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </RailGroup>
+
+          <RailGroup label="Project">
+            <ProjectPickerPill
+              projects={projects}
+              projectId={task.project_id}
+              onSelect={(projectId) => void patchTask({ project_id: projectId })}
+            />
+          </RailGroup>
+
+          <RailGroup label="Labels">
+            <LabelPickerPill
+              labels={labels}
+              selectedIds={task.labels.map((l) => l.id)}
+              onToggle={(labelId) => {
+                const current = task.labels.map((l) => l.id);
+                void patchTask({
+                  label_ids: current.includes(labelId)
+                    ? current.filter((id) => id !== labelId)
+                    : [...current, labelId],
+                });
+              }}
+              onCreate={(name) => void createLabelAndAttach(name)}
+            />
+          </RailGroup>
+
+          {/* Sessions are a count on purpose: each already renders as a card in
+              the timeline, and listing them twice says the same thing twice. */}
+          <RailGroup label="Sessions">
+            <span className="px-2 text-sm text-muted-foreground">
+              {sessions.length === 0 ? 'None yet' : `${sessions.length} linked`}
+            </span>
+          </RailGroup>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/tasks/[taskId]/task-timeline.test.ts
+++ b/apps/web/app/dashboard/tasks/[taskId]/task-timeline.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeReactors } from './task-timeline';
+import type { PrincipalResponse, TaskReactionSummary } from '@/lib/backend-api';
+import type { Principal } from '@/lib/principals';
+
+const viewer: Principal = { type: 'user', id: 'u1', name: 'test1@gmail.com' };
+
+const person = (id: string, name: string | null): PrincipalResponse => ({
+  type: 'user',
+  id,
+  name,
+  avatar_image_uri: null,
+  emoji: null,
+  updated_at: null,
+});
+
+const reaction = (
+  over: Partial<TaskReactionSummary> = {},
+): TaskReactionSummary => ({
+  emoji: '👍',
+  count: 1,
+  reacted: false,
+  reactors: [],
+  ...over,
+});
+
+describe('describeReactors', () => {
+  it('names a single reactor', () => {
+    expect(
+      describeReactors(reaction({ reactors: [person('u2', 'Ada')] }), viewer),
+    ).toBe('Ada reacted with 👍');
+  });
+
+  it('calls the signed-in user "You" and puts them first', () => {
+    // Slack and GitHub both front-load you in your own reactions; seeing your
+    // own display name in a list you are part of reads as someone else.
+    const out = describeReactors(
+      reaction({
+        count: 2,
+        reactors: [person('u2', 'Ada'), person('u1', null)],
+      }),
+      viewer,
+    );
+    expect(out).toBe('You and Ada reacted with 👍');
+  });
+
+  it('joins three with commas and a final "and"', () => {
+    const out = describeReactors(
+      reaction({
+        count: 3,
+        reactors: [person('u2', 'Ada'), person('u3', 'Bo'), person('u4', 'Cy')],
+      }),
+      viewer,
+    );
+    expect(out).toBe('Ada, Bo and Cy reacted with 👍');
+  });
+
+  it('collapses the reactors the server did not name', () => {
+    // The list is capped server-side but `count` stays true, so the tooltip
+    // must not quietly under-report how many people are on a pill.
+    const out = describeReactors(
+      reaction({ count: 5, reactors: [person('u2', 'Ada'), person('u3', 'Bo')] }),
+      viewer,
+    );
+    expect(out).toBe('Ada, Bo and 3 others reacted with 👍');
+  });
+
+  it('says "1 other" when exactly one is unnamed', () => {
+    const out = describeReactors(
+      reaction({ count: 2, reactors: [person('u2', 'Ada')] }),
+      viewer,
+    );
+    expect(out).toBe('Ada and 1 other reacted with 👍');
+  });
+});

--- a/apps/web/app/dashboard/tasks/[taskId]/task-timeline.test.ts
+++ b/apps/web/app/dashboard/tasks/[taskId]/task-timeline.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { describeReactors } from './task-timeline';
-import type { PrincipalResponse, TaskReactionSummary } from '@/lib/backend-api';
+import { buildEntries, buildThreads, describeReactors } from './task-timeline';
+import type {
+  PrincipalResponse,
+  TaskCommentResponse,
+  TaskReactionSummary,
+} from '@/lib/backend-api';
 import type { Principal } from '@/lib/principals';
 
 const viewer: Principal = { type: 'user', id: 'u1', name: 'test1@gmail.com' };
@@ -72,5 +76,122 @@ describe('describeReactors', () => {
       viewer,
     );
     expect(out).toBe('Ada and 1 other reacted with 👍');
+  });
+});
+
+const comment = (
+  id: string,
+  createdAt: string,
+  parent: string | null = null,
+): TaskCommentResponse => ({
+  id,
+  task_id: 't1',
+  parent_comment_id: parent,
+  author: person('u1', 'Nick'),
+  body: id,
+  kind: 'comment',
+  reactions: [],
+  created_at: createdAt,
+  edited_at: null,
+  deleted_at: null,
+});
+
+describe('buildThreads', () => {
+  it('hangs replies off their root, oldest first', () => {
+    const threads = buildThreads([
+      comment('root', '2026-09-01T10:00:00Z'),
+      comment('r2', '2026-09-01T12:00:00Z', 'root'),
+      comment('r1', '2026-09-01T11:00:00Z', 'root'),
+    ]);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].root.id).toBe('root');
+    expect(threads[0].replies.map((r) => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('orders threads by their root, not by their newest reply', () => {
+    // Rule 4: a thread sits where it started, so an answer written a day later
+    // stays next to the thing it answers instead of jumping to the bottom.
+    const threads = buildThreads([
+      comment('first', '2026-09-01T10:00:00Z'),
+      comment('late-reply', '2026-09-03T10:00:00Z', 'first'),
+      comment('second', '2026-09-02T10:00:00Z'),
+    ]);
+    expect(threads.map((t) => t.root.id)).toEqual(['first', 'second']);
+  });
+
+  it('promotes a reply whose root is missing rather than dropping it', () => {
+    const threads = buildThreads([comment('orphan', '2026-09-01T10:00:00Z', 'gone')]);
+    expect(threads.map((t) => t.root.id)).toEqual(['orphan']);
+  });
+});
+
+const activityRow = (
+  id: string,
+  createdAt: string,
+  details: Record<string, unknown> = {},
+) => ({
+  id,
+  actor: person('u1', 'Nick'),
+  action: 'status_changed',
+  details,
+  created_at: createdAt,
+});
+
+describe('buildEntries', () => {
+  it('does not give a reply a timeline row of its own', () => {
+    const entries = buildEntries(
+      [
+        comment('root', '2026-09-01T10:00:00Z'),
+        comment('reply', '2026-09-01T11:00:00Z', 'root'),
+      ],
+      [],
+      [],
+    );
+    expect(entries).toHaveLength(1);
+    if (entries[0].kind !== 'thread') throw new Error('expected a thread entry');
+    expect(entries[0].thread.replies.map((r) => r.id)).toEqual(['reply']);
+  });
+
+  it('gives each thread its own card', () => {
+    // Rule 2: a thread owns its card because it owns its reply box. Merging two
+    // threads into one surface would leave two reply boxes inside it.
+    const entries = buildEntries(
+      [
+        comment('a', '2026-09-01T10:00:00Z'),
+        comment('b', '2026-09-01T10:01:00Z'),
+      ],
+      [],
+      [],
+    );
+    expect(entries.map((e) => e.kind)).toEqual(['thread', 'thread']);
+  });
+
+  it('keeps activity whose session is not linked to the task', () => {
+    // It was bucketed against a session card that never renders, so the row —
+    // a change that really happened — silently vanished from the timeline.
+    const entries = buildEntries(
+      [],
+      [activityRow('a1', '2026-09-01T10:00:00Z', { agent_instance_id: 'gone' })],
+      [],
+    );
+    expect(entries).toHaveLength(1);
+    if (entries[0].kind !== 'activity') throw new Error('expected an activity entry');
+    expect(entries[0].items.map((r) => r.id)).toEqual(['a1']);
+  });
+
+  it('still folds activity into the session that caused it', () => {
+    const session = {
+      id: 's1',
+      started_at: '2026-09-01T09:00:00Z',
+      status: 'ACTIVE',
+    } as never;
+    const entries = buildEntries(
+      [],
+      [activityRow('a1', '2026-09-01T10:00:00Z', { agent_instance_id: 's1' })],
+      [session],
+    );
+    expect(entries).toHaveLength(1);
+    if (entries[0].kind !== 'session') throw new Error('expected a session entry');
+    expect(entries[0].absorbed.map((r) => r.id)).toEqual(['a1']);
   });
 });

--- a/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
@@ -10,15 +10,28 @@
 //    leading glyph at the same x and uses the same avatar size. Cards carry a
 //    real border and bare rows a transparent one so a 1px edge can't knock the
 //    column out of true.
-// 2. ONE SURFACE PER RUN OF COMMENTS. Consecutive comments share a single card
-//    with dividers between them rather than each getting its own floating
-//    bubble; the author row lives inside that surface. A thread should read as
-//    one object, not as a chat between two parties.
+// 2. ONE SURFACE PER THREAD. A root, its replies and the box you answer in
+//    share a single card with dividers between them, rather than each comment
+//    getting its own floating bubble. The thread is the object; the card is its
+//    edge. (Before threads existed this grouped *runs* of comments instead —
+//    once a comment can be answered, the run is no longer the real unit.)
 // 3. SESSIONS ABSORB THEIR OWN NOISE. A session's status hops (in_progress →
 //    done → in_review) are real activity rows, but they are folded into that
 //    session's card via `details.agent_instance_id` instead of being listed
 //    three times in the stream. Without this the timeline of a task that ran
 //    three sessions is nine automated lines and no content.
+// 4. A THREAD SITS WHERE IT STARTED, AND NEVER BRANCHES — SO IT NEVER INDENTS.
+//    Replies are one level deep (the server guarantees it): under a root they
+//    are a single ordered chain, never a tree. That is exactly why they are NOT
+//    indented — an indent encodes depth, and there is no second level for it to
+//    distinguish. The card's edge and the reply box at its foot already say
+//    "one conversation", so rule 1 holds with no exception. The thread is placed
+//    at its ROOT's timestamp, so an answer written a day later appears next to
+//    the thing it answers rather than stranded at the bottom of the page.
+// 5. THE REPLY BOX IS ALWAYS THERE. Every thread ends in a quiet "Leave a
+//    reply…" row — click and type. A hover-revealed or click-to-open affordance
+//    costs a click to discover that it exists, and this page is also a phone
+//    browser, where hover does not exist at all.
 
 import { useMemo, useState } from 'react';
 import { ChevronDown, ExternalLink, SmilePlus } from 'lucide-react';
@@ -35,6 +48,7 @@ import {
   TaskReactionSummary,
 } from '@/lib/backend-api';
 import { EmojiPicker } from '@/components/ui/emoji-picker';
+import { CommentComposer } from './comment-composer';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Tooltip,
@@ -56,8 +70,11 @@ const ROW_INSET = 'border px-3';
 const CARD_ROW = `${ROW_INSET} rounded-lg border-border bg-card`;
 const BARE_ROW = `${ROW_INSET} border-transparent`;
 
+/** A root comment and the replies hanging off it. Never deeper than this. */
+type Thread = { root: TaskCommentResponse; replies: TaskCommentResponse[] };
+
 type Entry =
-  | { kind: 'comments'; id: string; at: string; items: TaskCommentResponse[] }
+  | { kind: 'thread'; id: string; at: string; thread: Thread }
   | { kind: 'activity'; id: string; at: string; items: TaskActivityResponse[] }
   | {
       kind: 'session';
@@ -126,6 +143,45 @@ function timeLabel(iso: string): string {
 }
 
 /**
+ * Group a flat comment list into one-level threads.
+ *
+ * Built from `parent_comment_id` rather than from arrival order: the server
+ * already sends the list threaded, but a client that silently depends on that
+ * ordering breaks in a way nobody notices until a reply renders as a root.
+ * A reply whose root isn't in the list is promoted to a root — a comment that
+ * exists must be readable.
+ */
+export function buildThreads(comments: TaskCommentResponse[]): Thread[] {
+  const threads = new Map<string, Thread>();
+  const order: string[] = [];
+  const orphans: TaskCommentResponse[] = [];
+
+  for (const comment of comments) {
+    if (comment.parent_comment_id === null) {
+      threads.set(comment.id, { root: comment, replies: [] });
+      order.push(comment.id);
+    }
+  }
+  for (const comment of comments) {
+    if (comment.parent_comment_id === null) continue;
+    const thread = threads.get(comment.parent_comment_id);
+    if (thread) thread.replies.push(comment);
+    else orphans.push(comment);
+  }
+  for (const orphan of orphans) {
+    threads.set(orphan.id, { root: orphan, replies: [] });
+    order.push(orphan.id);
+  }
+
+  const out = order.map((id) => threads.get(id)!);
+  out.sort((a, b) => a.root.created_at.localeCompare(b.root.created_at));
+  for (const thread of out) {
+    thread.replies.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  }
+  return out;
+}
+
+/**
  * Fold the three sources into one ordered stream.
  *
  * Sessions are placed at their start time and swallow the activity rows they
@@ -137,11 +193,20 @@ export function buildEntries(
   activity: TaskActivityResponse[],
   sessions: AgentInstanceResponse[],
 ): Entry[] {
+  // Threads are placed by their ROOT's timestamp (rule 4), so a reply never
+  // pulls its thread down the page away from the conversation it belongs to.
+  const threads = buildThreads(comments);
+  // Only a session that is actually on this task can absorb anything. An
+  // activity row naming a session the task no longer links to (unlinked, or
+  // deleted) would otherwise be bucketed against a card that never renders and
+  // vanish from the timeline — the change really happened, so it stays as a
+  // normal line instead.
+  const linked = new Set(sessions.map((session) => session.id));
   const bySession = new Map<string, TaskActivityResponse[]>();
   const loose: TaskActivityResponse[] = [];
   for (const row of activity) {
     const instanceId = row.details?.agent_instance_id;
-    if (typeof instanceId === 'string') {
+    if (typeof instanceId === 'string' && linked.has(instanceId)) {
       const bucket = bySession.get(instanceId);
       if (bucket) bucket.push(row);
       else bySession.set(instanceId, [row]);
@@ -151,12 +216,16 @@ export function buildEntries(
   }
 
   type Raw =
-    | { at: string; kind: 'comment'; comment: TaskCommentResponse }
+    | { at: string; kind: 'comment'; thread: Thread }
     | { at: string; kind: 'activity'; row: TaskActivityResponse }
     | { at: string; kind: 'session'; session: AgentInstanceResponse };
 
   const raw: Raw[] = [
-    ...comments.map((comment) => ({ at: comment.created_at, kind: 'comment' as const, comment })),
+    ...threads.map((thread) => ({
+      at: thread.root.created_at,
+      kind: 'comment' as const,
+      thread,
+    })),
     ...loose.map((row) => ({ at: row.created_at, kind: 'activity' as const, row })),
     // A session with no start time sorts to the top rather than being dropped;
     // it is still a real link on the task.
@@ -171,14 +240,14 @@ export function buildEntries(
   for (const item of raw) {
     const last = entries[entries.length - 1];
     if (item.kind === 'comment') {
-      if (last?.kind === 'comments') last.items.push(item.comment);
-      else
-        entries.push({
-          kind: 'comments',
-          id: `c-${item.comment.id}`,
-          at: item.at,
-          items: [item.comment],
-        });
+      // Never merged with the thread before it (rule 2): each thread owns its
+      // own card because each thread owns its own reply box.
+      entries.push({
+        kind: 'thread',
+        id: `c-${item.thread.root.id}`,
+        at: item.at,
+        thread: item.thread,
+      });
     } else if (item.kind === 'activity') {
       if (last?.kind === 'activity') last.items.push(item.row);
       else
@@ -297,65 +366,100 @@ export function ReactionRow({
   );
 }
 
-function CommentGroup({
-  comments,
+function CommentBody({
+  comment,
   viewer,
   onToggleReaction,
 }: {
-  comments: TaskCommentResponse[];
+  comment: TaskCommentResponse;
   viewer: Principal | null;
   onToggleReaction: (commentId: string, emoji: string) => void;
 }) {
+  const author = principalFromResponse(comment.author);
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <PrincipalAvatar principal={principalForAvatar(author, viewer)} size="xs" />
+        <span className="text-sm font-medium">
+          {principalDisplayName(author, viewer)}
+        </span>
+        {comment.author.type === 'agent' && (
+          <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">
+            agent
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {timeLabel(comment.created_at)}
+        </span>
+        {comment.edited_at && (
+          <span className="text-xs text-muted-foreground/60">(edited)</span>
+        )}
+      </div>
+      {comment.deleted_at || comment.body === null ? (
+        // The tombstone stays: its replies are still on screen under it, and a
+        // thread with a hole where its opening post was is unreadable.
+        <div className="mt-1.5 text-sm italic text-muted-foreground/60">
+          This comment was deleted.
+        </div>
+      ) : (
+        <>
+          {/* Body starts at the avatar's left edge, not indented under the
+              name — the indent buys nothing and costs the column. */}
+          <div className="mt-1.5 text-sm leading-relaxed">
+            <MessageMarkdown>{comment.body}</MessageMarkdown>
+          </div>
+          <ReactionRow
+            className="mt-2"
+            reactions={comment.reactions}
+            viewer={viewer}
+            onToggle={(emoji) => onToggleReaction(comment.id, emoji)}
+          />
+        </>
+      )}
+    </>
+  );
+}
+
+function ThreadCard({
+  thread,
+  viewer,
+  onToggleReaction,
+  onReply,
+}: {
+  thread: Thread;
+  viewer: Principal | null;
+  onToggleReaction: (commentId: string, emoji: string) => void;
+  onReply?: (parentCommentId: string, body: string) => Promise<void>;
+}) {
   return (
     <div className={cn(CARD_ROW, 'px-0')}>
-      {comments.map((comment, index) => {
-        const author = principalFromResponse(comment.author);
-        return (
-          <div
-            key={comment.id}
-            // Divider between entries, never around them: the run is one
-            // surface, and a border on each child would rebuild the bubbles.
-            className={cn('px-3 py-2.5', index > 0 && 'border-t')}
-          >
-            <div className="flex items-center gap-2">
-              <PrincipalAvatar principal={principalForAvatar(author, viewer)} size="xs" />
-              <span className="text-sm font-medium">
-                {principalDisplayName(author, viewer)}
-              </span>
-              {comment.author.type === 'agent' && (
-                <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">
-                  agent
-                </span>
-              )}
-              <span className="text-xs text-muted-foreground">
-                {timeLabel(comment.created_at)}
-              </span>
-              {comment.edited_at && (
-                <span className="text-xs text-muted-foreground/60">(edited)</span>
-              )}
-            </div>
-            {comment.deleted_at || comment.body === null ? (
-              <div className="mt-1.5 text-sm italic text-muted-foreground/60">
-                This comment was deleted.
-              </div>
-            ) : (
-              <>
-                {/* Body starts at the avatar's left edge, not indented under the
-                    name — the indent buys nothing and costs the column. */}
-                <div className="mt-1.5 text-sm leading-relaxed">
-                  <MessageMarkdown>{comment.body}</MessageMarkdown>
-                </div>
-                <ReactionRow
-                  className="mt-2"
-                  reactions={comment.reactions}
-                  viewer={viewer}
-                  onToggle={(emoji) => onToggleReaction(comment.id, emoji)}
-                />
-              </>
-            )}
-          </div>
-        );
-      })}
+      <div className="px-3 py-2.5">
+        <CommentBody comment={thread.root} viewer={viewer} onToggleReaction={onToggleReaction} />
+      </div>
+      {/* Not indented (rule 4). The card's edge already says these belong
+          together, and there is no second level to distinguish them from — a
+          reply cannot itself be replied to, so an indent would only encode
+          depth that cannot exist. */}
+      {thread.replies.map((reply) => (
+        <div key={reply.id} className="border-t px-3 py-2.5">
+          <CommentBody comment={reply} viewer={viewer} onToggleReaction={onToggleReaction} />
+        </div>
+      ))}
+      {onReply && (
+        <div className="border-t px-3 py-1.5">
+          <CommentComposer
+            variant="inline"
+            placeholder="Leave a reply…"
+            leading={
+              <PrincipalAvatar
+                principal={viewer ?? { type: 'user', name: null }}
+                size="xs"
+              />
+            }
+            onSubmit={(body) => onReply(thread.root.id, body)}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -493,6 +597,7 @@ export function TaskTimeline({
   sessions,
   viewer,
   onToggleCommentReaction,
+  onReply,
 }: {
   comments: TaskCommentResponse[];
   activity: TaskActivityResponse[];
@@ -500,6 +605,8 @@ export function TaskTimeline({
   /** The signed-in user, so a nameless principal can still read as "You". */
   viewer: Principal | null;
   onToggleCommentReaction: (commentId: string, emoji: string) => void;
+  /** Omitted on a read-only surface (P4's public board): no composer, no Reply. */
+  onReply?: (parentCommentId: string, body: string) => Promise<void>;
 }) {
   const entries = useMemo(
     () => buildEntries(comments, activity, sessions),
@@ -509,13 +616,14 @@ export function TaskTimeline({
   return (
     <div className="space-y-1.5">
       {entries.map((entry) => {
-        if (entry.kind === 'comments') {
+        if (entry.kind === 'thread') {
           return (
-            <CommentGroup
+            <ThreadCard
               key={entry.id}
-              comments={entry.items}
+              thread={entry.thread}
               viewer={viewer}
               onToggleReaction={onToggleCommentReaction}
+              onReply={onReply}
             />
           );
         }
@@ -528,4 +636,4 @@ export function TaskTimeline({
   );
 }
 
-export type { Entry, Principal };
+export type { Entry, Thread, Principal };

--- a/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
@@ -37,6 +37,12 @@ import {
 import { EmojiPicker } from '@/components/ui/emoji-picker';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
   principalDisplayName,
   principalForAvatar,
   principalFromResponse,
@@ -191,6 +197,36 @@ export function buildEntries(
 }
 
 /**
+ * "Nick and Ada reacted with 👍" — the sentence a pill's tooltip reads.
+ *
+ * The signed-in user comes first and reads as "You", the way Slack and GitHub
+ * put you at the front of your own reactions. Past the server's cap the
+ * remainder collapses to "and N others" rather than the list simply ending,
+ * so the tooltip never quietly under-reports who is on a pill.
+ */
+export function describeReactors(
+  reaction: TaskReactionSummary,
+  viewer: Principal | null,
+): string {
+  const named = reaction.reactors.map((r) => {
+    const principal = principalFromResponse(r);
+    const isViewer = !!viewer?.id && r.id === viewer.id;
+    return isViewer ? 'You' : principalDisplayName(principal, viewer);
+  });
+  const mine = named.indexOf('You');
+  if (mine > 0) named.unshift(...named.splice(mine, 1));
+
+  const unnamed = reaction.count - named.length;
+  if (unnamed > 0) named.push(`${unnamed} other${unnamed === 1 ? '' : 's'}`);
+
+  const people =
+    named.length <= 1
+      ? (named[0] ?? 'Someone')
+      : `${named.slice(0, -1).join(', ')} and ${named[named.length - 1]}`;
+  return `${people} reacted with ${reaction.emoji}`;
+}
+
+/**
  * The pill row plus its add button.
  *
  * The add button opens the shared `<EmojiPicker>` — the one project icons and
@@ -201,31 +237,42 @@ export function buildEntries(
  */
 export function ReactionRow({
   reactions,
+  viewer,
   onToggle,
   className,
 }: {
   reactions: TaskReactionSummary[];
+  /** Resolves a nameless reactor to "You" rather than "Unknown". */
+  viewer: Principal | null;
   onToggle: (emoji: string) => void;
   className?: string;
 }) {
   const [picking, setPicking] = useState(false);
   return (
     <div className={cn('flex flex-wrap items-center gap-1', className)}>
-      {reactions.map((reaction) => (
-        <button
-          key={reaction.emoji}
-          type="button"
-          onClick={() => onToggle(reaction.emoji)}
-          className={cn(
-            'flex cursor-pointer items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] transition-colors',
-            reaction.reacted
-              ? 'border-primary/40 bg-primary/10 text-foreground'
-              : 'bg-muted/50 hover:bg-muted',
-          )}
-        >
-          {reaction.emoji} {reaction.count}
-        </button>
-      ))}
+      <TooltipProvider delayDuration={200}>
+        {reactions.map((reaction) => (
+          <Tooltip key={reaction.emoji}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => onToggle(reaction.emoji)}
+                className={cn(
+                  'flex cursor-pointer items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] transition-colors',
+                  reaction.reacted
+                    ? 'border-primary/40 bg-primary/10 text-foreground'
+                    : 'bg-muted/50 hover:bg-muted',
+                )}
+              >
+                {reaction.emoji} {reaction.count}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-56">
+              {describeReactors(reaction, viewer)}
+            </TooltipContent>
+          </Tooltip>
+        ))}
+      </TooltipProvider>
       <Popover open={picking} onOpenChange={setPicking}>
         <PopoverTrigger asChild>
           <button
@@ -301,6 +348,7 @@ function CommentGroup({
                 <ReactionRow
                   className="mt-2"
                   reactions={comment.reactions}
+                  viewer={viewer}
                   onToggle={(emoji) => onToggleReaction(comment.id, emoji)}
                 />
               </>

--- a/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
+++ b/apps/web/app/dashboard/tasks/[taskId]/task-timeline.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+// The task-detail timeline: comments, generated activity and agent sessions in
+// one chronological stream.
+//
+// Three rules hold the whole thing together, and they are the reason it does
+// not look like a chat log:
+//
+// 1. ONE COLUMN. Every row — comment, activity line, session card — puts its
+//    leading glyph at the same x and uses the same avatar size. Cards carry a
+//    real border and bare rows a transparent one so a 1px edge can't knock the
+//    column out of true.
+// 2. ONE SURFACE PER RUN OF COMMENTS. Consecutive comments share a single card
+//    with dividers between them rather than each getting its own floating
+//    bubble; the author row lives inside that surface. A thread should read as
+//    one object, not as a chat between two parties.
+// 3. SESSIONS ABSORB THEIR OWN NOISE. A session's status hops (in_progress →
+//    done → in_review) are real activity rows, but they are folded into that
+//    session's card via `details.agent_instance_id` instead of being listed
+//    three times in the stream. Without this the timeline of a task that ran
+//    three sessions is nine automated lines and no content.
+
+import { useMemo, useState } from 'react';
+import { ChevronDown, ExternalLink, SmilePlus } from 'lucide-react';
+import Link from 'next/link';
+
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import { MessageMarkdown } from '@/components/ui/message-markdown';
+import { SessionAgentIcon } from '@/components/dashboard/agent-type-icon';
+import { formatSidebarTime, getSessionTitle } from '@/components/dashboard/session-display';
+import {
+  AgentInstanceResponse,
+  TaskActivityResponse,
+  TaskCommentResponse,
+  TaskReactionSummary,
+} from '@/lib/backend-api';
+import { EmojiPicker } from '@/components/ui/emoji-picker';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  principalDisplayName,
+  principalForAvatar,
+  principalFromResponse,
+  type Principal,
+} from '@/lib/principals';
+import { cn } from '@/lib/utils';
+
+// See rule 1. Both values are used by the composer too, so the stream and the
+// box you type into share a left edge.
+const ROW_INSET = 'border px-3';
+const CARD_ROW = `${ROW_INSET} rounded-lg border-border bg-card`;
+const BARE_ROW = `${ROW_INSET} border-transparent`;
+
+type Entry =
+  | { kind: 'comments'; id: string; at: string; items: TaskCommentResponse[] }
+  | { kind: 'activity'; id: string; at: string; items: TaskActivityResponse[] }
+  | {
+      kind: 'session';
+      id: string;
+      at: string;
+      session: AgentInstanceResponse;
+      absorbed: TaskActivityResponse[];
+    };
+
+const STATUS_LABELS: Record<string, string> = {
+  backlog: 'Backlog',
+  todo: 'Todo',
+  in_progress: 'In Progress',
+  in_review: 'In Review',
+  done: 'Done',
+  blocked: 'Blocked',
+  cancelled: 'Cancelled',
+};
+
+function pretty(value: unknown): string {
+  if (value === null || value === undefined || value === '') return 'none';
+  const text = String(value);
+  return STATUS_LABELS[text] ?? text;
+}
+
+/** The one-line phrase an activity row reads as. */
+export function activityText(entry: TaskActivityResponse): string {
+  const d = entry.details ?? {};
+  switch (entry.action) {
+    case 'created':
+      return 'created this task';
+    case 'status_changed':
+      return `moved from ${pretty(d.from)} to ${pretty(d.to)}`;
+    case 'priority_changed':
+      return `changed priority from ${pretty(d.from)} to ${pretty(d.to)}`;
+    case 'assigned':
+      return d.to ? 'changed the assignee' : 'cleared the assignee';
+    case 'title_changed':
+      return 'edited the title';
+    case 'description_changed':
+      return 'edited the description';
+    case 'label_added':
+      return `added label ${pretty(d.label)}`;
+    case 'label_removed':
+      return `removed label ${pretty(d.label)}`;
+    case 'due_date_set':
+      return d.to ? 'set a due date' : 'removed the due date';
+    case 'start_date_set':
+      return d.to ? 'set a start date' : 'removed the start date';
+    case 'project_changed':
+      return 'moved this task to another project';
+    case 'parent_changed':
+      return d.to ? 'changed the parent task' : 'removed the parent task';
+    default:
+      return entry.action.replace(/_/g, ' ');
+  }
+}
+
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Fold the three sources into one ordered stream.
+ *
+ * Sessions are placed at their start time and swallow the activity rows they
+ * caused (rule 3); whatever is left merges by kind, so a burst of edits becomes
+ * one line and a back-and-forth becomes one card.
+ */
+export function buildEntries(
+  comments: TaskCommentResponse[],
+  activity: TaskActivityResponse[],
+  sessions: AgentInstanceResponse[],
+): Entry[] {
+  const bySession = new Map<string, TaskActivityResponse[]>();
+  const loose: TaskActivityResponse[] = [];
+  for (const row of activity) {
+    const instanceId = row.details?.agent_instance_id;
+    if (typeof instanceId === 'string') {
+      const bucket = bySession.get(instanceId);
+      if (bucket) bucket.push(row);
+      else bySession.set(instanceId, [row]);
+    } else {
+      loose.push(row);
+    }
+  }
+
+  type Raw =
+    | { at: string; kind: 'comment'; comment: TaskCommentResponse }
+    | { at: string; kind: 'activity'; row: TaskActivityResponse }
+    | { at: string; kind: 'session'; session: AgentInstanceResponse };
+
+  const raw: Raw[] = [
+    ...comments.map((comment) => ({ at: comment.created_at, kind: 'comment' as const, comment })),
+    ...loose.map((row) => ({ at: row.created_at, kind: 'activity' as const, row })),
+    // A session with no start time sorts to the top rather than being dropped;
+    // it is still a real link on the task.
+    ...sessions.map((session) => ({
+      at: session.started_at ?? new Date(0).toISOString(),
+      kind: 'session' as const,
+      session,
+    })),
+  ].sort((a, b) => a.at.localeCompare(b.at));
+
+  const entries: Entry[] = [];
+  for (const item of raw) {
+    const last = entries[entries.length - 1];
+    if (item.kind === 'comment') {
+      if (last?.kind === 'comments') last.items.push(item.comment);
+      else
+        entries.push({
+          kind: 'comments',
+          id: `c-${item.comment.id}`,
+          at: item.at,
+          items: [item.comment],
+        });
+    } else if (item.kind === 'activity') {
+      if (last?.kind === 'activity') last.items.push(item.row);
+      else
+        entries.push({ kind: 'activity', id: `a-${item.row.id}`, at: item.at, items: [item.row] });
+    } else {
+      entries.push({
+        kind: 'session',
+        id: `s-${item.session.id}`,
+        at: item.at,
+        session: item.session,
+        absorbed: bySession.get(item.session.id) ?? [],
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * The pill row plus its add button.
+ *
+ * The add button opens the shared `<EmojiPicker>` — the one project icons and
+ * avatars already use — in its `reaction` variant: a curated set of things
+ * people actually answer with, a search box, and "All emoji" for the full
+ * Unicode set behind a click. A fixed six-emoji strip is the thing this
+ * replaces; there is no reason a reaction can be 👍 but not 🤯.
+ */
+export function ReactionRow({
+  reactions,
+  onToggle,
+  className,
+}: {
+  reactions: TaskReactionSummary[];
+  onToggle: (emoji: string) => void;
+  className?: string;
+}) {
+  const [picking, setPicking] = useState(false);
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1', className)}>
+      {reactions.map((reaction) => (
+        <button
+          key={reaction.emoji}
+          type="button"
+          onClick={() => onToggle(reaction.emoji)}
+          className={cn(
+            'flex cursor-pointer items-center gap-1 rounded-full border px-1.5 py-0.5 text-[11px] transition-colors',
+            reaction.reacted
+              ? 'border-primary/40 bg-primary/10 text-foreground'
+              : 'bg-muted/50 hover:bg-muted',
+          )}
+        >
+          {reaction.emoji} {reaction.count}
+        </button>
+      ))}
+      <Popover open={picking} onOpenChange={setPicking}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label="Add reaction"
+            className="flex size-6 cursor-pointer items-center justify-center rounded-full border text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <SmilePlus className="size-3.5" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-auto p-0">
+          <EmojiPicker
+            variant="reaction"
+            onSelect={(emoji) => {
+              onToggle(emoji);
+              setPicking(false);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+function CommentGroup({
+  comments,
+  viewer,
+  onToggleReaction,
+}: {
+  comments: TaskCommentResponse[];
+  viewer: Principal | null;
+  onToggleReaction: (commentId: string, emoji: string) => void;
+}) {
+  return (
+    <div className={cn(CARD_ROW, 'px-0')}>
+      {comments.map((comment, index) => {
+        const author = principalFromResponse(comment.author);
+        return (
+          <div
+            key={comment.id}
+            // Divider between entries, never around them: the run is one
+            // surface, and a border on each child would rebuild the bubbles.
+            className={cn('px-3 py-2.5', index > 0 && 'border-t')}
+          >
+            <div className="flex items-center gap-2">
+              <PrincipalAvatar principal={principalForAvatar(author, viewer)} size="xs" />
+              <span className="text-sm font-medium">
+                {principalDisplayName(author, viewer)}
+              </span>
+              {comment.author.type === 'agent' && (
+                <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">
+                  agent
+                </span>
+              )}
+              <span className="text-xs text-muted-foreground">
+                {timeLabel(comment.created_at)}
+              </span>
+              {comment.edited_at && (
+                <span className="text-xs text-muted-foreground/60">(edited)</span>
+              )}
+            </div>
+            {comment.deleted_at || comment.body === null ? (
+              <div className="mt-1.5 text-sm italic text-muted-foreground/60">
+                This comment was deleted.
+              </div>
+            ) : (
+              <>
+                {/* Body starts at the avatar's left edge, not indented under the
+                    name — the indent buys nothing and costs the column. */}
+                <div className="mt-1.5 text-sm leading-relaxed">
+                  <MessageMarkdown>{comment.body}</MessageMarkdown>
+                </div>
+                <ReactionRow
+                  className="mt-2"
+                  reactions={comment.reactions}
+                  onToggle={(emoji) => onToggleReaction(comment.id, emoji)}
+                />
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActivityLine({
+  row,
+  viewer,
+}: {
+  row: TaskActivityResponse;
+  viewer: Principal | null;
+}) {
+  const actor = principalFromResponse(row.actor);
+  return (
+    <div className={cn(BARE_ROW, 'flex items-center gap-2 py-1 text-xs text-muted-foreground')}>
+      <PrincipalAvatar principal={principalForAvatar(actor, viewer)} size="xs" />
+      <span className="min-w-0 truncate">
+        <span className="text-foreground/70">{principalDisplayName(actor, viewer)}</span>{' '}
+        {activityText(row)}
+      </span>
+      <span className="shrink-0 opacity-50">{timeLabel(row.created_at)}</span>
+    </div>
+  );
+}
+
+function ActivityRun({
+  rows,
+  viewer,
+}: {
+  rows: TaskActivityResponse[];
+  viewer: Principal | null;
+}) {
+  const [open, setOpen] = useState(false);
+  if (rows.length === 1) return <ActivityLine row={rows[0]} viewer={viewer} />;
+
+  const actors = Array.from(
+    new Set(
+      rows.map((row) => principalDisplayName(principalFromResponse(row.actor), viewer)),
+    ),
+  );
+  const lead = principalFromResponse(rows[0].actor);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          BARE_ROW,
+          'flex w-full cursor-pointer items-center gap-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground',
+        )}
+      >
+        <PrincipalAvatar principal={principalForAvatar(lead, viewer)} size="xs" />
+        <span>
+          <span className="text-foreground/70">{actors.join(' & ')}</span> made {rows.length}{' '}
+          changes
+        </span>
+        <span className="opacity-50">{timeLabel(rows[0].created_at)}</span>
+        <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} />
+      </button>
+      {open && (
+        <div className="ml-5 mt-1 space-y-0.5 border-l">
+          {rows.map((row) => (
+            <ActivityLine key={row.id} row={row} viewer={viewer} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionCard({
+  session,
+  absorbed,
+}: {
+  session: AgentInstanceResponse;
+  absorbed: TaskActivityResponse[];
+}) {
+  const [open, setOpen] = useState(false);
+  const live = session.status === 'ACTIVE';
+  return (
+    <div className={cn(CARD_ROW, 'px-0')}>
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        <SessionAgentIcon
+          agentTypeName={session.agent_type_name}
+          status={session.status}
+          size={16}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium">{getSessionTitle(session)}</div>
+          <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+            {live ? (
+              <span className="flex items-center gap-1 text-emerald-500">
+                <span className="size-1.5 animate-pulse rounded-full bg-emerald-500" />
+                running
+              </span>
+            ) : (
+              <span>{String(session.status).toLowerCase()}</span>
+            )}
+            <span className="opacity-40">·</span>
+            <span>{formatSidebarTime(session)}</span>
+          </div>
+        </div>
+        <Link
+          href={`/dashboard?instance=${session.id}`}
+          className="flex shrink-0 cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          Open <ExternalLink className="size-3" />
+        </Link>
+      </div>
+      {absorbed.length > 0 && (
+        <>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="flex w-full cursor-pointer items-center gap-1.5 border-t px-3 py-1.5 text-left text-[11px] text-muted-foreground/70 transition-colors hover:text-muted-foreground"
+          >
+            <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} />
+            {absorbed.length} status change{absorbed.length === 1 ? '' : 's'} from this session
+          </button>
+          {open && (
+            <div className="space-y-1 border-t px-3 py-2 text-[11px] text-muted-foreground">
+              {absorbed.map((row) => (
+                <div key={row.id}>{activityText(row)}</div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function TaskTimeline({
+  comments,
+  activity,
+  sessions,
+  viewer,
+  onToggleCommentReaction,
+}: {
+  comments: TaskCommentResponse[];
+  activity: TaskActivityResponse[];
+  sessions: AgentInstanceResponse[];
+  /** The signed-in user, so a nameless principal can still read as "You". */
+  viewer: Principal | null;
+  onToggleCommentReaction: (commentId: string, emoji: string) => void;
+}) {
+  const entries = useMemo(
+    () => buildEntries(comments, activity, sessions),
+    [comments, activity, sessions],
+  );
+
+  return (
+    <div className="space-y-1.5">
+      {entries.map((entry) => {
+        if (entry.kind === 'comments') {
+          return (
+            <CommentGroup
+              key={entry.id}
+              comments={entry.items}
+              viewer={viewer}
+              onToggleReaction={onToggleCommentReaction}
+            />
+          );
+        }
+        if (entry.kind === 'activity') {
+          return <ActivityRun key={entry.id} rows={entry.items} viewer={viewer} />;
+        }
+        return <SessionCard key={entry.id} session={entry.session} absorbed={entry.absorbed} />;
+      })}
+    </div>
+  );
+}
+
+export type { Entry, Principal };

--- a/apps/web/app/dashboard/tasks/page.tsx
+++ b/apps/web/app/dashboard/tasks/page.tsx
@@ -188,10 +188,9 @@ function TasksPageInner() {
     };
   }, [api, refresh]);
 
-  // Deep link from the ⌘K palette: /dashboard/tasks?task={id} opens that
-  // task's dialog once its row is available (cached rows immediately, else
-  // after the fetch lands), then strips the param so refresh/back doesn't
-  // reopen it. An unknown id (e.g. deleted task) just leaves the board as-is.
+  // `?task=new` still opens the create dialog. `?task={id}` is the old deep
+  // link shape — it now forwards to the task's own route so older links (and
+  // anything still generating them) land on the same surface as a click.
   useEffect(() => {
     const taskId = searchParams?.get('task');
     if (!taskId) return;
@@ -200,11 +199,8 @@ function TasksPageInner() {
       router.replace('/dashboard/tasks', { scroll: false });
       return;
     }
-    const target = tasks.find((t) => t.id === taskId);
-    if (!target) return;
-    setDialog({ open: true, task: target });
-    router.replace('/dashboard/tasks', { scroll: false });
-  }, [searchParams, tasks, router]);
+    router.replace(`/dashboard/tasks/${taskId}`, { scroll: false });
+  }, [searchParams, router]);
 
   // Keep the in-memory cache warm from the current rows — seeds the next visit.
   // Gated on !isLoading so the pre-load empty state is never cached; every
@@ -587,9 +583,13 @@ function TasksPageInner() {
       setDialog({ open: true, task: null, defaults }),
     [],
   );
+  // Opening an existing task goes to its page, not to the dialog: that page is
+  // where comments, history and the full property set live, and a task the
+  // ⌘K palette or a "VIC-42" reference resolves to has to land somewhere
+  // deep-linkable. The dialog stays the fast *create* path.
   const openEditDialog = useCallback(
-    (task: TaskResponse) => setDialog({ open: true, task }),
-    [],
+    (task: TaskResponse) => router.push(`/dashboard/tasks/${task.id}`),
+    [router],
   );
   const closeDialog = useCallback(() => setDialog({ open: false, task: null }), []);
 

--- a/apps/web/app/dashboard/tasks/task-board.tsx
+++ b/apps/web/app/dashboard/tasks/task-board.tsx
@@ -29,6 +29,7 @@ import {
   LabelChips,
   ParentChip,
   PriorityIcon,
+  TaskIdentifier,
   ProjectChip,
   STATUS_CONFIG,
   STATUS_ORDER,
@@ -95,9 +96,12 @@ function TaskCard({
       )}
       onClick={dragOverlay ? undefined : () => onEdit(task)}
     >
-      {/* Row 1: priority (left) + actions (right, on hover) */}
+      {/* Row 1: identity + priority (left) + actions (right, on hover) */}
       <div className="flex items-center justify-between gap-2">
-        {display.priority ? <PriorityIcon priority={task.priority} /> : <span />}
+        <span className="flex min-w-0 items-center gap-1.5">
+          {display.priority && <PriorityIcon priority={task.priority} />}
+          <TaskIdentifier task={task} />
+        </span>
         {!dragOverlay && (
           <span
             onClick={(e) => e.stopPropagation()}

--- a/apps/web/app/dashboard/tasks/task-dialog.tsx
+++ b/apps/web/app/dashboard/tasks/task-dialog.tsx
@@ -21,6 +21,7 @@ import {
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import {
   DropdownMenu,
@@ -331,7 +332,21 @@ export function TaskDialog({
           <div className="flex items-center gap-1.5 text-xs">
             <span className="text-muted-foreground">Tasks</span>
             <ChevronRight className="size-3 text-muted-foreground/50" />
-            <span className="font-medium">{task ? 'Edit task' : 'New task'}</span>
+            {/* The identifier doubles as the way into the full task page — the
+                dialog stays the fast edit path, so it needs one obvious exit to
+                the surface that has comments and history. Absent for a task
+                that predates the number backfill. */}
+            {task?.identifier ? (
+              <Link
+                href={`/dashboard/tasks/${task.id}`}
+                className="cursor-pointer rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] tracking-tight text-muted-foreground transition-colors hover:text-foreground"
+                title="Open full task page"
+              >
+                {task.identifier}
+              </Link>
+            ) : (
+              <span className="font-medium">{task ? 'Edit task' : 'New task'}</span>
+            )}
           </div>
           <div className="flex items-center gap-0.5">
             <button

--- a/apps/web/app/dashboard/tasks/task-list.tsx
+++ b/apps/web/app/dashboard/tasks/task-list.tsx
@@ -30,6 +30,7 @@ import {
   LabelChips,
   ParentChip,
   PriorityIcon,
+  TaskIdentifier,
   ProjectChip,
   STATUS_ORDER,
   StatusHeading,
@@ -83,6 +84,7 @@ function TaskRow({
       onClick={dragOverlay ? undefined : () => onEdit(task)}
     >
       {display.priority && <PriorityIcon priority={task.priority} />}
+      <TaskIdentifier task={task} />
       <span className={cn('min-w-0 flex-1 truncate', isClosed && 'text-muted-foreground line-through')}>
         {task.title}
       </span>

--- a/apps/web/components/dashboard/search-palette.tsx
+++ b/apps/web/components/dashboard/search-palette.tsx
@@ -402,7 +402,7 @@ export function SearchPalette({ open, onOpenChange }: SearchPaletteProps) {
       } else if (item.kind === 'session') {
         router.push(`/dashboard/agents/${item.session.id}`);
       } else if (item.kind === 'task') {
-        router.push(`/dashboard/tasks?task=${item.task.id}`);
+        router.push(`/dashboard/tasks/${item.task.id}`);
       } else if (item.kind === 'automation') {
         router.push(`/dashboard/automation?automation=${item.automation.id}`);
       } else {

--- a/apps/web/components/dashboard/session-grouping.test.ts
+++ b/apps/web/components/dashboard/session-grouping.test.ts
@@ -32,6 +32,7 @@ const make = (over: Partial<AgentInstanceResponse>): AgentInstanceResponse => ({
 
 const proj = (over: Partial<ProjectResponse> & { id: string }): ProjectResponse => ({
   name: over.id,
+  key: null,
   git_remote_url: null,
   color: null,
   icon: null,

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -467,6 +467,39 @@ export function ProjectIcon({
   return <Icon aria-hidden="true" className={cn('text-muted-foreground', box)} />;
 }
 
+/**
+ * "VIC-42" — the task's identifier, wherever a task is listed.
+ *
+ * Always rendered, not behind the display menu that governs priority, labels
+ * and dates. Those are properties you may not care about; this is the task's
+ * name. The whole reason the key exists (D-B) is to give every task something
+ * speakable and greppable to use in chat, in an agent prompt and in a commit
+ * message — hiding it by default would defeat the feature.
+ *
+ * Renders nothing when the task has no identifier: a project only takes a key
+ * on its first task, and rows created before the backfill have no number. A
+ * placeholder there would look like a reference that doesn't resolve.
+ */
+export function TaskIdentifier({
+  task,
+  className,
+}: {
+  task: Pick<TaskResponse, 'identifier'>;
+  className?: string;
+}) {
+  if (!task.identifier) return null;
+  return (
+    <span
+      className={cn(
+        'shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground/70',
+        className,
+      )}
+    >
+      {task.identifier}
+    </span>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // PillButton — the trigger every property picker renders
 //

--- a/apps/web/components/dashboard/task-ui.tsx
+++ b/apps/web/components/dashboard/task-ui.tsx
@@ -6,7 +6,7 @@
 // status/priority vocabulary. Used by the tasks page (list + board), the
 // task dialog, and the new-session task picker.
 
-import { useEffect, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import {
   CalendarClock,
   CalendarDays,
@@ -22,6 +22,7 @@ import {
   Repeat,
   Tag,
   Trash2,
+  UserRound,
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -49,6 +50,8 @@ import {
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import {
+  AgentProfile,
+  PrincipalResponse,
   ProjectResponse,
   TaskLabelResponse,
   TaskPriority,
@@ -57,6 +60,13 @@ import {
   UpdateTaskRequest,
 } from '@/lib/backend-api';
 import { projectAvatarColor, projectIconSrc, projectInitial } from '@/lib/project-icons';
+import { PrincipalAvatar } from '@/components/ui/principal-avatar';
+import {
+  principalDisplayName,
+  principalForAvatar,
+  principalFromResponse,
+  type Principal,
+} from '@/lib/principals';
 import { cn } from '@/lib/utils';
 import { pointerWithin, closestCenter, type CollisionDetection } from '@dnd-kit/core';
 
@@ -458,22 +468,47 @@ export function ProjectIcon({
 }
 
 // ---------------------------------------------------------------------------
-// PillButton — outlined property-pill trigger (multica common/pill-button)
+// PillButton — the trigger every property picker renders
+//
+// Two shapes, same component. `pill` is the outlined chip the create dialog
+// packs into a wrapping row. `row` is the full-width borderless line a sidebar
+// wants: under a group heading, a column of them reads as a property list, and
+// eight outlined chips stacked vertically would read as eight buttons.
+//
+// The shape travels by context rather than by a prop so the rail sets it once
+// instead of every picker growing (and forwarding) a `variant`.
 // ---------------------------------------------------------------------------
+
+type PillVariant = 'pill' | 'row';
+
+const PillVariantContext = createContext<PillVariant>('pill');
+
+/** Render every picker inside as a full-width sidebar row. */
+export function PropertyRows({ children }: { children: React.ReactNode }) {
+  return (
+    <PillVariantContext.Provider value="row">
+      <div className="space-y-0.5">{children}</div>
+    </PillVariantContext.Provider>
+  );
+}
 
 export function PillButton({
   children,
   className,
   ...props
 }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const variant = useContext(PillVariantContext);
   return (
     <button
       type="button"
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
-        'hover:bg-accent/60 transition-colors cursor-pointer',
+        'inline-flex items-center gap-1.5 border transition-colors cursor-pointer',
+        'hover:bg-accent/60',
         'data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
         'disabled:cursor-not-allowed disabled:hover:bg-transparent',
+        variant === 'row'
+          ? 'w-full justify-start rounded-md border-transparent px-2 py-1.5 text-sm'
+          : 'rounded-full px-2.5 py-1 text-xs',
         className,
       )}
       {...props}
@@ -513,7 +548,7 @@ export function PickerItem({
   );
 }
 
-function PickerPopover({
+export function PickerPopover({
   open,
   onOpenChange,
   trigger,
@@ -694,6 +729,92 @@ export function collectDescendantIds(
  * `currentTaskId` and its descendants are excluded to keep the tree acyclic;
  * in create mode (`currentTaskId` null) nothing is excluded.
  */
+export function AssigneePickerPill({
+  assignee,
+  viewer,
+  agentProfiles,
+  onSelect,
+}: {
+  assignee: PrincipalResponse | null;
+  /** The signed-in user — the only human assignable until P3 adds grants. */
+  viewer: Principal | null;
+  agentProfiles: AgentProfile[];
+  onSelect: (next: { type: 'user' | 'agent'; id: string } | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = principalFromResponse(assignee);
+  return (
+    <PickerPopover
+      open={open}
+      onOpenChange={setOpen}
+      width="w-52"
+      trigger={
+        <PillButton>
+          {current ? (
+            <>
+              <PrincipalAvatar principal={principalForAvatar(current, viewer)} size="xs" />
+              <span className="truncate">{principalDisplayName(current, viewer)}</span>
+            </>
+          ) : (
+            <>
+              <UserRound className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="truncate text-muted-foreground">Assign</span>
+            </>
+          )}
+        </PillButton>
+      }
+    >
+      <PickerItem
+        selected={!assignee}
+        onClick={() => {
+          onSelect(null);
+          setOpen(false);
+        }}
+      >
+        <UserRound className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-muted-foreground">Unassigned</span>
+      </PickerItem>
+      {viewer?.id && (
+        <PickerItem
+          selected={assignee?.type === 'user' && assignee.id === viewer.id}
+          onClick={() => {
+            onSelect({ type: 'user', id: viewer.id! });
+            setOpen(false);
+          }}
+        >
+          <PrincipalAvatar principal={principalForAvatar(viewer, viewer)} size="xs" />
+          <span className="truncate">{principalDisplayName(viewer, viewer)}</span>
+        </PickerItem>
+      )}
+      {/* Agents are assignable principals, not just runners (§2 layer 1) —
+          "Claude owns this one" is the single-player half of assignment. */}
+      {agentProfiles.map((profile) => (
+        <PickerItem
+          key={profile.id}
+          selected={assignee?.type === 'agent' && assignee.id === profile.id}
+          onClick={() => {
+            onSelect({ type: 'agent', id: profile.id });
+            setOpen(false);
+          }}
+        >
+          <PrincipalAvatar
+            principal={{
+              type: 'agent',
+              id: profile.id,
+              name: profile.name,
+              avatarImageUri: profile.avatar_image_uri,
+              emoji: profile.emoji,
+              updatedAt: profile.updated_at,
+            }}
+            size="xs"
+          />
+          <span className="truncate">{profile.name}</span>
+        </PickerItem>
+      ))}
+    </PickerPopover>
+  );
+}
+
 export function ParentPickerPill({
   tasks,
   currentTaskId,
@@ -1077,7 +1198,7 @@ export function LabelPickerPill({
               </span>
             </span>
           ) : (
-            <span>Labels</span>
+            <span>Add label</span>
           )}
         </PillButton>
       </PopoverTrigger>

--- a/apps/web/components/navigation-header.tsx
+++ b/apps/web/components/navigation-header.tsx
@@ -143,7 +143,7 @@ export function NavigationHeader() {
               rel="noopener noreferrer"
               aria-label="Vicoa on GitHub"
               title="Vicoa is open source — star us on GitHub"
-              className="flex h-10 w-10 items-center justify-center rounded-full text-foreground/80 hover:text-foreground hover:bg-muted transition-all"
+              className="flex h-10 w-10 items-center justify-center rounded-full text-foreground hover:bg-muted transition-all"
             >
               <GithubIcon className="h-6 w-6" />
             </a>

--- a/apps/web/components/ui/emoji-picker.tsx
+++ b/apps/web/components/ui/emoji-picker.tsx
@@ -217,7 +217,58 @@ const AVATAR_GROUPS: EmojiGroup[] = [
   },
 ];
 
-export type EmojiPickerVariant = 'project' | 'avatar';
+// Reactions want a third vocabulary again: not nouns for work and not a
+// character, but the small set of things people actually answer a comment with.
+// Everything else is one click away behind "All emoji".
+const REACTION_GROUPS: EmojiGroup[] = [
+  {
+    label: 'Common',
+    entries: [
+      { emoji: '\u{1F44D}', keywords: 'thumbs up yes agree approve lgtm +1' },
+      { emoji: '\u{1F44E}', keywords: 'thumbs down no disagree reject -1' },
+      { emoji: '\u{2764}\u{FE0F}', keywords: 'heart love like' },
+      { emoji: '\u{1F389}', keywords: 'tada party celebrate shipped done' },
+      { emoji: '\u{1F680}', keywords: 'rocket ship launch shipped fast' },
+      { emoji: '\u{1F440}', keywords: 'eyes looking reviewing watching' },
+      { emoji: '\u{1F525}', keywords: 'fire hot great burn' },
+      { emoji: '\u{1F4AF}', keywords: 'hundred perfect score exactly' },
+      { emoji: '\u{2705}', keywords: 'check done complete resolved fixed' },
+      { emoji: '\u{274C}', keywords: 'cross no wrong failed broken' },
+      { emoji: '\u{1F914}', keywords: 'thinking hmm unsure question' },
+      { emoji: '\u{1F64F}', keywords: 'pray thanks please thank you' },
+    ],
+  },
+  {
+    label: 'Faces',
+    entries: [
+      { emoji: '\u{1F604}', keywords: 'smile happy grin laugh' },
+      { emoji: '\u{1F602}', keywords: 'joy laughing tears funny lol' },
+      { emoji: '\u{1F60D}', keywords: 'heart eyes love adore' },
+      { emoji: '\u{1F62E}', keywords: 'surprised wow open mouth' },
+      { emoji: '\u{1F622}', keywords: 'cry sad tear' },
+      { emoji: '\u{1F621}', keywords: 'angry mad rage' },
+      { emoji: '\u{1F605}', keywords: 'sweat smile nervous phew close call' },
+      { emoji: '\u{1F643}', keywords: 'upside down irony sarcasm' },
+      { emoji: '\u{1F9D0}', keywords: 'monocle inspect scrutiny suspicious' },
+      { emoji: '\u{1F634}', keywords: 'sleeping tired boring zzz' },
+    ],
+  },
+  {
+    label: 'Work',
+    entries: [
+      { emoji: '\u{1F41B}', keywords: 'bug defect issue broken' },
+      { emoji: '\u{1F6A2}', keywords: 'ship shipped release deploy' },
+      { emoji: '\u{1F6A8}', keywords: 'siren alert urgent incident' },
+      { emoji: '\u{1F44F}', keywords: 'clap applause well done nice' },
+      { emoji: '\u{1F91D}', keywords: 'handshake agree deal thanks' },
+      { emoji: '\u{1F4A1}', keywords: 'idea bulb suggestion insight' },
+      { emoji: '\u{26A0}\u{FE0F}', keywords: 'warning caution careful risk' },
+      { emoji: '\u{1F6D1}', keywords: 'stop blocked halt' },
+    ],
+  },
+];
+
+export type EmojiPickerVariant = 'project' | 'avatar' | 'reaction';
 
 /** The full Unicode set, grouped, as `unicode-emoji-json` ships it. */
 type RawEmojiGroup = {
@@ -264,6 +315,7 @@ async function loadFullEmojiGroups(): Promise<EmojiGroup[]> {
 const GROUPS_BY_VARIANT: Record<EmojiPickerVariant, EmojiGroup[]> = {
   project: PROJECT_GROUPS,
   avatar: AVATAR_GROUPS,
+  reaction: REACTION_GROUPS,
 };
 
 export function EmojiPicker({

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -505,6 +505,12 @@ export interface TaskReactionSummary {
 export interface TaskCommentResponse {
   id: string;
   task_id: string;
+  /**
+   * The root this comment answers, or null when it is one. Threads are one
+   * level deep, so this always names a root — never another reply. The list
+   * arrives in thread order: each root immediately followed by its replies.
+   */
+  parent_comment_id: string | null;
   author: PrincipalResponse;
   /** null once soft-deleted; render a tombstone, not an empty comment. */
   body: string | null;
@@ -1487,10 +1493,15 @@ class BackendAPI {
   // Every mutation below answers with the whole timeline: the caller was going
   // to revalidate anyway, and it closes the window where an optimistic append
   // and a background poll disagree about ordering.
-  async createTaskComment(taskId: string, body: string): Promise<TaskTimelineResponse> {
+  async createTaskComment(
+    taskId: string,
+    body: string,
+    /** Reply into this comment's thread. Replying to a reply lands in the same thread. */
+    parentCommentId?: string,
+  ): Promise<TaskTimelineResponse> {
     return this.request<TaskTimelineResponse>(`/api/v1/tasks/${taskId}/comments`, {
       method: 'POST',
-      body: JSON.stringify({ body }),
+      body: JSON.stringify({ body, parent_comment_id: parentCommentId ?? null }),
     });
   }
 

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -420,6 +420,13 @@ export interface ProjectDirectory {
 export interface ProjectResponse {
   id: string;
   name: string;
+  /**
+   * Task-identifier prefix — "VIC" makes this project's tasks read "VIC-42".
+   * Auto-derived on the project's first task, so it is null for a project that
+   * has never held one. Editable in project settings; unique within the owner,
+   * never globally.
+   */
+  key: string | null;
   git_remote_url: string | null;
   color: string | null;
   icon: string | null;
@@ -448,20 +455,75 @@ export interface TaskLabelResponse {
   color: string;
 }
 
+/** A user or an agent, in the one shape `<PrincipalAvatar>` renders. */
+export interface PrincipalResponse {
+  type: 'user' | 'agent' | 'system';
+  id: string | null;
+  name: string | null;
+  avatar_image_uri: string | null;
+  emoji: string | null;
+  updated_at: string | null;
+}
+
 export interface TaskResponse {
   id: string;
   project_id: string;
+  /** Per-project sequential number; null for a task that predates the backfill. */
+  number: number | null;
+  /** "VIC-42" — null when the project has no key or the task has no number. */
+  identifier: string | null;
   title: string;
   description: string | null;
   status: TaskStatus;
   priority: TaskPriority;
   position: number;
   parent_task_id: string | null;
+  /** Denormalized so a sub-task can say "Part of: <title>" without a refetch. */
+  parent_title: string | null;
+  assignee_type: 'user' | 'agent' | null;
+  assignee_id: string | null;
+  assignee: PrincipalResponse | null;
   labels: TaskLabelResponse[];
   start_date: string | null;
   due_date: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface TaskReactionSummary {
+  emoji: string;
+  count: number;
+  /** Whether the signed-in user is one of them — drives the pill's filled state. */
+  reacted: boolean;
+}
+
+export interface TaskCommentResponse {
+  id: string;
+  task_id: string;
+  author: PrincipalResponse;
+  /** null once soft-deleted; render a tombstone, not an empty comment. */
+  body: string | null;
+  kind: 'comment' | 'system';
+  reactions: TaskReactionSummary[];
+  created_at: string;
+  edited_at: string | null;
+  deleted_at: string | null;
+}
+
+export interface TaskActivityResponse {
+  id: string;
+  /** null when the change had no request context (a background sweep). */
+  actor: PrincipalResponse | null;
+  action: string;
+  details: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface TaskTimelineResponse {
+  comments: TaskCommentResponse[];
+  activity: TaskActivityResponse[];
+  /** Reactions on the task itself, not on any comment. */
+  reactions: TaskReactionSummary[];
 }
 
 export interface CreateProjectRequest {
@@ -504,6 +566,9 @@ export interface UpdateTaskRequest {
   label_ids?: string[];
   start_date?: string | null;
   due_date?: string | null;
+  /** The pair moves together — the backend rejects one without the other. */
+  assignee_type?: 'user' | 'agent' | null;
+  assignee_id?: string | null;
 }
 
 export interface CreateTaskLabelRequest {
@@ -1407,6 +1472,53 @@ class BackendAPI {
   /** Agent sessions started from this task, most recent first. */
   async listTaskSessions(taskId: string): Promise<AgentInstanceResponse[]> {
     return this.request<AgentInstanceResponse[]>(`/api/v1/tasks/${taskId}/sessions`);
+  }
+
+  /** Comments + activity in one round trip (no WS channel for tasks). */
+  async getTaskTimeline(taskId: string): Promise<TaskTimelineResponse> {
+    return this.request<TaskTimelineResponse>(`/api/v1/tasks/${taskId}/timeline`);
+  }
+
+  // Every mutation below answers with the whole timeline: the caller was going
+  // to revalidate anyway, and it closes the window where an optimistic append
+  // and a background poll disagree about ordering.
+  async createTaskComment(taskId: string, body: string): Promise<TaskTimelineResponse> {
+    return this.request<TaskTimelineResponse>(`/api/v1/tasks/${taskId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async updateTaskComment(
+    taskId: string,
+    commentId: string,
+    body: string,
+  ): Promise<TaskTimelineResponse> {
+    return this.request<TaskTimelineResponse>(
+      `/api/v1/tasks/${taskId}/comments/${commentId}`,
+      { method: 'PATCH', body: JSON.stringify({ body }) },
+    );
+  }
+
+  async deleteTaskComment(taskId: string, commentId: string): Promise<TaskTimelineResponse> {
+    return this.request<TaskTimelineResponse>(
+      `/api/v1/tasks/${taskId}/comments/${commentId}`,
+      { method: 'DELETE' },
+    );
+  }
+
+  async toggleTaskReaction(
+    taskId: string,
+    target: { targetType: 'task' | 'comment'; targetId: string; emoji: string },
+  ): Promise<TaskTimelineResponse> {
+    return this.request<TaskTimelineResponse>(`/api/v1/tasks/${taskId}/reactions`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        target_type: target.targetType,
+        target_id: target.targetId,
+        emoji: target.emoji,
+      }),
+    });
   }
 
   async updateTask(taskId: string, data: UpdateTaskRequest): Promise<TaskResponse> {

--- a/apps/web/lib/backend-api.ts
+++ b/apps/web/lib/backend-api.ts
@@ -495,6 +495,11 @@ export interface TaskReactionSummary {
   count: number;
   /** Whether the signed-in user is one of them — drives the pill's filled state. */
   reacted: boolean;
+  /**
+   * Who reacted, oldest first, capped server-side. `count` is the true total,
+   * so "and N others" is the difference.
+   */
+  reactors: PrincipalResponse[];
 }
 
 export interface TaskCommentResponse {

--- a/apps/web/lib/principals.test.ts
+++ b/apps/web/lib/principals.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { principalAvatarSrc, principalColor, principalInitial } from './principals';
+import {
+  principalAvatarSrc,
+  principalColor,
+  principalDisplayName,
+  principalForAvatar,
+  principalInitial,
+} from './principals';
 import { projectAvatarColor } from './project-icons';
 
 describe('principalAvatarSrc', () => {
@@ -68,5 +74,67 @@ describe('principalInitial', () => {
     expect(principalInitial('')).toBeNull();
     expect(principalInitial('   ')).toBeNull();
     expect(principalInitial(null)).toBeNull();
+  });
+});
+
+describe('principalDisplayName', () => {
+  const viewer = { type: 'user' as const, id: 'u1', name: 'test1@gmail.com' };
+
+  it('prefers the principal own name', () => {
+    expect(principalDisplayName({ type: 'user', id: 'u2', name: 'Ada' }, viewer)).toBe('Ada');
+  });
+
+  it('falls back to the viewer own label for the viewer', () => {
+    // display_name is null on plenty of accounts (an email/password signup
+    // carries no full name). Showing the signed-in user "Unknown" about their
+    // own comment is the bug this exists to prevent.
+    expect(principalDisplayName({ type: 'user', id: 'u1', name: null }, viewer)).toBe(
+      'test1@gmail.com',
+    );
+  });
+
+  it('says You when even the viewer has no label', () => {
+    expect(
+      principalDisplayName({ type: 'user', id: 'u1', name: null }, { type: 'user', id: 'u1' }),
+    ).toBe('You');
+  });
+
+  it('does not borrow the viewer label for someone else', () => {
+    expect(principalDisplayName({ type: 'user', id: 'u2', name: null }, viewer)).toBe('Unknown');
+  });
+
+  it('names a nameless agent as an agent', () => {
+    expect(principalDisplayName({ type: 'agent', id: 'a1', name: null }, viewer)).toBe('Agent');
+  });
+});
+
+describe('principalForAvatar', () => {
+  const viewer = { type: 'user' as const, id: 'u1', name: 'test1@gmail.com' };
+
+  it('keeps a real name so the monogram is drawn', () => {
+    const out = principalForAvatar({ type: 'user', id: 'u2', name: 'Ada' }, viewer);
+    expect(out.name).toBe('Ada');
+  });
+
+  it('lends the viewer their own label', () => {
+    // The account menu already seeds a letter from the email when display_name
+    // is null; the timeline must not render the same person as a blank glyph.
+    const out = principalForAvatar({ type: 'user', id: 'u1', name: null }, viewer);
+    expect(out.name).toBe('test1@gmail.com');
+  });
+
+  it('leaves a nameless stranger nameless, so the glyph wins', () => {
+    // "Unknown"/"Deleted user" must never become a monogram: a letter is an
+    // identity mark, and there is no identity here to mark.
+    const out = principalForAvatar({ type: 'user', id: 'u2', name: null }, viewer);
+    expect(out.name).toBeNull();
+  });
+
+  it('does not invent a letter when the viewer has no label either', () => {
+    const out = principalForAvatar(
+      { type: 'user', id: 'u1', name: null },
+      { type: 'user', id: 'u1' },
+    );
+    expect(out.name).toBeNull();
   });
 });

--- a/apps/web/lib/principals.ts
+++ b/apps/web/lib/principals.ts
@@ -55,6 +55,90 @@ export function principalAvatarSrc(principal: Principal | null | undefined): str
   return `/api/${base}/${principal.id}/avatar${version}`;
 }
 
+/**
+ * Map the backend's `PrincipalResponse` onto the client shape.
+ *
+ * The two disagree on one field name — `avatar_image_uri` on the wire (it
+ * mirrors the DB column) versus `avatarImageUri` here — and §8.1 asked whoever
+ * shipped the first backend serializer to pick one and make the other follow
+ * rather than let them drift. This is that one place; nothing else should be
+ * hand-rolling the conversion.
+ */
+export function principalFromResponse(
+  response: {
+    type: 'user' | 'agent' | 'system';
+    id: string | null;
+    name: string | null;
+    avatar_image_uri: string | null;
+    emoji: string | null;
+    updated_at: string | null;
+  } | null
+  | undefined,
+): Principal | null {
+  if (!response) return null;
+  return {
+    // 'system' is an actor, not a principal that can hold an avatar; it falls
+    // back to the agent glyph, which is what an automated action reads as.
+    type: response.type === 'system' ? 'agent' : response.type,
+    id: response.id,
+    name: response.name,
+    avatarImageUri: response.avatar_image_uri,
+    emoji: response.emoji,
+    updatedAt: response.updated_at,
+  };
+}
+
+/**
+ * What to call a principal on screen.
+ *
+ * `users.display_name` is nullable and a lot of accounts have none (an
+ * email/password signup carries no full name), so the raw name is often null
+ * and "Unknown" is the wrong thing to show someone about themselves. The
+ * backend deliberately does NOT fall back to the email — that serializer also
+ * feeds shared and public surfaces, where §10.4 says an email may never appear.
+ *
+ * The viewer is the one principal whose email is already on screen in their own
+ * chrome, so the fallback is resolved here, client-side, and only for them.
+ */
+export function principalDisplayName(
+  principal: Principal | null | undefined,
+  viewer?: Principal | null,
+): string {
+  const name = principal?.name?.trim();
+  if (name) return name;
+  if (viewer && principal?.id && principal.id === viewer.id) {
+    const own = viewer.name?.trim();
+    if (own) return own;
+    return 'You';
+  }
+  return principal?.type === 'agent' ? 'Agent' : 'Unknown';
+}
+
+/**
+ * The principal to hand `<PrincipalAvatar>`, with the viewer fallback applied.
+ *
+ * Separate from `principalDisplayName` because the avatar wants a *real* name or
+ * nothing at all. A letter is a better fallback than the generic glyph — the
+ * account menu already seeds one from the email when `display_name` is null, and
+ * a row reading "test1@gmail.com" next to a featureless person icon is the same
+ * identity rendered two different ways on one screen.
+ *
+ * But only when the name is real. Seeding a monogram from "You" would stamp a Y
+ * on every author, and seeding one from "Deleted user" invents an identity mark
+ * for someone who is not there. Those keep the glyph, which is the honest
+ * rendering of "we don't know who this is".
+ */
+export function principalForAvatar(
+  principal: Principal | null | undefined,
+  viewer?: Principal | null,
+): Principal {
+  if (!principal) return { type: 'user' };
+  if (principal.name?.trim()) return principal;
+  const isViewer = !!viewer && !!principal.id && principal.id === viewer.id;
+  const own = viewer?.name?.trim();
+  return isViewer && own ? { ...principal, name: own } : principal;
+}
+
 /** Deterministic palette color for a principal (seeded by id, then name). */
 export function principalColor(principal: Principal): string {
   return projectAvatarColor(principal.id || principal.name || principal.type);

--- a/backend/src/backend/api/tasks.py
+++ b/backend/src/backend/api/tasks.py
@@ -26,17 +26,24 @@ from shared.database.session import get_db
 from shared.images import InvalidImageError, process_image
 
 from ..auth.dependencies import get_current_user
-from ..db import task_queries
+from ..db import task_queries, task_timeline_queries
 from ..db.queries import list_task_instances
+from ..db.task_serializers import serialize_task, serialize_tasks
 from ..db.task_queries import (
+    AssigneeNotFoundError,
     InboxImmutableError,
     LabelNotFoundError,
+    ProjectKeyTakenError,
     MachineNotFoundError,
     ParentTaskError,
     ProjectNotFoundError,
 )
 from ..models import (
     AgentInstanceResponse,
+    CreateTaskCommentRequest,
+    ToggleTaskReactionRequest,
+    TaskTimelineResponse,
+    UpdateTaskCommentRequest,
     CreateProjectRequest,
     CreateTaskLabelRequest,
     CreateTaskRequest,
@@ -120,6 +127,10 @@ def update_project_endpoint(
     except InboxImmutableError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    except ProjectKeyTakenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
         ) from exc
     if project is None:
         raise HTTPException(
@@ -358,7 +369,9 @@ def delete_label_endpoint(
 
 def _raise_task_ref_errors(exc: Exception) -> None:
     """Map task-reference validation errors onto HTTP statuses."""
-    if isinstance(exc, ProjectNotFoundError) or isinstance(exc, LabelNotFoundError):
+    if isinstance(
+        exc, (ProjectNotFoundError, LabelNotFoundError, AssigneeNotFoundError)
+    ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
         ) from exc
@@ -387,7 +400,7 @@ def list_tasks_endpoint(
         status=task_status,
         priority=task_priority,
     )
-    return [TaskResponse.model_validate(t) for t in tasks]
+    return serialize_tasks(db, tasks)
 
 
 @router.post(
@@ -414,11 +427,18 @@ def create_task_endpoint(
             label_ids=request.label_ids,
             start_date=request.start_date,
             due_date=request.due_date,
+            assignee_type=request.assignee_type,
+            assignee_id=request.assignee_id,
         )
-    except (ProjectNotFoundError, LabelNotFoundError, ParentTaskError) as exc:
+    except (
+        ProjectNotFoundError,
+        LabelNotFoundError,
+        ParentTaskError,
+        AssigneeNotFoundError,
+    ) as exc:
         _raise_task_ref_errors(exc)
         raise  # unreachable; keeps the type checker satisfied
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @router.get("/tasks/{task_id}", response_model=TaskResponse)
@@ -432,7 +452,7 @@ def get_task_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @router.get("/tasks/{task_id}/sessions", response_model=list[AgentInstanceResponse])
@@ -459,14 +479,19 @@ def update_task_endpoint(
     fields = request.model_dump(exclude_unset=True)
     try:
         task = task_queries.update_task(db, current_user.id, task_id, fields)
-    except (ProjectNotFoundError, LabelNotFoundError, ParentTaskError) as exc:
+    except (
+        ProjectNotFoundError,
+        LabelNotFoundError,
+        ParentTaskError,
+        AssigneeNotFoundError,
+    ) as exc:
         _raise_task_ref_errors(exc)
         raise  # unreachable; keeps the type checker satisfied
     if task is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -479,3 +504,133 @@ def delete_task_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task timeline — comments, reactions, activity (collaboration §3.5)
+#
+# There is no WebSocket channel for tasks in this phase, by decision (§9):
+# comments ride refresh-on-focus plus a short SWR interval on an open task.
+# Polling hits this stateless, horizontally scalable app; the relay is pinned to
+# workers=1 and already carries every daemon socket.
+# ---------------------------------------------------------------------------
+
+
+def _require_task(db: Session, user_id: UUID, task_id: UUID):
+    """The user-scoped resolve every timeline route starts from.
+
+    The timeline tables carry no `user_id` of their own, so this is what keeps
+    them scoped: nothing below reaches a comment or activity row except through
+    a task this user owns.
+    """
+    task = task_queries.get_task(db, user_id, task_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+    return task
+
+
+@router.get("/tasks/{task_id}/timeline", response_model=TaskTimelineResponse)
+def get_task_timeline_endpoint(
+    task_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    """Comments and activity together — one round trip, one SWR key."""
+    task = _require_task(db, current_user.id, task_id)
+    return task_timeline_queries.build_timeline(db, task, current_user.id)
+
+
+@router.post(
+    "/tasks/{task_id}/comments",
+    response_model=TaskTimelineResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_task_comment_endpoint(
+    task_id: UUID,
+    request: CreateTaskCommentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    """Post a comment and return the whole timeline.
+
+    Returning the timeline rather than the one new comment costs nothing (the
+    caller was about to revalidate anyway) and closes the window where an
+    optimistic append and a background poll disagree about ordering.
+    """
+    task = _require_task(db, current_user.id, task_id)
+    task_timeline_queries.create_comment(db, task, current_user.id, request.body)
+    return task_timeline_queries.build_timeline(db, task, current_user.id)
+
+
+@router.patch(
+    "/tasks/{task_id}/comments/{comment_id}", response_model=TaskTimelineResponse
+)
+def update_task_comment_endpoint(
+    task_id: UUID,
+    comment_id: UUID,
+    request: UpdateTaskCommentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    task = _require_task(db, current_user.id, task_id)
+    try:
+        task_timeline_queries.update_comment(
+            db, task, comment_id, current_user.id, request.body
+        )
+    except task_timeline_queries.CommentNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    return task_timeline_queries.build_timeline(db, task, current_user.id)
+
+
+@router.delete(
+    "/tasks/{task_id}/comments/{comment_id}", response_model=TaskTimelineResponse
+)
+def delete_task_comment_endpoint(
+    task_id: UUID,
+    comment_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    task = _require_task(db, current_user.id, task_id)
+    try:
+        task_timeline_queries.delete_comment(db, task, comment_id, current_user.id)
+    except task_timeline_queries.CommentNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    return task_timeline_queries.build_timeline(db, task, current_user.id)
+
+
+@router.put("/tasks/{task_id}/reactions", response_model=TaskTimelineResponse)
+def toggle_task_reaction_endpoint(
+    task_id: UUID,
+    request: ToggleTaskReactionRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    """Add or remove one emoji. PUT, not POST: the operation is idempotent per
+    (user, target, emoji) — clicking twice lands back where it started."""
+    task = _require_task(db, current_user.id, task_id)
+    if request.target_type == "task" and request.target_id != task.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="target_id must be this task",
+        )
+    try:
+        task_timeline_queries.toggle_reaction(
+            db,
+            current_user.id,
+            request.target_type,
+            request.target_id,
+            request.emoji,
+        )
+    except task_timeline_queries.UnknownReactionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported reaction",
+        ) from exc
+    return task_timeline_queries.build_timeline(db, task, current_user.id)

--- a/backend/src/backend/api/tasks.py
+++ b/backend/src/backend/api/tasks.py
@@ -443,42 +443,35 @@ def create_task_endpoint(
 
 @router.get("/tasks/{task_id}", response_model=TaskResponse)
 def get_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TaskResponse:
-    task = task_queries.get_task(db, current_user.id, task_id)
-    if task is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
-        )
-    return serialize_task(db, task)
+    return serialize_task(db, _require_task(db, current_user.id, task_id))
 
 
 @router.get("/tasks/{task_id}/sessions", response_model=list[AgentInstanceResponse])
 def list_task_sessions_endpoint(
-    task_id: UUID,
+    task_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> list[AgentInstanceResponse]:
     """Agent sessions started from this task, most recent first."""
-    if task_queries.get_task(db, current_user.id, task_id) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
-        )
-    return list_task_instances(db, current_user.id, task_id)
+    task = _require_task(db, current_user.id, task_id)
+    return list_task_instances(db, current_user.id, task.id)
 
 
 @router.patch("/tasks/{task_id}", response_model=TaskResponse)
 def update_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     request: UpdateTaskRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TaskResponse:
     fields = request.model_dump(exclude_unset=True)
+    existing = _require_task(db, current_user.id, task_id)
     try:
-        task = task_queries.update_task(db, current_user.id, task_id, fields)
+        task = task_queries.update_task(db, current_user.id, existing.id, fields)
     except (
         ProjectNotFoundError,
         LabelNotFoundError,
@@ -496,11 +489,12 @@ def update_task_endpoint(
 
 @router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> None:
-    if not task_queries.delete_task(db, current_user.id, task_id):
+    task = _require_task(db, current_user.id, task_id)
+    if not task_queries.delete_task(db, current_user.id, task.id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
@@ -516,14 +510,17 @@ def delete_task_endpoint(
 # ---------------------------------------------------------------------------
 
 
-def _require_task(db: Session, user_id: UUID, task_id: UUID):
-    """The user-scoped resolve every timeline route starts from.
+def _require_task(db: Session, user_id: UUID, task_id: str):
+    """The user-scoped resolve every task route starts from.
 
-    The timeline tables carry no `user_id` of their own, so this is what keeps
-    them scoped: nothing below reaches a comment or activity row except through
-    a task this user owns.
+    Takes the reference as it arrived — a UUID *or* a "VIC-42" identifier, since
+    that is the only handle a person can read off the screen and say out loud.
+
+    It is also what keeps the timeline scoped: those tables carry no `user_id`
+    of their own, so nothing below reaches a comment or activity row except
+    through a task this user owns.
     """
-    task = task_queries.get_task(db, user_id, task_id)
+    task = task_queries.resolve_task(db, user_id, task_id)
     if task is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
@@ -533,7 +530,7 @@ def _require_task(db: Session, user_id: UUID, task_id: UUID):
 
 @router.get("/tasks/{task_id}/timeline", response_model=TaskTimelineResponse)
 def get_task_timeline_endpoint(
-    task_id: UUID,
+    task_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TaskTimelineResponse:
@@ -548,19 +545,32 @@ def get_task_timeline_endpoint(
     status_code=status.HTTP_201_CREATED,
 )
 def create_task_comment_endpoint(
-    task_id: UUID,
+    task_id: str,
     request: CreateTaskCommentRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TaskTimelineResponse:
-    """Post a comment and return the whole timeline.
+    """Post a comment — or a reply to one — and return the whole timeline.
 
     Returning the timeline rather than the one new comment costs nothing (the
     caller was about to revalidate anyway) and closes the window where an
-    optimistic append and a background poll disagree about ordering.
+    optimistic append and a background poll disagree about ordering. With
+    threads it also saves the client from having to splice a reply into the
+    right place itself.
     """
     task = _require_task(db, current_user.id, task_id)
-    task_timeline_queries.create_comment(db, task, current_user.id, request.body)
+    try:
+        task_timeline_queries.create_comment(
+            db,
+            task,
+            current_user.id,
+            request.body,
+            parent_comment_id=request.parent_comment_id,
+        )
+    except task_timeline_queries.CommentNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     return task_timeline_queries.build_timeline(db, task, current_user.id)
 
 
@@ -568,7 +578,7 @@ def create_task_comment_endpoint(
     "/tasks/{task_id}/comments/{comment_id}", response_model=TaskTimelineResponse
 )
 def update_task_comment_endpoint(
-    task_id: UUID,
+    task_id: str,
     comment_id: UUID,
     request: UpdateTaskCommentRequest,
     current_user: User = Depends(get_current_user),
@@ -590,7 +600,7 @@ def update_task_comment_endpoint(
     "/tasks/{task_id}/comments/{comment_id}", response_model=TaskTimelineResponse
 )
 def delete_task_comment_endpoint(
-    task_id: UUID,
+    task_id: str,
     comment_id: UUID,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -607,7 +617,7 @@ def delete_task_comment_endpoint(
 
 @router.put("/tasks/{task_id}/reactions", response_model=TaskTimelineResponse)
 def toggle_task_reaction_endpoint(
-    task_id: UUID,
+    task_id: str,
     request: ToggleTaskReactionRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),

--- a/backend/src/backend/auth/dependencies.py
+++ b/backend/src/backend/auth/dependencies.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from fastapi import BackgroundTasks, Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from shared.database.models import User
+from shared.database.actor import Actor, set_session_actor
 from shared.database.session import get_db
 from shared.database.users import ensure_local_user
 from sqlalchemy.orm import Session
@@ -161,6 +162,12 @@ async def get_current_user(
     if created:
         _schedule_signup_side_effects(background_tasks, user)
     _maybe_seed_avatar(background_tasks, user, claims.avatar_url)
+    # Attribution for anything this request's session flushes (collaboration
+    # §3.5): the task-activity listener has no request context of its own, and
+    # this dependency is the one place every authenticated dashboard route
+    # already passes through. Stamping it here means no endpoint has to
+    # remember to.
+    set_session_actor(db, Actor(type="user", id=user.id))
     return user
 
 

--- a/backend/src/backend/db/task_queries.py
+++ b/backend/src/backend/db/task_queries.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from shared.database import (
@@ -17,10 +18,17 @@ from shared.database import (
     Project,
     ProjectDirectory,
     Task,
+    TaskActivity,
+    TaskComment,
     TaskLabel,
     get_or_create_inbox,
 )
+from shared.database.agent_profile_models import AgentProfile
 from shared.database.project_matching import backfill_project_id_for_directory
+from shared.database.task_identity import (
+    allocate_task_number,
+    ensure_project_key_committed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +54,16 @@ class ProjectNotFoundError(Exception):
     """Raised when a referenced project doesn't exist or isn't the user's."""
 
 
+class ProjectKeyTakenError(Exception):
+    """Another of this owner's projects already holds that task key."""
+
+
 class LabelNotFoundError(Exception):
     """Raised when a referenced label doesn't exist or isn't the user's."""
+
+
+class AssigneeNotFoundError(Exception):
+    """The assignee isn't the requesting user or one of their agent profiles."""
 
 
 class ParentTaskError(Exception):
@@ -241,10 +257,17 @@ def update_project(
         if archived != project.is_archived:
             project.is_archived = archived
             project.archived_at = datetime.now(timezone.utc) if archived else None
-    for key in ("name", "color", "icon", "git_remote_url"):
-        if key in fields:
-            setattr(project, key, fields[key])
-    db.commit()
+    for field in ("name", "color", "icon", "git_remote_url", "key"):
+        if field in fields:
+            setattr(project, field, fields[field])
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        # The only unique constraint reachable from here is the task key, which
+        # is unique within the owner. Surface it as a conflict rather than a 500
+        # so the settings form can say "that key is taken".
+        db.rollback()
+        raise ProjectKeyTakenError("That project key is already in use") from exc
     return project
 
 
@@ -411,6 +434,30 @@ def _resolve_labels(
     return labels
 
 
+def _validate_assignee(
+    db: Session, user_id: UUID, assignee_type: str | None, assignee_id: UUID | None
+) -> None:
+    """A task may only be assigned to a principal this user can actually see.
+
+    Today that is themselves or one of their own agent profiles. When P3 lands
+    project grants this grows a "…or a grantee on the task's project" branch —
+    it is deliberately one function so that stays a single edit.
+    """
+    if assignee_type is None or assignee_id is None:
+        return
+    if assignee_type == "user":
+        if assignee_id != user_id:
+            raise AssigneeNotFoundError("Assignee not found")
+        return
+    owned = (
+        db.query(AgentProfile.id)
+        .filter(AgentProfile.id == assignee_id, AgentProfile.user_id == user_id)
+        .first()
+    )
+    if owned is None:
+        raise AssigneeNotFoundError("Assignee not found")
+
+
 def _validate_parent(
     db: Session, user_id: UUID, task_id: UUID | None, parent_id: UUID
 ) -> None:
@@ -474,6 +521,8 @@ def create_task(
     label_ids: list[UUID] | None = None,
     start_date: datetime | None = None,
     due_date: datetime | None = None,
+    assignee_type: str | None = None,
+    assignee_id: UUID | None = None,
 ) -> Task:
     """Create a task; without an explicit project it lands in the Inbox."""
     if project_id is None:
@@ -485,10 +534,21 @@ def create_task(
 
     if parent_task_id is not None:
         _validate_parent(db, user_id, None, parent_task_id)
+    _validate_assignee(db, user_id, assignee_type, assignee_id)
+    # Resolve labels before taking a number: _resolve_labels raises on an
+    # unknown label, and a rejected create should not burn an identifier.
+    labels = _resolve_labels(db, user_id, label_ids or [])
+
+    # Identity (§3.5). The key is allocated lazily, on the project's first task,
+    # in its own savepoint; the number comes from UPDATE ... RETURNING on the
+    # counter, whose row lock serializes concurrent inserts into this project.
+    ensure_project_key_committed(db, project)
+    number = allocate_task_number(db, project)
 
     task = Task(
         user_id=user_id,
         project_id=project.id,
+        number=number,
         title=title,
         description=description,
         status=status,
@@ -497,9 +557,11 @@ def create_task(
         parent_task_id=parent_task_id,
         start_date=start_date,
         due_date=due_date,
+        assignee_type=assignee_type,
+        assignee_id=assignee_id,
     )
-    if label_ids:
-        task.labels = _resolve_labels(db, user_id, label_ids)
+    if labels:
+        task.labels = labels
     db.add(task)
     db.commit()
     return task
@@ -528,7 +590,23 @@ def update_task(db: Session, user_id: UUID, task_id: UUID, fields: dict) -> Task
             project = _get_project(db, user_id, project_id)
             if project is None:
                 raise ProjectNotFoundError("Project not found")
-        task.project_id = project.id
+        if project.id != task.project_id:
+            # Moving a task reassigns BOTH halves of its identifier — GitHub does
+            # the same on issue transfer, and D-B accepts the cost: "VIC-42"
+            # written in an old comment goes stale. The number it vacates is
+            # never reused; counters only ever climb.
+            #
+            # The child rows carry a denormalized project_id (so P3 can add a
+            # project-level access predicate without a join), so they have to
+            # move too — a comment left pointing at the old project would be
+            # readable through a grant on a project it no longer belongs to.
+            ensure_project_key_committed(db, project)
+            for model in (TaskComment, TaskActivity):
+                db.query(model).filter(model.task_id == task.id).update(
+                    {"project_id": project.id}, synchronize_session=False
+                )
+            task.project_id = project.id
+            task.number = allocate_task_number(db, project)
 
     if "parent_task_id" in fields:
         parent_id = fields.pop("parent_task_id")
@@ -539,6 +617,19 @@ def update_task(db: Session, user_id: UUID, task_id: UUID, fields: dict) -> Task
     if "label_ids" in fields:
         label_ids = fields.pop("label_ids") or []
         task.labels = _resolve_labels(db, user_id, label_ids)
+
+    # The assignee pair moves together (the request model enforces that both are
+    # present or both null), so one branch applies both columns.
+    if "assignee_type" in fields or "assignee_id" in fields:
+        assignee_type = fields.pop("assignee_type", task.assignee_type)
+        assignee_id = fields.pop("assignee_id", task.assignee_id)
+        _validate_assignee(db, user_id, assignee_type, assignee_id)
+        task.assignee_type = assignee_type
+        task.assignee_id = assignee_id
+        if assignee_type == "user" and assignee_id is not None:
+            from .task_timeline_queries import subscribe
+
+            subscribe(db, task.id, assignee_id, "assignee")
 
     for key in (
         "title",

--- a/backend/src/backend/db/task_queries.py
+++ b/backend/src/backend/db/task_queries.py
@@ -5,6 +5,7 @@ bucket: lazily created, never archivable or deletable.
 """
 
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
@@ -572,6 +573,50 @@ def get_task(db: Session, user_id: UUID, task_id: UUID) -> Task | None:
         db.query(Task)
         .options(selectinload(Task.labels))
         .filter(Task.id == task_id, Task.user_id == user_id)
+        .first()
+    )
+
+
+# "VIC-42" — a project key (2-8 chars, letter-led) and a per-project number.
+# Deliberately not anchored to the key length the deriver produces: a key is
+# user-editable, and a resolver that rejected what the editor accepted would be
+# the worse of the two bugs.
+_IDENTIFIER_RE = re.compile(r"^([A-Za-z][A-Za-z0-9]{1,7})-([0-9]+)$")
+
+
+def resolve_task(db: Session, user_id: UUID, ref: str) -> Task | None:
+    """Find one of `user_id`'s tasks by UUID **or** by its "VIC-42" identifier.
+
+    Every surface where a person or an agent types a task reference goes through
+    here, because the identifier is the only handle either of them can actually
+    see: it is what the task-detail header shows, what `vicoa task ls` prints,
+    and what someone says out loud. A UUID is an implementation detail that
+    happens to be in a URL. Both are accepted — the web already holds UUIDs and
+    should not have to translate.
+
+    The key is matched case-insensitively and scoped to `user_id`, which is also
+    what makes it unambiguous: keys are unique per owner, not globally, so
+    "VIC-1" means a different task in a different account and neither can reach
+    the other.
+    """
+    ref = (ref or "").strip()
+    try:
+        return get_task(db, user_id, UUID(ref))
+    except ValueError:
+        pass
+    match = _IDENTIFIER_RE.match(ref)
+    if match is None:
+        return None
+    key, number = match.group(1), int(match.group(2))
+    return (
+        db.query(Task)
+        .options(selectinload(Task.labels))
+        .join(Project, Project.id == Task.project_id)
+        .filter(
+            Task.user_id == user_id,
+            func.upper(Project.key) == key.upper(),
+            Task.number == number,
+        )
         .first()
     )
 

--- a/backend/src/backend/db/task_serializers.py
+++ b/backend/src/backend/db/task_serializers.py
@@ -1,0 +1,65 @@
+"""TaskResponse assembly — the three fields a task can't answer alone.
+
+`identifier` needs the project's key, `parent_title` needs the parent row, and
+`assignee` needs a users/agent_profiles lookup. Doing those per task would be
+three extra queries per row, so everything here is batched: one pass over a
+whole list costs three queries total, and the single-task path is the same
+function with a list of one.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from shared.database import Project, Task
+from shared.database.task_identity import format_task_identifier
+
+from ..models import TaskResponse
+from .task_timeline_queries import PrincipalRef, resolve_principals
+
+
+def serialize_tasks(db: Session, tasks: list[Task]) -> list[TaskResponse]:
+    if not tasks:
+        return []
+
+    project_ids = {t.project_id for t in tasks}
+    keys: dict[UUID, str | None] = {
+        row[0]: row[1]
+        for row in db.query(Project.id, Project.key)
+        .filter(Project.id.in_(project_ids))
+        .all()
+    }
+
+    parent_ids = {t.parent_task_id for t in tasks if t.parent_task_id is not None}
+    parent_titles: dict[UUID, str] = {
+        row[0]: row[1]
+        for row in (
+            db.query(Task.id, Task.title).filter(Task.id.in_(parent_ids)).all()
+            if parent_ids
+            else []
+        )
+    }
+
+    refs: set[PrincipalRef] = {
+        (t.assignee_type, t.assignee_id)
+        for t in tasks
+        if t.assignee_type is not None and t.assignee_id is not None
+    }
+    principals = resolve_principals(db, refs) if refs else {}
+
+    out: list[TaskResponse] = []
+    for task in tasks:
+        response = TaskResponse.model_validate(task)
+        response.identifier = format_task_identifier(
+            keys.get(task.project_id), task.number
+        )
+        if task.parent_task_id is not None:
+            response.parent_title = parent_titles.get(task.parent_task_id)
+        if task.assignee_type is not None and task.assignee_id is not None:
+            response.assignee = principals.get((task.assignee_type, task.assignee_id))
+        out.append(response)
+    return out
+
+
+def serialize_task(db: Session, task: Task) -> TaskResponse:
+    return serialize_tasks(db, [task])[0]

--- a/backend/src/backend/db/task_timeline_queries.py
+++ b/backend/src/backend/db/task_timeline_queries.py
@@ -1,0 +1,309 @@
+"""Task timeline — comments, reactions, activity, subscribers (collab §3.5).
+
+Kept out of `task_queries` because that module is already the projects+tasks
+CRUD surface and this is a second, differently-shaped concern.
+
+**Scoping.** None of these tables carries `user_id` — a comment's author need
+not be the task's owner once sharing lands, so there is no single owning user to
+filter on. Every entry point here therefore takes an already-resolved `Task`
+that the caller obtained through the user-scoped `task_queries.get_task`, which
+is what keeps the house rule intact.
+"""
+
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from shared.database import (
+    Task,
+    TaskActivity,
+    TaskComment,
+    TaskReaction,
+    TaskSubscriber,
+    User,
+)
+from shared.database.agent_profile_models import AgentProfile
+from shared.database.reactions import is_emoji
+
+from ..models import (
+    PrincipalResponse,
+    TaskActivityResponse,
+    TaskCommentResponse,
+    TaskReactionSummary,
+    TaskTimelineResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# A principal reference as it appears on a row: ('user' | 'agent', id).
+PrincipalRef = tuple[str, UUID]
+
+
+class CommentNotFoundError(Exception):
+    """The comment doesn't exist, isn't on this task, or is already deleted."""
+
+
+class UnknownReactionError(Exception):
+    """The reaction value isn't an emoji."""
+
+
+class AssigneeNotFoundError(Exception):
+    """The assignee isn't one of this user's users/agent profiles."""
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# --- Principals -------------------------------------------------------------
+
+
+def resolve_principals(
+    db: Session, refs: set[PrincipalRef]
+) -> dict[PrincipalRef, PrincipalResponse]:
+    """Batch-resolve (type, id) pairs to renderable principals.
+
+    Two queries for a whole page rather than one per row. A reference that no
+    longer resolves (deleted user, deleted agent profile) is returned as a
+    named-but-idless principal so the thread stays readable instead of showing
+    a blank author.
+    """
+    resolved: dict[PrincipalRef, PrincipalResponse] = {}
+    user_ids = {rid for kind, rid in refs if kind == "user"}
+    agent_ids = {rid for kind, rid in refs if kind == "agent"}
+
+    if user_ids:
+        for user in db.query(User).filter(User.id.in_(user_ids)).all():
+            resolved[("user", user.id)] = PrincipalResponse(
+                type="user",
+                id=user.id,
+                # display_name only — an email must never reach a shared or
+                # public surface (§10.4), and this serializer feeds both.
+                name=user.display_name,
+                avatar_image_uri=user.avatar_image_uri,
+                emoji=user.avatar_emoji,
+                updated_at=user.updated_at,
+            )
+    if agent_ids:
+        for profile in (
+            db.query(AgentProfile).filter(AgentProfile.id.in_(agent_ids)).all()
+        ):
+            resolved[("agent", profile.id)] = PrincipalResponse(
+                type="agent",
+                id=profile.id,
+                name=profile.name,
+                avatar_image_uri=profile.avatar_image_uri,
+                emoji=profile.emoji,
+                updated_at=profile.updated_at,
+            )
+
+    for ref in refs:
+        if ref not in resolved:
+            kind, _ = ref
+            resolved[ref] = PrincipalResponse(
+                type="user" if kind == "user" else "agent",
+                id=None,
+                name="Deleted user" if kind == "user" else "Deleted agent",
+            )
+    return resolved
+
+
+# --- Reactions --------------------------------------------------------------
+
+
+def _reaction_summaries(
+    db: Session, user_id: UUID, targets: list[tuple[str, UUID]]
+) -> dict[tuple[str, UUID], list[TaskReactionSummary]]:
+    """Counts per (target, emoji) plus whether `user_id` is among them."""
+    if not targets:
+        return {}
+    target_ids = [tid for _, tid in targets]
+    rows = db.execute(
+        select(
+            TaskReaction.target_type,
+            TaskReaction.target_id,
+            TaskReaction.emoji,
+            func.count().label("n"),
+            func.bool_or(TaskReaction.user_id == user_id).label("mine"),
+        )
+        .where(TaskReaction.target_id.in_(target_ids))
+        .group_by(TaskReaction.target_type, TaskReaction.target_id, TaskReaction.emoji)
+    ).all()
+
+    out: dict[tuple[str, UUID], list[TaskReactionSummary]] = {}
+    for target_type, target_id, emoji, count, mine in rows:
+        out.setdefault((target_type, target_id), []).append(
+            TaskReactionSummary(emoji=emoji, count=int(count), reacted=bool(mine))
+        )
+    # Most-used first, then by emoji so ties don't shuffle between renders.
+    # There is no offered-set order to sort by any more — reactions are open.
+    for summaries in out.values():
+        summaries.sort(key=lambda s: (-s.count, s.emoji))
+    return out
+
+
+def toggle_reaction(
+    db: Session, user_id: UUID, target_type: str, target_id: UUID, emoji: str
+) -> bool:
+    """Add the reaction, or remove it if it's already there. True = now on."""
+    if not is_emoji(emoji):
+        raise UnknownReactionError(emoji)
+    existing = (
+        db.query(TaskReaction)
+        .filter(
+            TaskReaction.target_type == target_type,
+            TaskReaction.target_id == target_id,
+            TaskReaction.user_id == user_id,
+            TaskReaction.emoji == emoji,
+        )
+        .first()
+    )
+    if existing is not None:
+        db.delete(existing)
+        db.commit()
+        return False
+    db.add(
+        TaskReaction(
+            target_type=target_type,
+            target_id=target_id,
+            user_id=user_id,
+            emoji=emoji,
+        )
+    )
+    db.commit()
+    return True
+
+
+# --- Subscribers ------------------------------------------------------------
+
+
+def subscribe(db: Session, task_id: UUID, user_id: UUID, reason: str) -> None:
+    """Idempotent auto-subscribe. The first reason wins — an explicit 'manual'
+    is never downgraded by a later automatic one."""
+    existing = (
+        db.query(TaskSubscriber)
+        .filter(TaskSubscriber.task_id == task_id, TaskSubscriber.user_id == user_id)
+        .first()
+    )
+    if existing is not None:
+        return
+    db.add(TaskSubscriber(task_id=task_id, user_id=user_id, reason=reason))
+
+
+# --- Comments ---------------------------------------------------------------
+
+
+def create_comment(db: Session, task: Task, user_id: UUID, body: str) -> TaskComment:
+    comment = TaskComment(
+        task_id=task.id,
+        project_id=task.project_id,
+        author_type="user",
+        author_id=user_id,
+        body=body,
+    )
+    db.add(comment)
+    subscribe(db, task.id, user_id, "commenter")
+    db.commit()
+    return comment
+
+
+def _own_comment(db: Session, task: Task, comment_id: UUID, user_id: UUID):
+    comment = (
+        db.query(TaskComment)
+        .filter(TaskComment.id == comment_id, TaskComment.task_id == task.id)
+        .first()
+    )
+    if comment is None or comment.deleted_at is not None:
+        raise CommentNotFoundError("Comment not found")
+    # Editing and deleting are the author's alone — the task owner does not
+    # inherit the right to rewrite someone else's words.
+    if comment.author_type != "user" or comment.author_id != user_id:
+        raise CommentNotFoundError("Comment not found")
+    return comment
+
+
+def update_comment(
+    db: Session, task: Task, comment_id: UUID, user_id: UUID, body: str
+) -> TaskComment:
+    comment = _own_comment(db, task, comment_id, user_id)
+    comment.body = body
+    comment.edited_at = _utcnow()
+    db.commit()
+    return comment
+
+
+def delete_comment(db: Session, task: Task, comment_id: UUID, user_id: UUID) -> None:
+    """Soft delete: the row stays so the thread keeps its shape and reactions
+    and cross-references don't dangle; the text stops being served."""
+    comment = _own_comment(db, task, comment_id, user_id)
+    comment.deleted_at = _utcnow()
+    db.commit()
+
+
+# --- Timeline ---------------------------------------------------------------
+
+
+def build_timeline(db: Session, task: Task, user_id: UUID) -> TaskTimelineResponse:
+    """Everything the task-detail timeline renders, in one round trip."""
+    comments = (
+        db.query(TaskComment)
+        .filter(TaskComment.task_id == task.id)
+        .order_by(TaskComment.created_at.asc())
+        .all()
+    )
+    activity = (
+        db.query(TaskActivity)
+        .filter(TaskActivity.task_id == task.id)
+        .order_by(TaskActivity.created_at.asc())
+        .all()
+    )
+
+    refs: set[PrincipalRef] = {(c.author_type, c.author_id) for c in comments}
+    refs |= {
+        (str(a.actor_type), a.actor_id)
+        for a in activity
+        if a.actor_type in ("user", "agent") and a.actor_id is not None
+    }
+    principals = resolve_principals(db, refs)
+    reactions = _reaction_summaries(
+        db, user_id, [("comment", c.id) for c in comments] + [("task", task.id)]
+    )
+
+    return TaskTimelineResponse(
+        reactions=reactions.get(("task", task.id), []),
+        comments=[
+            TaskCommentResponse(
+                id=c.id,
+                task_id=c.task_id,
+                author=principals[(c.author_type, c.author_id)],
+                body=None if c.deleted_at else c.body,
+                kind="system" if c.kind == "system" else "comment",
+                reactions=reactions.get(("comment", c.id), []),
+                created_at=c.created_at,
+                edited_at=c.edited_at,
+                deleted_at=c.deleted_at,
+            )
+            for c in comments
+        ],
+        activity=[
+            TaskActivityResponse(
+                id=a.id,
+                actor=(
+                    principals.get((str(a.actor_type), a.actor_id))
+                    if a.actor_id is not None
+                    else (
+                        PrincipalResponse(type="system", name="Vicoa")
+                        if a.actor_type == "system"
+                        else None
+                    )
+                ),
+                action=a.action,
+                details=a.details or {},
+                created_at=a.created_at,
+            )
+            for a in activity
+        ],
+    )

--- a/backend/src/backend/db/task_timeline_queries.py
+++ b/backend/src/backend/db/task_timeline_queries.py
@@ -223,16 +223,61 @@ def subscribe(db: Session, task_id: UUID, user_id: UUID, reason: str) -> None:
 # --- Comments ---------------------------------------------------------------
 
 
-def create_comment(db: Session, task: Task, user_id: UUID, body: str) -> TaskComment:
+def resolve_thread_root(db: Session, task: Task, parent_comment_id: UUID) -> UUID:
+    """The root a reply to `parent_comment_id` should hang off.
+
+    Threads are one level deep (see `TaskComment`), so a reply *to a reply* is
+    re-pointed at that reply's root rather than rejected: the person clicking
+    "Reply" under a nested comment means "answer in this thread", and refusing
+    them would be a rule about our schema, not about what they asked for.
+    """
+    parent = (
+        db.query(TaskComment)
+        .filter(TaskComment.id == parent_comment_id, TaskComment.task_id == task.id)
+        .first()
+    )
+    # A deleted parent still anchors a thread — its replies are still on screen
+    # under the tombstone, and "Reply" there has to keep working.
+    if parent is None:
+        raise CommentNotFoundError("Parent comment not found")
+    return parent.parent_comment_id or parent.id
+
+
+def create_comment(
+    db: Session,
+    task: Task,
+    user_id: UUID,
+    body: str,
+    *,
+    parent_comment_id: UUID | None = None,
+    author: PrincipalRef | None = None,
+) -> TaskComment:
+    """Post a comment as `user_id`, or as `author` when an agent wrote it.
+
+    `author` is how an agent-authored comment gets its own name in the timeline:
+    the agent-facing API resolves the calling session's agent profile and passes
+    ('agent', profile_id). `user_id` still governs *scope* — the comment lands on
+    a task that user owns either way.
+    """
+    author_type, author_id = author or ("user", user_id)
+    root_id = (
+        resolve_thread_root(db, task, parent_comment_id)
+        if parent_comment_id is not None
+        else None
+    )
     comment = TaskComment(
         task_id=task.id,
         project_id=task.project_id,
-        author_type="user",
-        author_id=user_id,
+        parent_comment_id=root_id,
+        author_type=author_type,
+        author_id=author_id,
         body=body,
     )
     db.add(comment)
-    subscribe(db, task.id, user_id, "commenter")
+    # Only when the human is the one talking. An agent commenting through this
+    # user's API key is not that user choosing to follow the thread.
+    if author_type == "user" and author_id == user_id:
+        subscribe(db, task.id, user_id, "commenter")
     db.commit()
     return comment
 
@@ -273,9 +318,34 @@ def delete_comment(db: Session, task: Task, comment_id: UUID, user_id: UUID) -> 
 # --- Timeline ---------------------------------------------------------------
 
 
+def thread_order(comments: list[TaskComment]) -> list[TaskComment]:
+    """Roots oldest-first, each immediately followed by its replies.
+
+    Serving the list already threaded means a client that wants the tree reads
+    `parent_comment_id` and one that just wants to print the conversation (the
+    CLI, mobile's first pass) can walk the list straight through. A reply whose
+    root somehow isn't in the list is emitted as a root rather than dropped —
+    a comment that exists must be readable.
+    """
+    replies: dict[UUID, list[TaskComment]] = {}
+    by_id = {c.id: c for c in comments}
+    roots: list[TaskComment] = []
+    for comment in sorted(comments, key=lambda c: c.created_at):
+        parent_id = comment.parent_comment_id
+        if parent_id is not None and parent_id in by_id:
+            replies.setdefault(parent_id, []).append(comment)
+        else:
+            roots.append(comment)
+    ordered: list[TaskComment] = []
+    for root in roots:
+        ordered.append(root)
+        ordered.extend(replies.get(root.id, ()))
+    return ordered
+
+
 def build_timeline(db: Session, task: Task, user_id: UUID) -> TaskTimelineResponse:
     """Everything the task-detail timeline renders, in one round trip."""
-    comments = (
+    comments = thread_order(
         db.query(TaskComment)
         .filter(TaskComment.task_id == task.id)
         .order_by(TaskComment.created_at.asc())
@@ -305,6 +375,7 @@ def build_timeline(db: Session, task: Task, user_id: UUID) -> TaskTimelineRespon
             TaskCommentResponse(
                 id=c.id,
                 task_id=c.task_id,
+                parent_comment_id=c.parent_comment_id,
                 author=principals[(c.author_type, c.author_id)],
                 body=None if c.deleted_at else c.body,
                 kind="system" if c.kind == "system" else "comment",

--- a/backend/src/backend/db/task_timeline_queries.py
+++ b/backend/src/backend/db/task_timeline_queries.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import Session
 
 from shared.database import (
@@ -29,6 +30,7 @@ from shared.database.agent_profile_models import AgentProfile
 from shared.database.reactions import is_emoji
 
 from ..models import (
+    MAX_NAMED_REACTORS,
     PrincipalResponse,
     TaskActivityResponse,
     TaskCommentResponse,
@@ -117,7 +119,12 @@ def resolve_principals(
 def _reaction_summaries(
     db: Session, user_id: UUID, targets: list[tuple[str, UUID]]
 ) -> dict[tuple[str, UUID], list[TaskReactionSummary]]:
-    """Counts per (target, emoji) plus whether `user_id` is among them."""
+    """Counts per (target, emoji), who reacted, and whether `user_id` did.
+
+    The reactor names come back in the same aggregate rather than as a second
+    query per pill: a page can carry dozens of pills, and "who reacted" is a
+    hover away on every one of them.
+    """
     if not targets:
         return {}
     target_ids = [tid for _, tid in targets]
@@ -128,15 +135,35 @@ def _reaction_summaries(
             TaskReaction.emoji,
             func.count().label("n"),
             func.bool_or(TaskReaction.user_id == user_id).label("mine"),
+            # Oldest first, so the order a tooltip reads in is the order people
+            # actually reacted rather than whatever the planner returns.
+            func.array_agg(
+                aggregate_order_by(TaskReaction.user_id, TaskReaction.created_at)
+            ).label("user_ids"),
         )
         .where(TaskReaction.target_id.in_(target_ids))
         .group_by(TaskReaction.target_type, TaskReaction.target_id, TaskReaction.emoji)
     ).all()
 
+    # One principal lookup for every reactor on the page, not one per pill.
+    named: set[PrincipalRef] = set()
+    for row in rows:
+        for reactor_id in row.user_ids[:MAX_NAMED_REACTORS]:
+            named.add(("user", reactor_id))
+    principals = resolve_principals(db, named) if named else {}
+
     out: dict[tuple[str, UUID], list[TaskReactionSummary]] = {}
-    for target_type, target_id, emoji, count, mine in rows:
+    for target_type, target_id, emoji, count, mine, user_ids in rows:
         out.setdefault((target_type, target_id), []).append(
-            TaskReactionSummary(emoji=emoji, count=int(count), reacted=bool(mine))
+            TaskReactionSummary(
+                emoji=emoji,
+                count=int(count),
+                reacted=bool(mine),
+                reactors=[
+                    principals[("user", reactor_id)]
+                    for reactor_id in user_ids[:MAX_NAMED_REACTORS]
+                ],
+            )
         )
     # Most-used first, then by emoji so ties don't shuffle between renders.
     # There is no offered-set order to sort by any more — reactions are open.

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -5,6 +5,7 @@ This module contains all Pydantic models used for API request/response serializa
 Models are organized by functional area: questions, agents, billing, and detailed views.
 """
 
+import re
 from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
@@ -622,6 +623,8 @@ class ProjectDirectoryResponse(BaseModel):
 class ProjectResponse(BaseModel):
     id: UUID
     name: str
+    # Task-identifier prefix; None until the project's first task allocates one.
+    key: str | None = None
     git_remote_url: str | None = None
     color: str | None = None
     icon: str | None = None
@@ -660,17 +663,61 @@ class UpdateProjectRequest(BaseModel):
     icon: str | None = Field(default=None, max_length=64)
     git_remote_url: str | None = None
     is_archived: bool | None = None
+    # The task-identifier prefix ("VIC" → tasks read "VIC-42"). Auto-derived on
+    # a project's first task; editable here. Uppercased and validated against
+    # the same shape the deriver produces.
+    key: str | None = Field(default=None, min_length=2, max_length=8)
+
+    @field_validator("key")
+    @classmethod
+    def validate_key(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        upper = v.strip().upper()
+        if not re.fullmatch(r"[A-Z][A-Z0-9]{1,7}", upper):
+            raise ValueError(
+                "key must be 2-8 characters, letters and digits, starting with a letter"
+            )
+        return upper
+
+
+class PrincipalResponse(BaseModel):
+    """A user or an agent, in the one shape every surface renders (§2 layer 1).
+
+    Never carries an email: a principal may show a display name and a picture on
+    a shared or public surface, and nothing else (§10.4).
+    """
+
+    type: Literal["user", "agent", "system"]
+    id: UUID | None = None
+    name: str | None = None
+    avatar_image_uri: str | None = None
+    emoji: str | None = None
+    # Cache-buster for the avatar proxy; the URL itself is stable.
+    updated_at: datetime | None = None
 
 
 class TaskResponse(BaseModel):
     id: UUID
     project_id: UUID
+    # Per-project sequential number and the rendered "VIC-42". Both are None for
+    # a task whose project has no key yet (or that predates the backfill), and
+    # clients must render such a task without an identifier rather than
+    # inventing one.
+    number: int | None = None
+    identifier: str | None = None
     title: str
     description: str | None = None
     status: TaskStatusLiteral
     priority: TaskPriorityLiteral
     position: float
     parent_task_id: UUID | None = None
+    # Denormalized so a sub-task's session prompt can say "Part of: <title>"
+    # without a second fetch (§8.3).
+    parent_title: str | None = None
+    assignee_type: Literal["user", "agent"] | None = None
+    assignee_id: UUID | None = None
+    assignee: PrincipalResponse | None = None
     labels: list["TaskLabelResponse"] = Field(default_factory=list)
     start_date: datetime | None = None
     due_date: datetime | None = None
@@ -680,7 +727,22 @@ class TaskResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class CreateTaskRequest(BaseModel):
+class TaskAssigneeFields(BaseModel):
+    """Shared assignee validation: the pair moves together or not at all."""
+
+    assignee_type: Literal["user", "agent"] | None = None
+    assignee_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def check_assignee_pair(self):
+        if (self.assignee_type is None) != (self.assignee_id is None):
+            raise ValueError(
+                "assignee_type and assignee_id must be set or cleared together"
+            )
+        return self
+
+
+class CreateTaskRequest(TaskAssigneeFields):
     title: str = Field(..., min_length=1, max_length=255)
     description: str | None = None
     # Omitted → the user's Inbox ("No project" bucket).
@@ -694,7 +756,7 @@ class CreateTaskRequest(BaseModel):
     due_date: datetime | None = None
 
 
-class UpdateTaskRequest(BaseModel):
+class UpdateTaskRequest(TaskAssigneeFields):
     """PATCH body — only explicitly sent fields are applied, so date fields
     can be cleared by sending null."""
 
@@ -736,6 +798,75 @@ class UpdateTaskLabelRequest(BaseModel):
     @classmethod
     def validate_color(cls, v: str | None) -> str | None:
         return None if v is None else _normalize_label_color(v)
+
+
+TaskReactionTargetLiteral = Literal["task", "comment"]
+
+# Bounded so one comment cannot be a document. Generous enough for a pasted
+# stack trace, small enough that the timeline stays a timeline.
+MAX_COMMENT_BODY_CHARS = 20_000
+
+
+class TaskReactionSummary(BaseModel):
+    """One emoji on one target, collapsed across users."""
+
+    emoji: str
+    count: int
+    # Whether the requesting user is one of them — drives the pill's filled state.
+    reacted: bool
+
+
+class TaskCommentResponse(BaseModel):
+    id: UUID
+    task_id: UUID
+    author: PrincipalResponse
+    # None once soft-deleted: the row stays so the thread keeps its shape, but
+    # the text does not travel to the client.
+    body: str | None = None
+    kind: Literal["comment", "system"]
+    reactions: list[TaskReactionSummary] = Field(default_factory=list)
+    created_at: datetime
+    edited_at: datetime | None = None
+    deleted_at: datetime | None = None
+
+
+class TaskActivityResponse(BaseModel):
+    id: UUID
+    # None when the change had no request context (a background sweep). Rendered
+    # as an unattributed line rather than dropped.
+    actor: PrincipalResponse | None = None
+    action: str
+    details: dict = Field(default_factory=dict)
+    created_at: datetime
+
+
+class TaskTimelineResponse(BaseModel):
+    """Comments and activity in one fetch.
+
+    One round trip, one cache key, and — because reactions and principals are
+    resolved server-side across the whole page — no N+1 from the client
+    hydrating each row.
+    """
+
+    comments: list[TaskCommentResponse] = Field(default_factory=list)
+    activity: list[TaskActivityResponse] = Field(default_factory=list)
+    # Reactions on the task itself, not on any comment — the task body is a
+    # reactable target too, the same way a GitHub issue's opening post is.
+    reactions: list[TaskReactionSummary] = Field(default_factory=list)
+
+
+class CreateTaskCommentRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=MAX_COMMENT_BODY_CHARS)
+
+
+class UpdateTaskCommentRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=MAX_COMMENT_BODY_CHARS)
+
+
+class ToggleTaskReactionRequest(BaseModel):
+    target_type: TaskReactionTargetLiteral
+    target_id: UUID
+    emoji: str = Field(..., min_length=1, max_length=16)
 
 
 def _normalize_label_color(value: str) -> str:

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -807,6 +807,12 @@ TaskReactionTargetLiteral = Literal["task", "comment"]
 MAX_COMMENT_BODY_CHARS = 20_000
 
 
+# How many reactors a summary names before it stops. A tooltip that lists forty
+# people is not more informative than one that lists eight and says "and 32
+# others", and the payload grows with every reaction on a shared board.
+MAX_NAMED_REACTORS = 8
+
+
 class TaskReactionSummary(BaseModel):
     """One emoji on one target, collapsed across users."""
 
@@ -814,6 +820,10 @@ class TaskReactionSummary(BaseModel):
     count: int
     # Whether the requesting user is one of them — drives the pill's filled state.
     reacted: bool
+    # Who reacted, oldest first, capped at MAX_NAMED_REACTORS. `count` is the
+    # true total, so a client can render "and N others" from the difference.
+    # Display names only, never emails (§10.4) — this feeds public pages in P4.
+    reactors: list[PrincipalResponse] = Field(default_factory=list)
 
 
 class TaskCommentResponse(BaseModel):

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -829,6 +829,10 @@ class TaskReactionSummary(BaseModel):
 class TaskCommentResponse(BaseModel):
     id: UUID
     task_id: UUID
+    # The root this answers, or None when it is one. Threads are one level deep,
+    # so this always names a root and no client walks a chain. The list arrives
+    # already in thread order — each root followed by its replies.
+    parent_comment_id: UUID | None = None
     author: PrincipalResponse
     # None once soft-deleted: the row stays so the thread keeps its shape, but
     # the text does not travel to the client.
@@ -867,6 +871,24 @@ class TaskTimelineResponse(BaseModel):
 
 class CreateTaskCommentRequest(BaseModel):
     body: str = Field(..., min_length=1, max_length=MAX_COMMENT_BODY_CHARS)
+    # Reply to this comment. Threads are one level deep: passing a reply's id
+    # attaches to that reply's root rather than nesting further.
+    parent_comment_id: UUID | None = None
+
+
+class CreateAgentTaskCommentRequest(CreateTaskCommentRequest):
+    """The agent-facing body — the human one plus an authorship channel.
+
+    An API key identifies a *user*, so a comment posted through it is the user's
+    unless the caller says otherwise. `vicoa task comment` run inside a Vicoa
+    session passes that session's id (it has it as `VICOA_AGENT_INSTANCE_ID`),
+    and the server authors the comment as the session's agent profile — the only
+    way a comment ever gets `author_type='agent'`. A session with no profile, or
+    one belonging to another user, falls back to the user rather than failing:
+    losing the byline is a better outcome than losing the comment.
+    """
+
+    agent_instance_id: UUID | None = None
 
 
 class UpdateTaskCommentRequest(BaseModel):

--- a/backend/src/backend/tests/test_task_identity.py
+++ b/backend/src/backend/tests/test_task_identity.py
@@ -1,0 +1,421 @@
+"""Task identifiers and generated activity (collaboration plan §3.5, P2).
+
+Covers the two halves of KEY-42 — `projects.key` and `tasks.number` — and the
+`after_flush` listener that turns task mutations into `task_activity` rows.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from shared.database import (
+    AgentInstance,
+    Project,
+    Task,
+    TaskActivity,
+    TaskComment,
+    User,
+    get_or_create_inbox,
+)
+from shared.database.actor import Actor, set_session_actor
+from shared.database.enums import AgentStatus
+from shared.database.task_identity import (
+    derive_key_base,
+    format_task_identifier,
+    parse_task_identifier,
+)
+
+from backend.db import task_queries
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def second_user(test_db):
+    user = User(
+        id=uuid4(),
+        email="second@example.com",
+        display_name="Second",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    test_db.add(user)
+    test_db.commit()
+    return user
+
+
+def _project(db, user_id, name):
+    return task_queries.create_project(db, user_id, name=name)
+
+
+def _actions(db, task_id):
+    rows = (
+        db.query(TaskActivity)
+        .filter(TaskActivity.task_id == task_id)
+        .order_by(TaskActivity.created_at)
+        .all()
+    )
+    return [r.action for r in rows]
+
+
+class TestKeyDerivation:
+    """Pure string rules — no database."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("vicoa", "VIC"),
+            ("vicoa-ai", "VIC"),
+            ("Inbox", "INB"),
+            ("My Cool Project", "MYC"),
+            ("go", "GO"),
+        ],
+    )
+    def test_derives_from_ascii(self, name, expected):
+        assert derive_key_base(name) == expected
+
+    @pytest.mark.parametrize("name", ["工作台", "🚀", "", "a", "42"])
+    def test_falls_back_when_nothing_usable(self, name):
+        """A name with fewer than two ASCII alnum characters gets the neutral
+        key rather than a mangled one — CJK names are the real case here."""
+        assert derive_key_base(name) == "PRJ"
+
+    def test_drops_leading_digits(self):
+        """A key starting with a digit would read as part of the number."""
+        assert derive_key_base("2024-planning") == "PLA"
+
+
+class TestIdentifierFormat:
+    def test_round_trip(self):
+        assert format_task_identifier("VIC", 42) == "VIC-42"
+        assert parse_task_identifier("VIC-42") == ("VIC", 42)
+
+    def test_parse_is_case_insensitive(self):
+        assert parse_task_identifier("  vic-42 ") == ("VIC", 42)
+
+    def test_none_without_both_halves(self):
+        assert format_task_identifier(None, 42) is None
+        assert format_task_identifier("VIC", None) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-an-id",
+            str(uuid4()),  # a UUID must never be mistaken for KEY-42
+            "VIC-",
+            "-42",
+            "V-42",  # a one-character key is below the minimum
+        ],
+    )
+    def test_rejects_non_identifiers(self, value):
+        assert parse_task_identifier(value) is None
+
+
+class TestNumberAllocation:
+    def test_numbers_start_at_one_per_project(self, test_db, test_user):
+        a = _project(test_db, test_user.id, "Alpha")
+        b = _project(test_db, test_user.id, "Bravo")
+
+        a1 = task_queries.create_task(test_db, test_user.id, "one", project_id=a.id)
+        a2 = task_queries.create_task(test_db, test_user.id, "two", project_id=a.id)
+        b1 = task_queries.create_task(test_db, test_user.id, "one", project_id=b.id)
+
+        assert (a1.number, a2.number, b1.number) == (1, 2, 1)
+
+    def test_counter_never_reuses_a_deleted_number(self, test_db, test_user):
+        project = _project(test_db, test_user.id, "Alpha")
+        first = task_queries.create_task(
+            test_db, test_user.id, "one", project_id=project.id
+        )
+        task_queries.delete_task(test_db, test_user.id, first.id)
+
+        second = task_queries.create_task(
+            test_db, test_user.id, "two", project_id=project.id
+        )
+        assert second.number == 2
+
+    def test_inbox_tasks_get_numbers_too(self, test_db, test_user):
+        task = task_queries.create_task(test_db, test_user.id, "unfiled")
+        inbox = get_or_create_inbox(test_db, test_user.id)
+        assert task.number == 1
+        assert inbox.key == "INB"
+
+    def test_rejected_create_does_not_burn_a_number(self, test_db, test_user):
+        """Validation runs before allocation, so a 404 leaves no gap."""
+        project = _project(test_db, test_user.id, "Alpha")
+        with pytest.raises(task_queries.LabelNotFoundError):
+            task_queries.create_task(
+                test_db,
+                test_user.id,
+                "bad",
+                project_id=project.id,
+                label_ids=[uuid4()],
+            )
+        test_db.rollback()
+        ok = task_queries.create_task(
+            test_db, test_user.id, "good", project_id=project.id
+        )
+        assert ok.number == 1
+
+
+class TestKeyAllocation:
+    def test_key_allocated_on_first_task_not_on_create(self, test_db, test_user):
+        project = _project(test_db, test_user.id, "Vicoa")
+        assert project.key is None
+
+        task_queries.create_task(test_db, test_user.id, "one", project_id=project.id)
+        test_db.refresh(project)
+        assert project.key == "VIC"
+
+    def test_colliding_names_get_a_suffix(self, test_db, test_user):
+        first = _project(test_db, test_user.id, "Vicoa")
+        second = _project(test_db, test_user.id, "Vicious")
+        task_queries.create_task(test_db, test_user.id, "a", project_id=first.id)
+        task_queries.create_task(test_db, test_user.id, "b", project_id=second.id)
+
+        test_db.refresh(first)
+        test_db.refresh(second)
+        assert first.key == "VIC"
+        assert second.key == "VIC2"
+
+    def test_key_namespace_is_per_owner_not_global(
+        self, test_db, test_user, second_user
+    ):
+        mine = _project(test_db, test_user.id, "Vicoa")
+        theirs = _project(test_db, second_user.id, "Vicoa")
+        task_queries.create_task(test_db, test_user.id, "a", project_id=mine.id)
+        task_queries.create_task(test_db, second_user.id, "b", project_id=theirs.id)
+
+        test_db.refresh(mine)
+        test_db.refresh(theirs)
+        assert mine.key == theirs.key == "VIC"
+
+    def test_rename_does_not_re_derive_the_key(self, test_db, test_user):
+        """ "VIC-42" in an old commit message has to keep resolving."""
+        project = _project(test_db, test_user.id, "Vicoa")
+        task_queries.create_task(test_db, test_user.id, "a", project_id=project.id)
+        task_queries.update_project(
+            test_db, test_user.id, project.id, {"name": "Renamed"}
+        )
+        test_db.refresh(project)
+        assert project.key == "VIC"
+
+
+class TestProjectMove:
+    def test_move_reassigns_number_and_moves_child_rows(self, test_db, test_user):
+        source = _project(test_db, test_user.id, "Alpha")
+        target = _project(test_db, test_user.id, "Bravo")
+        task_queries.create_task(test_db, test_user.id, "filler", project_id=target.id)
+        task = task_queries.create_task(
+            test_db, test_user.id, "movable", project_id=source.id
+        )
+        comment = TaskComment(
+            task_id=task.id,
+            project_id=source.id,
+            author_type="user",
+            author_id=test_user.id,
+            body="stays with the task",
+        )
+        test_db.add(comment)
+        test_db.commit()
+
+        task_queries.update_task(
+            test_db, test_user.id, task.id, {"project_id": target.id}
+        )
+
+        test_db.refresh(task)
+        test_db.refresh(comment)
+        assert task.project_id == target.id
+        # Target already held one task, so the mover becomes its #2.
+        assert task.number == 2
+        # The denormalized project_id follows, or the comment would stay
+        # reachable through a grant on a project it no longer belongs to.
+        assert comment.project_id == target.id
+        assert (
+            test_db.query(TaskActivity)
+            .filter(TaskActivity.task_id == task.id)
+            .first()
+            .project_id
+            == target.id
+        )
+
+    def test_same_project_patch_keeps_the_number(self, test_db, test_user):
+        project = _project(test_db, test_user.id, "Alpha")
+        task = task_queries.create_task(
+            test_db, test_user.id, "stay", project_id=project.id
+        )
+        task_queries.update_task(
+            test_db, test_user.id, task.id, {"project_id": project.id}
+        )
+        test_db.refresh(task)
+        assert task.number == 1
+
+
+class TestGeneratedActivity:
+    def test_create_emits_one_created_row(self, test_db, test_user):
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        assert _actions(test_db, task.id) == ["created"]
+
+    def test_field_changes_emit_one_row_each(self, test_db, test_user):
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        task_queries.update_task(
+            test_db,
+            test_user.id,
+            task.id,
+            {"status": "in_progress", "priority": "high"},
+        )
+        assert set(_actions(test_db, task.id)) == {
+            "created",
+            "status_changed",
+            "priority_changed",
+        }
+
+    def test_no_row_when_nothing_actually_changed(self, test_db, test_user):
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        task_queries.update_task(test_db, test_user.id, task.id, {"status": "backlog"})
+        assert _actions(test_db, task.id) == ["created"]
+
+    def test_status_change_records_from_and_to(self, test_db, test_user):
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        task_queries.update_task(
+            test_db, test_user.id, task.id, {"status": "in_progress"}
+        )
+        row = (
+            test_db.query(TaskActivity)
+            .filter(
+                TaskActivity.task_id == task.id,
+                TaskActivity.action == "status_changed",
+            )
+            .one()
+        )
+        assert row.details == {"from": "backlog", "to": "in_progress"}
+
+    def test_long_text_is_recorded_without_a_diff(self, test_db, test_user):
+        """A before/after pair of two long descriptions is unrenderable and
+        would dwarf the table — record that it changed, not what to."""
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        task_queries.update_task(
+            test_db, test_user.id, task.id, {"description": "x" * 4000}
+        )
+        row = (
+            test_db.query(TaskActivity)
+            .filter(TaskActivity.action == "description_changed")
+            .one()
+        )
+        assert row.details == {}
+
+    def test_labels_emit_added_and_removed(self, test_db, test_user):
+        label = task_queries.create_label(test_db, test_user.id, "backend", "#ff0000")
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        task_queries.update_task(
+            test_db, test_user.id, task.id, {"label_ids": [label.id]}
+        )
+        task_queries.update_task(test_db, test_user.id, task.id, {"label_ids": []})
+        actions = _actions(test_db, task.id)
+        assert "label_added" in actions and "label_removed" in actions
+
+    def test_actor_comes_from_the_session(self, test_db, test_user):
+        set_session_actor(test_db, Actor(type="user", id=test_user.id))
+        try:
+            task = task_queries.create_task(test_db, test_user.id, "new")
+        finally:
+            set_session_actor(test_db, None)
+        row = test_db.query(TaskActivity).filter(TaskActivity.task_id == task.id).one()
+        assert (row.actor_type, row.actor_id) == ("user", test_user.id)
+
+    def test_unattributed_when_no_actor_is_set(self, test_db, test_user):
+        """A background sweep has no request context. An unattributed row is
+        honest; a guessed one is not."""
+        task = task_queries.create_task(test_db, test_user.id, "new")
+        row = test_db.query(TaskActivity).filter(TaskActivity.task_id == task.id).one()
+        assert row.actor_type is None and row.actor_id is None
+
+
+class TestStatusSyncAttribution:
+    def test_session_driven_status_is_attributed_to_the_session(
+        self, test_db, test_user, test_agent_type
+    ):
+        """The daemon posts the status update authenticated as the user, but the
+        thing that moved the task is the agent's session — and the timeline
+        needs the instance id to fold these hops into that session's card."""
+        set_session_actor(test_db, Actor(type="user", id=test_user.id))
+        try:
+            task = task_queries.create_task(test_db, test_user.id, "linked")
+            instance = AgentInstance(
+                id=uuid4(),
+                agent_type_id=test_agent_type.id,
+                user_id=test_user.id,
+                status=AgentStatus.ACTIVE,
+                task_id=task.id,
+            )
+            test_db.add(instance)
+            test_db.commit()
+        finally:
+            set_session_actor(test_db, None)
+
+        row = (
+            test_db.query(TaskActivity)
+            .filter(TaskActivity.action == "status_changed")
+            .one()
+        )
+        # No agent_profile_id on this instance, so it degrades to 'system'
+        # rather than inheriting the request's user.
+        assert row.actor_type == "system"
+        assert row.details["agent_instance_id"] == str(instance.id)
+
+    def test_override_does_not_leak_to_a_later_change(
+        self, test_db, test_user, test_agent_type
+    ):
+        set_session_actor(test_db, Actor(type="user", id=test_user.id))
+        try:
+            task = task_queries.create_task(test_db, test_user.id, "linked")
+            instance = AgentInstance(
+                id=uuid4(),
+                agent_type_id=test_agent_type.id,
+                user_id=test_user.id,
+                status=AgentStatus.ACTIVE,
+                task_id=task.id,
+            )
+            test_db.add(instance)
+            test_db.commit()
+
+            task_queries.update_task(
+                test_db, test_user.id, task.id, {"priority": "urgent"}
+            )
+        finally:
+            set_session_actor(test_db, None)
+
+        row = (
+            test_db.query(TaskActivity)
+            .filter(TaskActivity.action == "priority_changed")
+            .one()
+        )
+        assert row.actor_type == "user"
+        assert "agent_instance_id" not in row.details
+
+
+class TestProjectKeyUniquenessIndex:
+    def test_two_projects_cannot_hold_the_same_key(self, test_db, test_user):
+        from sqlalchemy.exc import IntegrityError
+
+        a = Project(user_id=test_user.id, name="Alpha", key="DUP")
+        b = Project(user_id=test_user.id, name="Bravo", key="dup")
+        test_db.add_all([a, b])
+        with pytest.raises(IntegrityError):
+            test_db.commit()
+        test_db.rollback()
+
+    def test_two_tasks_cannot_hold_the_same_number(self, test_db, test_user):
+        from sqlalchemy.exc import IntegrityError
+
+        project = _project(test_db, test_user.id, "Alpha")
+        test_db.add_all(
+            [
+                Task(user_id=test_user.id, project_id=project.id, title="a", number=7),
+                Task(user_id=test_user.id, project_id=project.id, title="b", number=7),
+            ]
+        )
+        with pytest.raises(IntegrityError):
+            test_db.commit()
+        test_db.rollback()

--- a/backend/src/backend/tests/test_task_timeline.py
+++ b/backend/src/backend/tests/test_task_timeline.py
@@ -178,6 +178,50 @@ class TestReactions:
                 test_db, test_user.id, "task", task.id, value
             )
 
+    def test_summary_names_who_reacted(self, test_db, test_user, stranger, task):
+        """A pill has to be able to answer "who?" on hover without a second
+        request per pill."""
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "nice"
+        )
+        for user_id in (test_user.id, stranger.id):
+            task_timeline_queries.toggle_reaction(
+                test_db, user_id, "comment", comment.id, "\U0001f44d"
+            )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        summary = timeline.comments[0].reactions[0]
+        # Oldest first — the order people actually reacted in.
+        assert [r.id for r in summary.reactors] == [test_user.id, stranger.id]
+        assert summary.count == 2
+
+    def test_reactor_names_are_capped(self, test_db, test_user, task):
+        """`count` stays true so the client can say "and N others"; the named
+        list stops before a tooltip becomes a directory."""
+        from backend.models import MAX_NAMED_REACTORS
+
+        extras = []
+        for i in range(MAX_NAMED_REACTORS + 3):
+            user = User(
+                id=uuid4(),
+                email=f"reactor{i}@example.com",
+                display_name=f"Reactor {i}",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            test_db.add(user)
+            extras.append(user)
+        test_db.commit()
+        for user in extras:
+            task_timeline_queries.toggle_reaction(
+                test_db, user.id, "task", task.id, "\U0001f680"
+            )
+
+        summary = task_timeline_queries.build_timeline(
+            test_db, task, test_user.id
+        ).reactions[0]
+        assert summary.count == MAX_NAMED_REACTORS + 3
+        assert len(summary.reactors) == MAX_NAMED_REACTORS
+
     def test_summaries_are_ordered_by_count(self, test_db, test_user, stranger, task):
         comment = task_timeline_queries.create_comment(
             test_db, task, test_user.id, "nice"

--- a/backend/src/backend/tests/test_task_timeline.py
+++ b/backend/src/backend/tests/test_task_timeline.py
@@ -1,0 +1,297 @@
+"""Task timeline API layer — comments, reactions, assignee, serialization.
+
+Companion to `test_task_identity.py`, which covers the DB-level identifier and
+activity rules. This file covers what the task-detail route actually calls.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from shared.database import User
+from shared.database.agent_profile_models import AgentProfile
+
+from backend.db import task_queries, task_timeline_queries
+from backend.db.task_serializers import serialize_task, serialize_tasks
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def agent_profile(test_db, test_user):
+    profile = AgentProfile(
+        user_id=test_user.id, name="Claude", agent="claude", emoji="🤖"
+    )
+    test_db.add(profile)
+    test_db.commit()
+    return profile
+
+
+@pytest.fixture
+def stranger(test_db):
+    user = User(
+        id=uuid4(),
+        email="stranger@example.com",
+        display_name="Stranger",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    test_db.add(user)
+    test_db.commit()
+    return user
+
+
+@pytest.fixture
+def task(test_db, test_user):
+    project = task_queries.create_project(test_db, test_user.id, name="Vicoa")
+    return task_queries.create_task(
+        test_db, test_user.id, "a task", project_id=project.id
+    )
+
+
+class TestComments:
+    def test_create_and_read_back(self, test_db, test_user, task):
+        task_timeline_queries.create_comment(test_db, task, test_user.id, "hello")
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert [c.body for c in timeline.comments] == ["hello"]
+        assert timeline.comments[0].author.name == test_user.display_name
+
+    def test_commenting_subscribes_the_author(self, test_db, test_user, task):
+        from shared.database import TaskSubscriber
+
+        task_timeline_queries.create_comment(test_db, task, test_user.id, "hello")
+        row = (
+            test_db.query(TaskSubscriber)
+            .filter(TaskSubscriber.task_id == task.id)
+            .one()
+        )
+        assert row.reason == "commenter"
+
+    def test_edit_stamps_edited_at(self, test_db, test_user, task):
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "typo"
+        )
+        task_timeline_queries.update_comment(
+            test_db, task, comment.id, test_user.id, "fixed"
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert timeline.comments[0].body == "fixed"
+        assert timeline.comments[0].edited_at is not None
+
+    def test_delete_is_soft_and_withholds_the_body(self, test_db, test_user, task):
+        """The row survives so the thread keeps its shape and reactions don't
+        dangle — but the text stops being served."""
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "oops"
+        )
+        task_timeline_queries.delete_comment(test_db, task, comment.id, test_user.id)
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert len(timeline.comments) == 1
+        assert timeline.comments[0].body is None
+        assert timeline.comments[0].deleted_at is not None
+
+    def test_only_the_author_can_edit(self, test_db, test_user, stranger, task):
+        """Owning the task does not confer the right to rewrite someone else's
+        words — the same reason GitHub separates the two."""
+        comment = task_timeline_queries.create_comment(
+            test_db, task, stranger.id, "not yours"
+        )
+        with pytest.raises(task_timeline_queries.CommentNotFoundError):
+            task_timeline_queries.update_comment(
+                test_db, task, comment.id, test_user.id, "rewritten"
+            )
+
+    def test_deleted_comment_cannot_be_edited(self, test_db, test_user, task):
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "gone"
+        )
+        task_timeline_queries.delete_comment(test_db, task, comment.id, test_user.id)
+        with pytest.raises(task_timeline_queries.CommentNotFoundError):
+            task_timeline_queries.update_comment(
+                test_db, task, comment.id, test_user.id, "back"
+            )
+
+
+class TestReactions:
+    def test_toggle_on_then_off(self, test_db, test_user, task):
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "nice"
+        )
+        assert (
+            task_timeline_queries.toggle_reaction(
+                test_db, test_user.id, "comment", comment.id, "👍"
+            )
+            is True
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert timeline.comments[0].reactions[0].count == 1
+        assert timeline.comments[0].reactions[0].reacted is True
+
+        assert (
+            task_timeline_queries.toggle_reaction(
+                test_db, test_user.id, "comment", comment.id, "👍"
+            )
+            is False
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert timeline.comments[0].reactions == []
+
+    def test_reacted_is_per_viewer(self, test_db, test_user, stranger, task):
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "nice"
+        )
+        task_timeline_queries.toggle_reaction(
+            test_db, stranger.id, "comment", comment.id, "🎉"
+        )
+        mine = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert mine.comments[0].reactions[0].count == 1
+        assert mine.comments[0].reactions[0].reacted is False
+
+    def test_the_task_itself_is_reactable(self, test_db, test_user, task):
+        """The task body is a target like any comment — the same way a GitHub
+        issue's opening post is."""
+        task_timeline_queries.toggle_reaction(
+            test_db, test_user.id, "task", task.id, "🚀"
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert [(r.emoji, r.count) for r in timeline.reactions] == [("🚀", 1)]
+        assert timeline.comments == []
+
+    @pytest.mark.parametrize("emoji", ["💩", "👩\u200d💻", "👍🏽", "❤️"])
+    def test_any_real_emoji_is_accepted(self, test_db, test_user, task, emoji):
+        """Reactions are open — the client offers the full Unicode picker, so a
+        server-side allowlist would only be a second, staler list."""
+        assert (
+            task_timeline_queries.toggle_reaction(
+                test_db, test_user.id, "task", task.id, emoji
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize("value", ["hello", "ok", "", "a👍", "   ", "<script>"])
+    def test_non_emoji_is_rejected(self, test_db, test_user, task, value):
+        """Free varchar + no allowlist still must not become a text-injection
+        surface: a reaction pill renders whatever it is handed."""
+        with pytest.raises(task_timeline_queries.UnknownReactionError):
+            task_timeline_queries.toggle_reaction(
+                test_db, test_user.id, "task", task.id, value
+            )
+
+    def test_summaries_are_ordered_by_count(self, test_db, test_user, stranger, task):
+        comment = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "nice"
+        )
+        for user_id in (test_user.id, stranger.id):
+            task_timeline_queries.toggle_reaction(
+                test_db, user_id, "comment", comment.id, "🎉"
+            )
+        task_timeline_queries.toggle_reaction(
+            test_db, test_user.id, "comment", comment.id, "👍"
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert [r.emoji for r in timeline.comments[0].reactions] == ["🎉", "👍"]
+
+
+class TestAssignee:
+    def test_assign_to_own_agent_profile(self, test_db, test_user, task, agent_profile):
+        task_queries.update_task(
+            test_db,
+            test_user.id,
+            task.id,
+            {"assignee_type": "agent", "assignee_id": agent_profile.id},
+        )
+        response = serialize_task(test_db, task)
+        assert response.assignee is not None
+        assert response.assignee.type == "agent"
+        assert response.assignee.name == "Claude"
+        assert response.assignee.emoji == "🤖"
+
+    def test_cannot_assign_to_a_foreign_agent_profile(
+        self, test_db, test_user, stranger, task
+    ):
+        theirs = AgentProfile(user_id=stranger.id, name="Theirs", agent="claude")
+        test_db.add(theirs)
+        test_db.commit()
+        with pytest.raises(task_queries.AssigneeNotFoundError):
+            task_queries.update_task(
+                test_db,
+                test_user.id,
+                task.id,
+                {"assignee_type": "agent", "assignee_id": theirs.id},
+            )
+
+    def test_cannot_assign_to_another_user(self, test_db, test_user, stranger, task):
+        with pytest.raises(task_queries.AssigneeNotFoundError):
+            task_queries.update_task(
+                test_db,
+                test_user.id,
+                task.id,
+                {"assignee_type": "user", "assignee_id": stranger.id},
+            )
+
+    def test_clearing_the_assignee(self, test_db, test_user, task, agent_profile):
+        task_queries.update_task(
+            test_db,
+            test_user.id,
+            task.id,
+            {"assignee_type": "agent", "assignee_id": agent_profile.id},
+        )
+        task_queries.update_task(
+            test_db,
+            test_user.id,
+            task.id,
+            {"assignee_type": None, "assignee_id": None},
+        )
+        assert serialize_task(test_db, task).assignee is None
+
+
+class TestSerialization:
+    def test_identifier_and_parent_title(self, test_db, test_user, task):
+        child = task_queries.create_task(
+            test_db,
+            test_user.id,
+            "child",
+            project_id=task.project_id,
+            parent_task_id=task.id,
+        )
+        [parent_response, child_response] = serialize_tasks(test_db, [task, child])
+        assert parent_response.identifier == "VIC-1"
+        assert child_response.identifier == "VIC-2"
+        assert child_response.parent_title == "a task"
+        assert parent_response.parent_title is None
+
+    def test_identifier_is_none_without_a_key(self, test_db, test_user):
+        """A task whose project never got a key renders without an identifier
+        rather than with a half-formed one."""
+        from shared.database import Project, Task
+
+        project = Project(user_id=test_user.id, name="Keyless")
+        test_db.add(project)
+        test_db.commit()
+        orphan = Task(
+            user_id=test_user.id, project_id=project.id, title="no key", number=4
+        )
+        test_db.add(orphan)
+        test_db.commit()
+        assert serialize_task(test_db, orphan).identifier is None
+
+    def test_deleted_author_still_renders(self, test_db, test_user, task):
+        """A comment outlives its author; a blank name would make the thread
+        unreadable."""
+        ghost = uuid4()
+        from shared.database import TaskComment
+
+        test_db.add(
+            TaskComment(
+                task_id=task.id,
+                project_id=task.project_id,
+                author_type="user",
+                author_id=ghost,
+                body="from beyond",
+            )
+        )
+        test_db.commit()
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert timeline.comments[0].author.name == "Deleted user"
+        assert timeline.comments[0].author.id is None

--- a/backend/src/backend/tests/test_task_timeline.py
+++ b/backend/src/backend/tests/test_task_timeline.py
@@ -113,6 +113,161 @@ class TestComments:
             )
 
 
+class TestTaskReferences:
+    """`resolve_task` — the identifier is the handle people can actually see."""
+
+    @pytest.fixture
+    def keyed_task(self, test_db, test_user):
+        project = task_queries.create_project(test_db, test_user.id, name="Vicoa")
+        return task_queries.create_task(
+            test_db, test_user.id, "keyed", project_id=project.id
+        )
+
+    def test_resolves_a_uuid(self, test_db, test_user, keyed_task):
+        found = task_queries.resolve_task(test_db, test_user.id, str(keyed_task.id))
+        assert found is not None and found.id == keyed_task.id
+
+    def test_resolves_an_identifier(self, test_db, test_user, keyed_task):
+        identifier = serialize_task(test_db, keyed_task).identifier
+        assert identifier is not None
+        found = task_queries.resolve_task(test_db, test_user.id, identifier)
+        assert found is not None and found.id == keyed_task.id
+
+    def test_identifier_is_case_insensitive(self, test_db, test_user, keyed_task):
+        """People type what they remember, not what they copied."""
+        identifier = serialize_task(test_db, keyed_task).identifier
+        assert identifier is not None
+        found = task_queries.resolve_task(test_db, test_user.id, identifier.lower())
+        assert found is not None and found.id == keyed_task.id
+
+    def test_whitespace_is_tolerated(self, test_db, test_user, keyed_task):
+        identifier = serialize_task(test_db, keyed_task).identifier
+        assert identifier is not None
+        found = task_queries.resolve_task(test_db, test_user.id, f"  {identifier} ")
+        assert found is not None and found.id == keyed_task.id
+
+    @pytest.mark.parametrize("ref", ["", "nonsense", "VIC-", "-42", "VIC-9999", "V-1"])
+    def test_unresolvable_refs_are_none_not_errors(self, test_db, test_user, ref):
+        """A bad reference is a 404, never a 500 — the route hands this whatever
+        the user typed."""
+        assert task_queries.resolve_task(test_db, test_user.id, ref) is None
+
+    def test_another_users_identifier_does_not_resolve(
+        self, test_db, test_user, stranger, keyed_task
+    ):
+        """Keys are unique per owner, not globally: the same "VIC-1" means a
+        different task in a different account, and neither can reach the other."""
+        identifier = serialize_task(test_db, keyed_task).identifier
+        assert identifier is not None
+        assert task_queries.resolve_task(test_db, stranger.id, identifier) is None
+
+
+class TestThreads:
+    """One-level threading (collab §3.5, decided 2026-09-09)."""
+
+    def test_reply_hangs_off_its_root(self, test_db, test_user, task):
+        root = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "question"
+        )
+        reply = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "answer", parent_comment_id=root.id
+        )
+        assert reply.parent_comment_id == root.id
+
+    def test_reply_to_a_reply_joins_the_same_thread(self, test_db, test_user, task):
+        """Not rejected, re-pointed: clicking "Reply" under a nested comment
+        means "answer in this thread", and refusing would be a rule about our
+        schema rather than about what the user asked for."""
+        root = task_timeline_queries.create_comment(test_db, task, test_user.id, "root")
+        reply = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "reply", parent_comment_id=root.id
+        )
+        nested = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "nested", parent_comment_id=reply.id
+        )
+        assert nested.parent_comment_id == root.id
+
+    def test_a_deleted_root_still_anchors_its_thread(self, test_db, test_user, task):
+        """Its replies are still on screen under the tombstone, so Reply there
+        has to keep working."""
+        root = task_timeline_queries.create_comment(test_db, task, test_user.id, "oops")
+        task_timeline_queries.delete_comment(test_db, task, root.id, test_user.id)
+        reply = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "still answering", parent_comment_id=root.id
+        )
+        assert reply.parent_comment_id == root.id
+
+    def test_parent_on_another_task_is_rejected(self, test_db, test_user, task):
+        other = task_queries.create_task(
+            test_db, test_user.id, "elsewhere", project_id=task.project_id
+        )
+        stray = task_timeline_queries.create_comment(
+            test_db, other, test_user.id, "over here"
+        )
+        with pytest.raises(task_timeline_queries.CommentNotFoundError):
+            task_timeline_queries.create_comment(
+                test_db, task, test_user.id, "reply", parent_comment_id=stray.id
+            )
+
+    def test_timeline_arrives_in_thread_order(self, test_db, test_user, task):
+        """Each root immediately followed by its replies — so the CLI and
+        mobile can print the list straight through without building a tree."""
+        first = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "first"
+        )
+        second = task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "second"
+        )
+        task_timeline_queries.create_comment(
+            test_db, task, test_user.id, "reply to first", parent_comment_id=first.id
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert [c.body for c in timeline.comments] == [
+            "first",
+            "reply to first",
+            "second",
+        ]
+        assert timeline.comments[1].parent_comment_id == first.id
+        assert timeline.comments[2].id == second.id
+
+    def test_agent_authored_comment_keeps_the_agents_name(
+        self, test_db, test_user, agent_profile, task
+    ):
+        """How `author_type='agent'` ever happens: the agent-facing API resolves
+        the calling session's profile and passes it here."""
+        task_timeline_queries.create_comment(
+            test_db,
+            task,
+            test_user.id,
+            "ran the tests, all green",
+            author=("agent", agent_profile.id),
+        )
+        timeline = task_timeline_queries.build_timeline(test_db, task, test_user.id)
+        assert timeline.comments[0].author.type == "agent"
+        assert timeline.comments[0].author.name == "Claude"
+
+    def test_an_agent_comment_does_not_subscribe_the_key_owner(
+        self, test_db, test_user, agent_profile, task
+    ):
+        """An agent talking through the user's API key is not that user choosing
+        to follow the thread."""
+        from shared.database import TaskSubscriber
+
+        task_timeline_queries.create_comment(
+            test_db,
+            task,
+            test_user.id,
+            "done",
+            author=("agent", agent_profile.id),
+        )
+        assert (
+            test_db.query(TaskSubscriber)
+            .filter(TaskSubscriber.task_id == task.id)
+            .count()
+            == 0
+        )
+
+
 class TestReactions:
     def test_toggle_on_then_off(self, test_db, test_user, task):
         comment = task_timeline_queries.create_comment(

--- a/backend/src/servers/api/auth.py
+++ b/backend/src/servers/api/auth.py
@@ -11,6 +11,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from shared.auth import Principal, TokenVerificationError, verify_agent_jwt
+from shared.database.actor import Actor, set_session_actor
 from shared.database.session import get_db
 from sqlalchemy.orm import Session
 
@@ -28,13 +29,20 @@ async def get_current_principal(
     reuses it rather than opening a second one.
     """
     try:
-        return verify_agent_jwt(credentials.credentials, db)
+        principal = verify_agent_jwt(credentials.credentials, db)
     except TokenVerificationError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
         )
+    # Attribution for generated task activity (collaboration §3.5). An API key
+    # identifies a user, not an agent profile — `vicoa task update` looks the
+    # same whether a human typed it or an agent ran it — so this attributes to
+    # the user. Genuinely agent-authored writes (an agent posting a comment)
+    # name their author explicitly instead of inheriting this.
+    set_session_actor(db, Actor(type="user", id=principal.user_id))
+    return principal
 
 
 async def get_current_user_id(

--- a/backend/src/servers/api/tasks.py
+++ b/backend/src/servers/api/tasks.py
@@ -28,6 +28,7 @@ from shared.database.session import get_db
 # Reused human-facing query layer + DTOs. See module docstring for why this
 # servers→backend import is deliberate rather than a duplicate implementation.
 from backend.db import task_queries
+from backend.db.task_serializers import serialize_task, serialize_tasks
 from backend.db.task_queries import (
     LabelNotFoundError,
     ParentTaskError,
@@ -92,7 +93,7 @@ def list_tasks_endpoint(
         status=task_status,
         priority=task_priority,
     )
-    return [TaskResponse.model_validate(t) for t in tasks]
+    return serialize_tasks(db, tasks)
 
 
 @task_router.post(
@@ -123,7 +124,7 @@ def create_task_endpoint(
     except (ProjectNotFoundError, LabelNotFoundError, ParentTaskError) as exc:
         _raise_task_ref_errors(exc)
         raise  # unreachable; keeps the type checker satisfied
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @task_router.get("/tasks/{task_id}", response_model=TaskResponse)
@@ -137,7 +138,7 @@ def get_task_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @task_router.patch("/tasks/{task_id}", response_model=TaskResponse)
@@ -157,7 +158,7 @@ def update_task_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
-    return TaskResponse.model_validate(task)
+    return serialize_task(db, task)
 
 
 @task_router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/servers/api/tasks.py
+++ b/backend/src/servers/api/tasks.py
@@ -9,7 +9,11 @@ authenticate against *this* server with their RS256 API-key JWT
 human-facing task surfaces can never drift.
 
 Tasks are user-scoped, not session-scoped: an agent acting for a user sees and
-mutates that user's whole backlog, exactly as the user's web session would.
+mutates that user's whole backlog, exactly as the user's web session would. The
+task timeline (comments + activity) is exposed here too, read and write, so an
+agent can report back on the task it was started from instead of only in a
+transcript the user has to go looking for.
+
 Kept in its own file to avoid bloating ``routers.py``.
 """
 
@@ -23,11 +27,12 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
+from shared.database.models import AgentInstance
 from shared.database.session import get_db
 
 # Reused human-facing query layer + DTOs. See module docstring for why this
 # servers→backend import is deliberate rather than a duplicate implementation.
-from backend.db import task_queries
+from backend.db import task_queries, task_timeline_queries
 from backend.db.task_serializers import serialize_task, serialize_tasks
 from backend.db.task_queries import (
     LabelNotFoundError,
@@ -35,10 +40,12 @@ from backend.db.task_queries import (
     ProjectNotFoundError,
 )
 from backend.models import (
+    CreateAgentTaskCommentRequest,
     CreateTaskRequest,
     TaskPriorityLiteral,
     TaskResponse,
     TaskStatusLiteral,
+    TaskTimelineResponse,
     UpdateTaskRequest,
 )
 
@@ -129,28 +136,25 @@ def create_task_endpoint(
 
 @task_router.get("/tasks/{task_id}", response_model=TaskResponse)
 def get_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
     db: Session = Depends(get_db),
 ) -> TaskResponse:
-    task = task_queries.get_task(db, _user_uuid(user_id), task_id)
-    if task is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
-        )
-    return serialize_task(db, task)
+    return serialize_task(db, _require_task(db, _user_uuid(user_id), task_id))
 
 
 @task_router.patch("/tasks/{task_id}", response_model=TaskResponse)
 def update_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     request: UpdateTaskRequest,
     user_id: Annotated[str, Depends(get_current_user_id)],
     db: Session = Depends(get_db),
 ) -> TaskResponse:
     fields = request.model_dump(exclude_unset=True)
+    resolved = _user_uuid(user_id)
+    existing = _require_task(db, resolved, task_id)
     try:
-        task = task_queries.update_task(db, _user_uuid(user_id), task_id, fields)
+        task = task_queries.update_task(db, resolved, existing.id, fields)
     except (ProjectNotFoundError, LabelNotFoundError, ParentTaskError) as exc:
         _raise_task_ref_errors(exc)
         raise  # unreachable; keeps the type checker satisfied
@@ -163,11 +167,107 @@ def update_task_endpoint(
 
 @task_router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_task_endpoint(
-    task_id: UUID,
+    task_id: str,
     user_id: Annotated[str, Depends(get_current_user_id)],
     db: Session = Depends(get_db),
 ) -> None:
-    if not task_queries.delete_task(db, _user_uuid(user_id), task_id):
+    resolved = _user_uuid(user_id)
+    task = _require_task(db, resolved, task_id)
+    if not task_queries.delete_task(db, resolved, task.id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
+
+
+# ---------------------------------------------------------------------------
+# Comments — the agent's half of the task timeline (`vicoa task comment`)
+#
+# Read and write only. Editing, deleting and reacting stay human-facing: an
+# agent revising or removing its own words after the fact is a rewrite of the
+# record the human is reading, and a reaction from an agent is noise.
+# ---------------------------------------------------------------------------
+
+
+def _require_task(db: Session, user_id: UUID, task_id: str):
+    """The user-scoped resolve every task route here starts from.
+
+    Takes a UUID *or* a "VIC-42" identifier. That matters most on this router:
+    the CLI is an agent's only task entrypoint, and both the agent and the human
+    instructing it see the identifier — asking either of them for a UUID means
+    asking for something neither has.
+
+    It is also what keeps `task_comments` scoped, since that table carries no
+    `user_id` of its own (the author need not be the task's owner once sharing
+    lands) — exactly as in `backend/api/tasks.py`.
+    """
+    task = task_queries.resolve_task(db, user_id, task_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+    return task
+
+
+def _comment_author(
+    db: Session, user_id: UUID, agent_instance_id: UUID | None
+) -> tuple[str, UUID]:
+    """Whose name goes on the comment.
+
+    The user's, unless the caller named a session of theirs that was started
+    from an agent profile — then the profile's, so the timeline can say "Claude
+    commented" instead of attributing the agent's words to the human. Scoped by
+    `user_id`: naming someone else's session must not borrow their agent's name.
+    """
+    if agent_instance_id is None:
+        return ("user", user_id)
+    profile_id = (
+        db.query(AgentInstance.agent_profile_id)
+        .filter(
+            AgentInstance.id == agent_instance_id,
+            AgentInstance.user_id == user_id,
+        )
+        .scalar()
+    )
+    return ("agent", profile_id) if profile_id is not None else ("user", user_id)
+
+
+@task_router.get("/tasks/{task_id}/timeline", response_model=TaskTimelineResponse)
+def get_task_timeline_endpoint(
+    task_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    """Comments and activity together — the same payload the web detail page
+    renders, so an agent reads exactly what its user sees."""
+    resolved = _user_uuid(user_id)
+    task = _require_task(db, resolved, task_id)
+    return task_timeline_queries.build_timeline(db, task, resolved)
+
+
+@task_router.post(
+    "/tasks/{task_id}/comments",
+    response_model=TaskTimelineResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_task_comment_endpoint(
+    task_id: str,
+    request: CreateAgentTaskCommentRequest,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    db: Session = Depends(get_db),
+) -> TaskTimelineResponse:
+    resolved = _user_uuid(user_id)
+    task = _require_task(db, resolved, task_id)
+    try:
+        task_timeline_queries.create_comment(
+            db,
+            task,
+            resolved,
+            request.body,
+            parent_comment_id=request.parent_comment_id,
+            author=_comment_author(db, resolved, request.agent_instance_id),
+        )
+    except task_timeline_queries.CommentNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    return task_timeline_queries.build_timeline(db, task, resolved)

--- a/backend/src/servers/tests/test_task_endpoints.py
+++ b/backend/src/servers/tests/test_task_endpoints.py
@@ -153,3 +153,151 @@ class TestScoping:
         stranger_client = _make_client(test_db, uuid4())
         assert stranger_client.get(f"/api/v1/tasks/{created['id']}").status_code == 404
         assert stranger_client.get("/api/v1/tasks").json() == []
+
+
+class TestIdentifierRefs:
+    """Every route takes "VIC-42" as readily as a UUID.
+
+    It matters most on this router: the CLI is an agent's only task entrypoint,
+    and the identifier is what both the agent and the human instructing it can
+    see. Asking either for a UUID asks for something neither has.
+    """
+
+    @pytest.fixture
+    def keyed(self, client):
+        """A task whose project got a key allocated on its first task."""
+        return client.post("/api/v1/tasks", json={"title": "Ship it"}).json()
+
+    def test_get_by_identifier(self, client, keyed):
+        assert keyed["identifier"]
+        resp = client.get(f"/api/v1/tasks/{keyed['identifier']}")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == keyed["id"]
+
+    def test_patch_by_identifier(self, client, keyed):
+        resp = client.patch(
+            f"/api/v1/tasks/{keyed['identifier']}", json={"status": "done"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "done"
+        assert resp.json()["id"] == keyed["id"]
+
+    def test_comment_by_identifier(self, client, keyed):
+        resp = client.post(
+            f"/api/v1/tasks/{keyed['identifier']}/comments", json={"body": "done"}
+        )
+        assert resp.status_code == 201, resp.text
+        assert [c["body"] for c in resp.json()["comments"]] == ["done"]
+
+    def test_unknown_identifier_is_404_not_422(self, client):
+        """The route takes whatever the user typed, so a typo has to land as
+        "not found" rather than as a validation error about UUIDs."""
+        assert client.get("/api/v1/tasks/NOPE-99").status_code == 404
+        assert client.get("/api/v1/tasks/not-a-ref-at-all").status_code == 404
+
+    def test_delete_by_identifier(self, client, keyed):
+        assert client.delete(f"/api/v1/tasks/{keyed['identifier']}").status_code == 204
+        assert client.get(f"/api/v1/tasks/{keyed['id']}").status_code == 404
+
+    def test_another_users_identifier_does_not_resolve(self, test_db, client, keyed):
+        stranger_client = _make_client(test_db, uuid4())
+        assert (
+            stranger_client.get(f"/api/v1/tasks/{keyed['identifier']}").status_code
+            == 404
+        )
+
+
+class TestComments:
+    """`vicoa task comment` — the agent's half of the task timeline."""
+
+    @pytest.fixture
+    def task(self, client):
+        return client.post("/api/v1/tasks", json={"title": "Ship it"}).json()
+
+    def test_post_and_read_back(self, client, task):
+        resp = client.post(
+            f"/api/v1/tasks/{task['id']}/comments",
+            json={"body": "ran the tests, all green"},
+        )
+        assert resp.status_code == 201, resp.text
+        assert [c["body"] for c in resp.json()["comments"]] == [
+            "ran the tests, all green"
+        ]
+
+        timeline = client.get(f"/api/v1/tasks/{task['id']}/timeline")
+        assert timeline.status_code == 200
+        assert len(timeline.json()["comments"]) == 1
+
+    def test_reply_threads_under_its_root(self, client, task):
+        root = client.post(
+            f"/api/v1/tasks/{task['id']}/comments", json={"body": "why?"}
+        ).json()["comments"][0]
+        replied = client.post(
+            f"/api/v1/tasks/{task['id']}/comments",
+            json={"body": "because", "parent_comment_id": root["id"]},
+        )
+        assert replied.status_code == 201, replied.text
+        comments = replied.json()["comments"]
+        assert [c["parent_comment_id"] for c in comments] == [None, root["id"]]
+
+    def test_unknown_parent_is_404(self, client, task):
+        resp = client.post(
+            f"/api/v1/tasks/{task['id']}/comments",
+            json={"body": "orphan", "parent_comment_id": str(uuid4())},
+        )
+        assert resp.status_code == 404
+
+    def test_comment_is_authored_by_the_calling_sessions_agent_profile(
+        self, test_db, test_user, client, task
+    ):
+        """The only path that ever produces `author_type='agent'`: the CLI
+        passes its `VICOA_AGENT_INSTANCE_ID`, and a session started from a
+        profile speaks in that profile's name."""
+        from shared.database.agent_profile_models import AgentProfile
+        from shared.database.models import AgentInstance, AgentType
+
+        profile = AgentProfile(
+            user_id=test_user.id, name="Reviewer", agent="claude", emoji="🤖"
+        )
+        test_db.add(profile)
+        test_db.flush()
+        instance = AgentInstance(
+            user_id=test_user.id,
+            agent_type_id=test_db.query(AgentType).first().id,
+            agent_profile_id=profile.id,
+        )
+        test_db.add(instance)
+        test_db.commit()
+
+        resp = client.post(
+            f"/api/v1/tasks/{task['id']}/comments",
+            json={"body": "reviewed", "agent_instance_id": str(instance.id)},
+        )
+        assert resp.status_code == 201, resp.text
+        author = resp.json()["comments"][0]["author"]
+        assert author["type"] == "agent"
+        assert author["name"] == "Reviewer"
+
+    def test_a_foreign_session_does_not_lend_its_agents_name(
+        self, test_db, test_user, client, task
+    ):
+        """Naming someone else's session must not borrow their agent's byline —
+        and must not fail the write either: losing the byline beats losing the
+        comment."""
+        resp = client.post(
+            f"/api/v1/tasks/{task['id']}/comments",
+            json={"body": "hello", "agent_instance_id": str(uuid4())},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["comments"][0]["author"]["type"] == "user"
+
+    def test_other_user_cannot_comment(self, test_db, test_user, task):
+        stranger_client = _make_client(test_db, uuid4())
+        resp = stranger_client.post(
+            f"/api/v1/tasks/{task['id']}/comments", json={"body": "sneaking in"}
+        )
+        assert resp.status_code == 404
+        assert (
+            stranger_client.get(f"/api/v1/tasks/{task['id']}/timeline").status_code
+            == 404
+        )

--- a/backend/src/shared/alembic/versions/a3f1c9e27b45_task_depth_keys_numbers_comments.py
+++ b/backend/src/shared/alembic/versions/a3f1c9e27b45_task_depth_keys_numbers_comments.py
@@ -1,0 +1,248 @@
+"""Task depth: project keys, task numbers, comments, reactions, activity, subscribers
+
+Collaboration plan §3.5 (P2). Tasks become addressable as KEY-42.
+
+Revision ID: a3f1c9e27b45
+Revises: e1c8f2a640b7
+Create Date: 2026-09-09
+
+Deploy order matters and is not optional: `tasks.number`, `projects.key` and
+`projects.task_counter` land on the ORM models, so every `db.query(Task)` and
+`db.query(Project)` enumerates them in its SELECT. Code deployed ahead of this
+migration means `UndefinedColumn` on every query touching those tables — a
+whole-backend outage, not "the new feature is inert". Run `alembic upgrade head`
+BEFORE the backend deploy (collaboration §10.10).
+"""
+
+import re
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "a3f1c9e27b45"
+down_revision = "e1c8f2a640b7"
+branch_labels = None
+depends_on = None
+
+
+# Mirror of shared.database.task_identity.derive_key_base. Duplicated on purpose:
+# a migration must keep producing the keys it produced on the day it ran, even
+# after the live helper's rules change.
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]+")
+_LEADING_DIGITS = re.compile(r"^[0-9]+")
+_FALLBACK = "PRJ"
+
+
+def _derive_key_base(name: str) -> str:
+    stripped = _LEADING_DIGITS.sub("", _NON_ALNUM.sub("", name or ""))
+    base = stripped[:3].upper()
+    return base if len(base) >= 2 else _FALLBACK
+
+
+def _backfill_keys(conn) -> None:
+    """Give every project that holds a task a key, unique within its owner.
+
+    Only projects with tasks: a key is a task-identifier prefix, and handing one
+    to an empty project would take a name out of the namespace for nothing. The
+    runtime allocates lazily on a project's first task for the same reason.
+    """
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT p.id, p.user_id, p.name
+            FROM projects p
+            WHERE EXISTS (SELECT 1 FROM tasks t WHERE t.project_id = p.id)
+            ORDER BY p.user_id, p.created_at, p.id
+            """
+        )
+    ).fetchall()
+
+    taken: dict[str, set[str]] = {}
+    for project_id, user_id, name in rows:
+        owned = taken.setdefault(str(user_id), set())
+        base = _derive_key_base(name)
+        key = base
+        suffix = 2
+        while key in owned:
+            key = f"{base}{suffix}"[:8]
+            suffix += 1
+        owned.add(key)
+        conn.execute(
+            sa.text("UPDATE projects SET key = :key WHERE id = :id"),
+            {"key": key, "id": project_id},
+        )
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("key", sa.String(length=8), nullable=True))
+    op.add_column(
+        "projects",
+        sa.Column(
+            "task_counter", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+    )
+    op.add_column("tasks", sa.Column("number", sa.Integer(), nullable=True))
+
+    conn = op.get_bind()
+
+    # Numbers first, ordered the way the tasks were written, so an existing
+    # backlog reads in the order it was created rather than at random.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE tasks t
+            SET number = numbered.rn
+            FROM (
+                SELECT id,
+                       row_number() OVER (
+                           PARTITION BY project_id ORDER BY created_at, id
+                       ) AS rn
+                FROM tasks
+            ) AS numbered
+            WHERE t.id = numbered.id
+            """
+        )
+    )
+    # The counter is the high-water mark, never a live count: deleting a task
+    # must not hand its number to the next one.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE projects p
+            SET task_counter = COALESCE(m.max_number, 0)
+            FROM (
+                SELECT project_id, MAX(number) AS max_number
+                FROM tasks GROUP BY project_id
+            ) AS m
+            WHERE p.id = m.project_id
+            """
+        )
+    )
+    _backfill_keys(conn)
+
+    op.create_index(
+        "uq_projects_user_key",
+        "projects",
+        ["user_id", sa.text("upper(key)")],
+        unique=True,
+        postgresql_where=sa.text("key IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_tasks_project_number",
+        "tasks",
+        ["project_id", "number"],
+        unique=True,
+        postgresql_where=sa.text("number IS NOT NULL"),
+    )
+
+    op.create_table(
+        "task_comments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("author_type", sa.String(length=8), nullable=False),
+        sa.Column("author_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("kind", sa.String(length=16), nullable=False),
+        sa.Column("edited_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "author_type IN ('user','agent')", name="ck_task_comments_author_type"
+        ),
+        sa.CheckConstraint(
+            "kind IN ('comment','system')", name="ck_task_comments_kind"
+        ),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_task_comments_task", "task_comments", ["task_id", "created_at"])
+    op.create_index("ix_task_comments_project", "task_comments", ["project_id"])
+
+    op.create_table(
+        "task_reactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_type", sa.String(length=8), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("emoji", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "target_type IN ('task','comment')", name="ck_task_reactions_target_type"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "target_type",
+            "target_id",
+            "user_id",
+            "emoji",
+            name="uq_task_reactions_target_user_emoji",
+        ),
+    )
+    op.create_index(
+        "ix_task_reactions_target", "task_reactions", ["target_type", "target_id"]
+    )
+
+    op.create_table(
+        "task_activity",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_type", sa.String(length=8), nullable=True),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("action", sa.String(length=40), nullable=False),
+        sa.Column(
+            "details",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "actor_type IS NULL OR actor_type IN ('user','agent','system')",
+            name="ck_task_activity_actor_type",
+        ),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_task_activity_task", "task_activity", ["task_id", "created_at"])
+    op.create_index("ix_task_activity_project", "task_activity", ["project_id"])
+
+    op.create_table(
+        "task_subscribers",
+        sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("reason", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "reason IN ('creator','assignee','commenter','mentioned','manual')",
+            name="ck_task_subscribers_reason",
+        ),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("task_id", "user_id"),
+    )
+    op.create_index("ix_task_subscribers_user", "task_subscribers", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_subscribers_user", table_name="task_subscribers")
+    op.drop_table("task_subscribers")
+    op.drop_index("ix_task_activity_project", table_name="task_activity")
+    op.drop_index("ix_task_activity_task", table_name="task_activity")
+    op.drop_table("task_activity")
+    op.drop_index("ix_task_reactions_target", table_name="task_reactions")
+    op.drop_table("task_reactions")
+    op.drop_index("ix_task_comments_project", table_name="task_comments")
+    op.drop_index("ix_task_comments_task", table_name="task_comments")
+    op.drop_table("task_comments")
+    op.drop_index("uq_tasks_project_number", table_name="tasks")
+    op.drop_index("uq_projects_user_key", table_name="projects")
+    op.drop_column("tasks", "number")
+    op.drop_column("projects", "task_counter")
+    op.drop_column("projects", "key")

--- a/backend/src/shared/alembic/versions/a3f1c9e27b45_task_depth_keys_numbers_comments.py
+++ b/backend/src/shared/alembic/versions/a3f1c9e27b45_task_depth_keys_numbers_comments.py
@@ -141,6 +141,10 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        # One-level threads: a reply points at a root, and a reply to a reply is
+        # re-pointed at that root by the write path, so this column never forms
+        # a chain deeper than one hop.
+        sa.Column("parent_comment_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("author_type", sa.String(length=8), nullable=False),
         sa.Column("author_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("body", sa.Text(), nullable=False),
@@ -157,10 +161,19 @@ def upgrade() -> None:
         ),
         sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["parent_comment_id"], ["task_comments.id"], ondelete="CASCADE"
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("ix_task_comments_task", "task_comments", ["task_id", "created_at"])
     op.create_index("ix_task_comments_project", "task_comments", ["project_id"])
+    op.create_index(
+        "ix_task_comments_parent",
+        "task_comments",
+        ["parent_comment_id"],
+        postgresql_where=sa.text("parent_comment_id IS NOT NULL"),
+    )
 
     op.create_table(
         "task_reactions",
@@ -238,6 +251,7 @@ def downgrade() -> None:
     op.drop_table("task_activity")
     op.drop_index("ix_task_reactions_target", table_name="task_reactions")
     op.drop_table("task_reactions")
+    op.drop_index("ix_task_comments_parent", table_name="task_comments")
     op.drop_index("ix_task_comments_project", table_name="task_comments")
     op.drop_index("ix_task_comments_task", table_name="task_comments")
     op.drop_table("task_comments")

--- a/backend/src/shared/database/__init__.py
+++ b/backend/src/shared/database/__init__.py
@@ -22,7 +22,17 @@ from .task_models import (
     Project,
     ProjectDirectory,
     Task,
+    TaskActivity,
+    TaskComment,
     TaskLabel,
+    TaskReaction,
+    TaskSubscriber,
+    ACTIVITY_ACTIONS,
+    ACTIVITY_ACTOR_TYPES,
+    COMMENT_AUTHOR_TYPES,
+    COMMENT_KINDS,
+    REACTION_TARGET_TYPES,
+    SUBSCRIBER_REASONS,
     TASK_PRIORITIES,
     TASK_STATUSES,
 )
@@ -42,7 +52,12 @@ from .activation_models import (
     ACTIVATION_NUDGE_CHANNELS,
     ACTIVATION_NUDGE_STATUSES,
 )
+from .actor import Actor, session_actor, set_session_actor
 from .tasks import INBOX_PROJECT_NAME, get_or_create_inbox
+
+# Side-effect import: registers the after_flush listener that generates
+# `task_activity`. Importing the package is what turns task history on.
+from . import task_activity as _task_activity  # noqa: F401
 from .users import ensure_local_user
 
 __all__ = [
@@ -67,11 +82,24 @@ __all__ = [
     "Project",
     "ProjectDirectory",
     "Task",
+    "TaskActivity",
+    "TaskComment",
     "TaskLabel",
+    "TaskReaction",
+    "TaskSubscriber",
+    "ACTIVITY_ACTIONS",
+    "ACTIVITY_ACTOR_TYPES",
+    "COMMENT_AUTHOR_TYPES",
+    "COMMENT_KINDS",
+    "REACTION_TARGET_TYPES",
+    "SUBSCRIBER_REASONS",
     "TASK_PRIORITIES",
     "TASK_STATUSES",
     "INBOX_PROJECT_NAME",
     "get_or_create_inbox",
+    "Actor",
+    "session_actor",
+    "set_session_actor",
     "Automation",
     "AutomationRun",
     "AUTOMATION_RUN_STATUSES",

--- a/backend/src/shared/database/actor.py
+++ b/backend/src/shared/database/actor.py
@@ -1,0 +1,69 @@
+"""Who is acting — the attribution channel for generated task activity.
+
+`task_activity` rows are written by a flush listener, not by call sites (§3.5),
+and a flush listener has no request context: it can see *that* a task's status
+changed but not *who* changed it. The actor therefore has to be handed to the
+Session, and the Session is the right carrier because it is exactly the scope
+the listener runs in — one request, one unit of work, one actor.
+
+It is stamped in **one place per process** rather than per endpoint:
+`backend.auth.dependencies.get_current_user` and `servers.api.auth`'s
+`get_current_user_id` both already run for every authenticated request and both
+already hold the session, so every route gets attribution with no per-route
+work. A request that never authenticates (health checks, the public router)
+leaves it unset, and the listener writes `actor_type = NULL` — an unattributed
+line, which is honest, rather than a guess.
+
+Per-mutation overrides exist for the one case the request actor gets wrong: the
+instance-status sync runs inside a request authenticated *as the user* but the
+thing that actually moved the task is the agent's session. See
+`register_activity_override`.
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+_SESSION_ACTOR_KEY = "vicoa_actor"
+_OVERRIDE_KEY = "vicoa_activity_actor_overrides"
+
+
+@dataclass(frozen=True)
+class Actor:
+    """A principal, as `task_activity` records it."""
+
+    type: str  # 'user' | 'agent' | 'system'
+    id: UUID | None = None
+    # Set when the action came from an agent session. Carried into
+    # `task_activity.details` so the task timeline can fold a session's status
+    # churn into that session's card instead of listing every hop separately.
+    agent_instance_id: UUID | None = None
+
+
+def set_session_actor(db: Session, actor: Actor | None) -> None:
+    """Attribute everything this session flushes to `actor`."""
+    if actor is None:
+        db.info.pop(_SESSION_ACTOR_KEY, None)
+        return
+    db.info[_SESSION_ACTOR_KEY] = actor
+
+
+def session_actor(db: Session) -> Actor | None:
+    return db.info.get(_SESSION_ACTOR_KEY)
+
+
+def register_activity_override(db: Session, task_id: UUID, actor: Actor) -> None:
+    """Attribute this session's *next* activity on `task_id` to `actor`.
+
+    Consumed by the activity listener and cleared as it goes, so an override
+    never leaks onto a later, unrelated change to the same task.
+    """
+    db.info.setdefault(_OVERRIDE_KEY, {})[task_id] = actor
+
+
+def take_activity_override(db: Session, task_id: UUID) -> Actor | None:
+    overrides = db.info.get(_OVERRIDE_KEY)
+    if not overrides:
+        return None
+    return overrides.pop(task_id, None)

--- a/backend/src/shared/database/reactions.py
+++ b/backend/src/shared/database/reactions.py
@@ -1,0 +1,40 @@
+"""What counts as an emoji.
+
+`task_reactions.emoji` is a free varchar and the client can send anything the
+full Unicode picker offers — skin-tone modifiers, ZWJ sequences, flags. So the
+server can't check membership in a list, but it must still check *shape*:
+without this, the column accepts "please click here" and the reaction row
+becomes a text-injection surface rather than a pill.
+
+The rule is deliberately structural rather than a codepoint whitelist (which
+goes stale with every Unicode release): an emoji is short, contains no ASCII
+letters, digits or whitespace, and has at least one character outside the
+Latin-1 range.
+"""
+
+MAX_EMOJI_LENGTH = 16
+
+# Joiners and modifiers that legitimately appear inside a single emoji and are
+# themselves below the "must be exotic" bar.
+_COMBINING = {
+    "‍",  # zero-width joiner (👨‍👩‍👧)
+    "️",  # variation selector-16 (❤️)
+    "︎",  # variation selector-15
+}
+
+
+def is_emoji(value: str) -> bool:
+    """True when `value` is plausibly a single emoji grapheme."""
+    if not value or len(value) > MAX_EMOJI_LENGTH:
+        return False
+    saw_exotic = False
+    for char in value:
+        if char in _COMBINING:
+            continue
+        if char.isalnum() and char.isascii():
+            return False
+        if char.isspace():
+            return False
+        if ord(char) > 0xFF:
+            saw_exotic = True
+    return saw_exotic

--- a/backend/src/shared/database/task_activity.py
+++ b/backend/src/shared/database/task_activity.py
@@ -1,0 +1,153 @@
+"""Generated task activity — one flush listener, never a call site (§3.5).
+
+Task mutations reach the database from the human REST API, the agent-facing
+REST API, the CLI, the automation runner and the instance-status sync. Writing
+an activity row at each of those is how the log ends up with holes, so the diff
+is taken where all of them converge: the flush. This is the same argument — and
+the same shape — as `tasks.py::_sync_task_status_before_flush`.
+
+**Why `after_flush` and not `before_flush`.** `Task.id` is a Python-side
+`default=uuid4`, so it is still `None` while `before_flush` runs and a `created`
+row would have nothing to point at. `after_flush` has the ids, still has full
+attribute history (that is reset later, in `after_flush_postexec`), and objects
+added to the session there are picked up by the flush loop `Session.commit()`
+runs until the session is clean. The recursion that implies terminates on its
+own: the second flush contains only `TaskActivity` rows, and this listener only
+ever looks at `Task`.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session, attributes
+
+from .actor import session_actor, take_activity_override
+from .task_models import Task, TaskActivity
+
+logger = logging.getLogger(__name__)
+
+# Scalar columns worth a timeline entry, mapped to the action they emit.
+# `assignee_id` stands in for the (assignee_type, assignee_id) pair — they
+# always move together and two rows for one edit reads as a bug.
+WATCHED_COLUMNS: dict[str, str] = {
+    "status": "status_changed",
+    "priority": "priority_changed",
+    "assignee_id": "assigned",
+    "title": "title_changed",
+    "description": "description_changed",
+    "due_date": "due_date_set",
+    "start_date": "start_date_set",
+    "project_id": "project_changed",
+    "parent_task_id": "parent_changed",
+}
+
+# Long free text is recorded as "changed", not as a before/after pair: a diff of
+# two 4 kB descriptions is not something a timeline row can usefully render, and
+# storing both copies on every keystroke-save would dwarf the table.
+_OPAQUE_COLUMNS = frozenset({"title", "description"})
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, UUID):
+        return str(value)
+    return str(value)
+
+
+def _changed(obj: Task, key: str) -> tuple[bool, Any, Any]:
+    """(has_changes, old, new) for one attribute of `obj`."""
+    history = attributes.get_history(obj, key)
+    if not history.has_changes():
+        return False, None, None
+    old = history.deleted[0] if history.deleted else None
+    new = history.added[0] if history.added else None
+    if old == new:
+        return False, None, None
+    return True, old, new
+
+
+def _activity(
+    task: Task, action: str, details: dict[str, Any], db: Session
+) -> TaskActivity:
+    """Build one row, resolving the actor: per-task override first, then the
+    session's request actor, then nothing (an unattributed line)."""
+    actor = take_activity_override(db, task.id) or session_actor(db)
+    payload = dict(details)
+    if actor is not None and actor.agent_instance_id is not None:
+        payload["agent_instance_id"] = str(actor.agent_instance_id)
+    return TaskActivity(
+        task_id=task.id,
+        project_id=task.project_id,
+        actor_type=actor.type if actor else None,
+        actor_id=actor.id if actor else None,
+        action=action,
+        details=payload,
+    )
+
+
+def _label_events(task: Task, db: Session) -> list[TaskActivity]:
+    history = attributes.get_history(task, "labels")
+    if not history.has_changes():
+        return []
+    rows: list[TaskActivity] = []
+    for label in history.added or ():
+        rows.append(
+            _activity(
+                task,
+                "label_added",
+                {"label_id": str(label.id), "label": label.name},
+                db,
+            )
+        )
+    for label in history.deleted or ():
+        rows.append(
+            _activity(
+                task,
+                "label_removed",
+                {"label_id": str(label.id), "label": label.name},
+                db,
+            )
+        )
+    return rows
+
+
+def _record_task_activity(session: Session, flush_context) -> None:
+    rows: list[TaskActivity] = []
+
+    for obj in session.new:
+        if isinstance(obj, Task):
+            # One `created` row, never a field-change row per column: everything
+            # about a brand-new task is part of creating it.
+            rows.append(_activity(obj, "created", {}, session))
+
+    for obj in session.dirty:
+        if not isinstance(obj, Task):
+            continue
+        for key, action in WATCHED_COLUMNS.items():
+            has_changes, old, new = _changed(obj, key)
+            if not has_changes:
+                continue
+            if key in _OPAQUE_COLUMNS:
+                details: dict[str, Any] = {}
+            elif key == "assignee_id":
+                details = {
+                    "to": _jsonable(new),
+                    "to_type": obj.assignee_type,
+                    "from": _jsonable(old),
+                }
+            else:
+                details = {"from": _jsonable(old), "to": _jsonable(new)}
+            rows.append(_activity(obj, action, details, session))
+        rows.extend(_label_events(obj, session))
+
+    if rows:
+        session.add_all(rows)
+
+
+event.listen(Session, "after_flush", _record_task_activity)

--- a/backend/src/shared/database/task_identity.py
+++ b/backend/src/shared/database/task_identity.py
@@ -1,0 +1,176 @@
+"""Task identifiers — `projects.key` + `tasks.number` (collaboration §3.5, D-B).
+
+Tasks display Linear-style as **KEY-42**. The two halves are independent
+choices that the first draft of the plan conflated:
+
+* counter **scope** → per project (`projects.task_counter`, every project counts
+  from 1), so the numbers stay small and a shared board is self-contained;
+* display **prefix** → `projects.key`, unique *within the owner* and never
+  globally. A global key namespace would re-import the squatting and enumeration
+  problems §3.2 avoids for team slugs, and inside one account "VIC-42" is
+  already unambiguous.
+
+**Keys are allocated lazily, on a project's first task**, not when the project
+is created. Projects are created from three places — the Inbox helper, the
+explicit REST create, and the session-registration auto-match, which runs on the
+daemon's hot path in the `servers` process — and only the last of those would
+have had to grow a uniqueness query and a race it cannot retry out of. Deferring
+to `create_task` puts the allocation somewhere that *can* retry, keeps the
+registration path untouched, and means a project that never holds a task never
+takes a name out of the namespace.
+"""
+
+import logging
+import re
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .task_models import Project
+
+logger = logging.getLogger(__name__)
+
+# Longest key the column takes. The derived base is 3, so the collision suffix
+# has room to run to five digits before it would have to truncate.
+MAX_KEY_LENGTH = 8
+# Derived base length. Three is the Linear/Jira convention ("VIC", "ENG").
+KEY_BASE_LENGTH = 3
+# Generic base for a name with nothing ASCII to derive from — CJK names, emoji
+# names, "工作". Mangling those into initials produces noise, so they get a
+# neutral key and the user renames it in project settings if they care.
+FALLBACK_KEY_BASE = "PRJ"
+
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]+")
+_LEADING_DIGITS = re.compile(r"^[0-9]+")
+# "VIC-42" / "vic-42". The key half is bounded by MAX_KEY_LENGTH so a stray
+# "AB-1234567890123" can't turn into a pathological lookup.
+_IDENTIFIER = re.compile(r"^\s*([A-Za-z][A-Za-z0-9]{1,7})-([0-9]{1,9})\s*$")
+
+
+def derive_key_base(name: str) -> str:
+    """The un-deduplicated key a project name suggests.
+
+    Uppercase, ASCII alnum only, leading digits dropped (a key that starts with
+    a number reads as part of the number), truncated to `KEY_BASE_LENGTH`.
+    Anything that leaves fewer than two usable characters falls back.
+    """
+    stripped = _NON_ALNUM.sub("", name or "")
+    stripped = _LEADING_DIGITS.sub("", stripped)
+    base = stripped[:KEY_BASE_LENGTH].upper()
+    return base if len(base) >= 2 else FALLBACK_KEY_BASE
+
+
+def _taken_keys(db: Session, user_id: UUID) -> set[str]:
+    """Every key already spoken for by this owner, uppercased.
+
+    P3 adds `projects.team_id`; when it does, a team-owned project's namespace
+    is the team's, and this predicate grows a branch. Until then there is only
+    one kind of owner.
+    """
+    rows = db.execute(
+        select(func.upper(Project.key)).where(
+            Project.user_id == user_id, Project.key.is_not(None)
+        )
+    ).all()
+    return {row[0] for row in rows if row[0]}
+
+
+def next_free_key(db: Session, user_id: UUID, name: str, *, attempt: int = 0) -> str:
+    """A key for `name` that no other project of this owner holds.
+
+    `attempt` shifts the starting suffix so a caller retrying after a lost race
+    doesn't re-propose the candidate that just collided.
+    """
+    base = derive_key_base(name)
+    taken = _taken_keys(db, user_id)
+    if attempt == 0 and base not in taken:
+        return base
+    # BASE, BASE2, BASE3 … — the same shape Linear uses, and short enough that
+    # the suffix never pushes past MAX_KEY_LENGTH in practice.
+    suffix = max(attempt, 1) + 1
+    while True:
+        candidate = f"{base}{suffix}"[:MAX_KEY_LENGTH]
+        if candidate not in taken:
+            return candidate
+        suffix += 1
+
+
+def allocate_task_number(db: Session, project: Project) -> int:
+    """Take the next number in `project`, bumping the counter atomically.
+
+    `UPDATE … RETURNING` on the counter column: the row lock it takes is held to
+    the end of the transaction, so two concurrent inserts into the same project
+    serialize instead of both reading the same value. A per-project sequence is
+    not an option (sequences are schema objects, not rows).
+    """
+    number = db.execute(
+        update(Project)
+        .where(Project.id == project.id)
+        .values(task_counter=Project.task_counter + 1)
+        .returning(Project.task_counter)
+    ).scalar_one()
+    # The ORM copy still holds the pre-UPDATE value; expire it so anything that
+    # reads `project.task_counter` later in this session sees the real one.
+    db.expire(project, ["task_counter"])
+    return int(number)
+
+
+def format_task_identifier(key: str | None, number: int | None) -> str | None:
+    """ "VIC-42", or None when the task predates its project's key/backfill."""
+    if not key or number is None:
+        return None
+    return f"{key}-{number}"
+
+
+def parse_task_identifier(value: str) -> tuple[str, int] | None:
+    """Split "VIC-42" into ("VIC", 42). None when it isn't an identifier.
+
+    Lets every task-by-id surface — the REST path param, `vicoa task get`, the
+    web route — accept the identifier a human (or an agent reading it out of a
+    prompt) actually has in hand, not just a UUID.
+    """
+    match = _IDENTIFIER.match(value)
+    if match is None:
+        return None
+    return match.group(1).upper(), int(match.group(2))
+
+
+# How many keys to try before giving up. A collision needs two projects of the
+# same owner, with names deriving to the same base, inserted concurrently — so
+# in practice the first attempt always wins and this only bounds pathology.
+KEY_ALLOCATION_ATTEMPTS = 5
+
+
+def ensure_project_key_committed(db: Session, project: Project) -> str | None:
+    """Give `project` a key, retrying past a lost uniqueness race.
+
+    Runs in a SAVEPOINT so a collision rolls back the key write **and nothing
+    else** — the caller is usually mid-way through creating or moving a task,
+    and a plain rollback would take that with it. Same shape as
+    `get_or_create_inbox`, for the same reason.
+
+    Returns None if every attempt collided: the task still gets its number and
+    simply renders without an identifier until someone sets a key by hand. A
+    project without a key is a cosmetic problem; a failed task create is not.
+    """
+    if project.key:
+        return project.key
+
+    for attempt in range(KEY_ALLOCATION_ATTEMPTS):
+        nested = db.begin_nested()
+        try:
+            project.key = next_free_key(
+                db, project.user_id, project.name, attempt=attempt
+            )
+            db.flush()
+            nested.commit()
+            return project.key
+        except IntegrityError:
+            nested.rollback()
+            logger.info(
+                "project key race for project %s (attempt %d)", project.id, attempt + 1
+            )
+    logger.warning("could not allocate a task key for project %s", project.id)
+    return None

--- a/backend/src/shared/database/task_models.py
+++ b/backend/src/shared/database/task_models.py
@@ -364,7 +364,16 @@ class Task(Base):
 
 
 class TaskComment(Base):
-    """A markdown comment on a task, by a user or an agent."""
+    """A markdown comment on a task, by a user or an agent.
+
+    Comments thread **one level deep**: a comment is either a root or a reply to
+    a root, never a reply to a reply. `create_comment` enforces that by
+    re-pointing a reply-to-a-reply at the thread's root rather than rejecting it,
+    which is what Slack and GitHub Discussions do and for the same reason — an
+    arbitrarily deep tree has to be indent-capped somewhere in the UI anyway, and
+    capping it in the data keeps every client (web, mobile, CLI) rendering the
+    same shape instead of each inventing its own flattening rule.
+    """
 
     __tablename__ = "task_comments"
     __table_args__ = (
@@ -374,6 +383,13 @@ class TaskComment(Base):
         CheckConstraint("kind IN ('comment','system')", name="ck_task_comments_kind"),
         Index("ix_task_comments_task", "task_id", "created_at"),
         Index("ix_task_comments_project", "project_id"),
+        # Partial: only replies carry a parent, and the lookup is always
+        # "the replies under this root", never "the roots".
+        Index(
+            "ix_task_comments_parent",
+            "parent_comment_id",
+            postgresql_where=text("parent_comment_id IS NOT NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -385,6 +401,17 @@ class TaskComment(Base):
     project_id: Mapped[UUID] = mapped_column(
         ForeignKey("projects.id", ondelete="CASCADE"),
         type_=PostgresUUID(as_uuid=True),
+    )
+    # The root this comment answers, or NULL when it *is* a root. Always points
+    # at a root (see the class docstring), so `parent_comment_id IS NULL` is the
+    # whole test for "is a root" and no client ever walks a chain. CASCADE is
+    # unreachable in practice — a comment is soft-deleted, so the only hard
+    # delete is the task's — but it keeps replies from outliving their root if
+    # one ever is purged.
+    parent_comment_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("task_comments.id", ondelete="CASCADE"),
+        type_=PostgresUUID(as_uuid=True),
+        default=None,
     )
     # Polymorphic author: users.id or agent_profiles.id. Not an FK — the two
     # targets are different tables and a deleted principal must leave the thread

--- a/backend/src/shared/database/task_models.py
+++ b/backend/src/shared/database/task_models.py
@@ -18,10 +18,12 @@ from sqlalchemy import (
     Double,
     ForeignKey,
     Index,
+    Integer,
     String,
     Table,
     Text,
     UniqueConstraint,
+    func,
     text,
 )
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID, JSONB
@@ -43,6 +45,37 @@ TASK_STATUSES = (
 )
 TASK_PRIORITIES = ("urgent", "high", "medium", "low", "none")
 
+# Task-depth vocabularies (collaboration plan §3.5).
+COMMENT_AUTHOR_TYPES = ("user", "agent")
+COMMENT_KINDS = ("comment", "system")
+REACTION_TARGET_TYPES = ("task", "comment")
+ACTIVITY_ACTOR_TYPES = ("user", "agent", "system")
+SUBSCRIBER_REASONS = ("creator", "assignee", "commenter", "mentioned", "manual")
+
+# Reactions are open-ended: the client offers a curated set plus the full
+# Unicode picker, so an allowlist here would only be a second, staler list to
+# keep in step. What IS enforced (`shared.database.reactions.is_emoji`) is that
+# the value is an emoji at all — the column is a free varchar, and letting
+# arbitrary text through would make it a junk-data and rendering vector.
+
+# Every `action` the activity listener can emit. Kept as a tuple (not a CHECK)
+# because the vocabulary grows with the UI and a stale CHECK would 500 a write
+# rather than degrade to an unrendered row.
+ACTIVITY_ACTIONS = (
+    "created",
+    "status_changed",
+    "priority_changed",
+    "assigned",
+    "title_changed",
+    "description_changed",
+    "label_added",
+    "label_removed",
+    "due_date_set",
+    "start_date_set",
+    "project_changed",
+    "parent_changed",
+)
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -60,6 +93,19 @@ class Project(Base):
             "user_id",
             unique=True,
             postgresql_where=text("is_inbox"),
+        ),
+        # The task key namespace (§3.5 / D-B): "VIC" makes tasks read "VIC-42".
+        # Unique within the OWNER, never globally — a global key namespace would
+        # re-import the squatting/enumeration problems §3.2 avoids for team slugs.
+        # P3 adds `projects.team_id` and splits this into two partial indexes
+        # (team_id IS NULL / IS NOT NULL); until that column exists there is only
+        # one owner to scope by.
+        Index(
+            "uq_projects_user_key",
+            "user_id",
+            func.upper(text("key")),
+            unique=True,
+            postgresql_where=text("key IS NOT NULL"),
         ),
     )
 
@@ -86,6 +132,16 @@ class Project(Base):
     # user_id) so a project can later move to a team without rekeying (§9).
     icon_image_uri: Mapped[str | None] = mapped_column(Text, default=None)
     icon_source: Mapped[str | None] = mapped_column(String(16), default=None)
+    # Display prefix for this project's task identifiers ("VIC" -> "VIC-42").
+    # Auto-derived from the name on create, user-editable afterwards. Renaming a
+    # project deliberately does NOT re-derive it: the whole point of the key is
+    # that "VIC-42" written in an old commit message keeps resolving.
+    key: Mapped[str | None] = mapped_column(String(8), default=None)
+    # High-water mark for `tasks.number` in this project. Bumped with
+    # UPDATE ... RETURNING inside the insert transaction (a per-project sequence
+    # is not an option; a counter row + row lock is). Never decremented — a
+    # deleted or moved-away task does not free its number.
+    task_counter: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     # The per-user "No project" bucket; non-archivable, non-deletable.
     is_inbox: Mapped[bool] = mapped_column(default=False)
     is_archived: Mapped[bool] = mapped_column(default=False)
@@ -227,6 +283,16 @@ class Task(Base):
         ),
         Index("ix_tasks_user", "user_id"),
         Index("ix_tasks_project", "project_id", "status"),
+        # Per-project sequential identifier. Partial because rows created before
+        # the backfill (and any row whose allocation lost a race) stay NULL and
+        # simply render without an identifier rather than blocking the insert.
+        Index(
+            "uq_tasks_project_number",
+            "project_id",
+            "number",
+            unique=True,
+            postgresql_where=text("number IS NOT NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -240,6 +306,12 @@ class Task(Base):
         ForeignKey("projects.id", ondelete="CASCADE"),
         type_=PostgresUUID(as_uuid=True),
     )
+
+    # Per-project sequential number; rendered as `{project.key}-{number}`.
+    # Allocated from projects.task_counter in the insert transaction. Nullable
+    # so the column can land ahead of its backfill and so a task can exist
+    # transiently without one.
+    number: Mapped[int | None] = mapped_column(Integer, default=None)
 
     title: Mapped[str] = mapped_column(String(255))
     description: Mapped[str | None] = mapped_column(Text, default=None)
@@ -275,4 +347,177 @@ class Task(Base):
 
     labels: Mapped[list["TaskLabel"]] = relationship(
         "TaskLabel", secondary=task_label_links, order_by="TaskLabel.name"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task depth — comments, reactions, activity, subscribers (collaboration §3.5)
+#
+# None of these tables carries `user_id`. That is deliberate and does NOT break
+# the "every query filters by user_id" house rule: a comment's author need not
+# be the task's owner once sharing lands, so the row has no single owning user.
+# Scoping runs through the task instead — resolve it with the user-scoped
+# `get_task(db, user_id, task_id)` first, then query by `task_id`. `project_id`
+# is denormalized onto the child rows so P3 can add a project-level predicate
+# without a join; it MUST be kept in step when a task moves project.
+# ---------------------------------------------------------------------------
+
+
+class TaskComment(Base):
+    """A markdown comment on a task, by a user or an agent."""
+
+    __tablename__ = "task_comments"
+    __table_args__ = (
+        CheckConstraint(
+            "author_type IN ('user','agent')", name="ck_task_comments_author_type"
+        ),
+        CheckConstraint("kind IN ('comment','system')", name="ck_task_comments_kind"),
+        Index("ix_task_comments_task", "task_id", "created_at"),
+        Index("ix_task_comments_project", "project_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgresUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    task_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tasks.id", ondelete="CASCADE"), type_=PostgresUUID(as_uuid=True)
+    )
+    project_id: Mapped[UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        type_=PostgresUUID(as_uuid=True),
+    )
+    # Polymorphic author: users.id or agent_profiles.id. Not an FK — the two
+    # targets are different tables and a deleted principal must leave the thread
+    # readable ("Deleted agent said …"), which a CASCADE would not.
+    author_type: Mapped[str] = mapped_column(String(8), default="user")
+    author_id: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True))
+    body: Mapped[str] = mapped_column(Text)
+    kind: Mapped[str] = mapped_column(String(16), default="comment")
+    # Soft delete: removing the row outright would strand replies and reactions
+    # and leave a hole in a thread other comments refer to.
+    edited_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+
+class TaskReaction(Base):
+    """One emoji from one user on one task or comment."""
+
+    __tablename__ = "task_reactions"
+    __table_args__ = (
+        CheckConstraint(
+            "target_type IN ('task','comment')", name="ck_task_reactions_target_type"
+        ),
+        UniqueConstraint(
+            "target_type",
+            "target_id",
+            "user_id",
+            "emoji",
+            name="uq_task_reactions_target_user_emoji",
+        ),
+        Index("ix_task_reactions_target", "target_type", "target_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgresUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    # Polymorphic target (task or comment), so no FK; both parents CASCADE from
+    # the task, and orphan reactions are swept with the task delete.
+    target_type: Mapped[str] = mapped_column(String(8))
+    target_id: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True))
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), type_=PostgresUUID(as_uuid=True)
+    )
+    # Validated as *an emoji* at the API layer, not constrained to a list: the
+    # offered set is a product choice that changes, and a CHECK would need a
+    # migration each time while rejecting rows an older client legitimately
+    # wrote. Long enough for a ZWJ sequence with skin-tone modifiers.
+    emoji: Mapped[str] = mapped_column(String(16))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow
+    )
+
+
+class TaskActivity(Base):
+    """A machine-generated record of one task mutation.
+
+    Written by the ``after_flush`` listener in ``shared/database/task_activity``
+    — never by a call site. Task mutations arrive from the human REST API, the
+    agent-facing REST API, the automation runner and the instance-status sync;
+    the flush is the one point all of them pass through.
+    """
+
+    __tablename__ = "task_activity"
+    __table_args__ = (
+        CheckConstraint(
+            "actor_type IS NULL OR actor_type IN ('user','agent','system')",
+            name="ck_task_activity_actor_type",
+        ),
+        Index("ix_task_activity_task", "task_id", "created_at"),
+        Index("ix_task_activity_project", "project_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgresUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    task_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tasks.id", ondelete="CASCADE"), type_=PostgresUUID(as_uuid=True)
+    )
+    project_id: Mapped[UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        type_=PostgresUUID(as_uuid=True),
+    )
+    # NULL when no actor could be resolved — a background sweep with no request
+    # context. Renders as an unattributed line rather than being dropped.
+    actor_type: Mapped[str | None] = mapped_column(String(8), default=None)
+    actor_id: Mapped[UUID | None] = mapped_column(
+        PostgresUUID(as_uuid=True), default=None
+    )
+    action: Mapped[str] = mapped_column(String(40))
+    # {"from": ..., "to": ...} for a field change. Also carries
+    # `agent_instance_id` when the change came from the instance-status sync, so
+    # the task-detail timeline can fold a session's status churn into that
+    # session's own card instead of listing it three times.
+    details: Mapped[dict] = mapped_column(JSONB, default=dict, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow
+    )
+
+
+class TaskSubscriber(Base):
+    """Who gets notified about a task. One row per (task, user)."""
+
+    __tablename__ = "task_subscribers"
+    __table_args__ = (
+        CheckConstraint(
+            "reason IN ('creator','assignee','commenter','mentioned','manual')",
+            name="ck_task_subscribers_reason",
+        ),
+        Index("ix_task_subscribers_user", "user_id"),
+    )
+
+    task_id: Mapped[UUID] = mapped_column(
+        ForeignKey("tasks.id", ondelete="CASCADE"),
+        type_=PostgresUUID(as_uuid=True),
+        primary_key=True,
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        type_=PostgresUUID(as_uuid=True),
+        primary_key=True,
+    )
+    # Why they are subscribed. First reason wins — an explicit 'manual' is not
+    # downgraded by a later auto-subscribe.
+    reason: Mapped[str] = mapped_column(String(16), default="manual")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow
     )

--- a/backend/src/shared/database/tasks.py
+++ b/backend/src/shared/database/tasks.py
@@ -11,6 +11,7 @@ from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, attributes
 
+from .actor import Actor, register_activity_override
 from .enums import AgentStatus
 from .models import AgentInstance
 from .task_models import Project, Task
@@ -101,6 +102,20 @@ def _sync_task_status_before_flush(session: Session, flush_context, instances) -
             obj.status.value,
             task.id,
             mapped,
+        )
+        # Attribute the move to the agent, not to whoever's request happened to
+        # carry the status update — the daemon posts it authenticated as the
+        # user, but the thing that moved the task is the session. Carrying the
+        # instance id lets the task timeline fold this session's status hops
+        # into its session card rather than listing each one.
+        register_activity_override(
+            session,
+            task.id,
+            Actor(
+                type="agent" if obj.agent_profile_id else "system",
+                id=obj.agent_profile_id,
+                agent_instance_id=obj.id,
+            ),
         )
         task.status = mapped
 

--- a/backend/src/vicoa/cli.py
+++ b/backend/src/vicoa/cli.py
@@ -1769,7 +1769,7 @@ Examples:
 
     task_parser = subparsers.add_parser(
         "task",
-        help="List, read, create, update, or delete tasks",
+        help="List, read, create, update, comment on, or delete tasks",
     )
     task_sub = task_parser.add_subparsers(dest="task_command")
 
@@ -1805,7 +1805,7 @@ Examples:
     task_get = task_sub.add_parser(
         "get", parents=[task_common], help="Show one task's full details"
     )
-    task_get.add_argument("task_id", help="Task id (full UUID)")
+    task_get.add_argument("task_id", help="Task identifier (VIC-42) or full UUID")
 
     task_create = task_sub.add_parser(
         "create", parents=[task_common], help="Create a task"
@@ -1824,7 +1824,9 @@ Examples:
         "--priority", choices=TASK_PRIORITIES, help="Priority (default: none)"
     )
     task_create.add_argument(
-        "--parent", metavar="TASK_ID", help="Parent task id (creates a subtask)"
+        "--parent",
+        metavar="TASK",
+        help="Parent task, VIC-42 or UUID (creates a subtask)",
     )
     task_create.add_argument(
         "--start", metavar="ISO8601", help="Start date, e.g. 2026-08-01"
@@ -1838,7 +1840,7 @@ Examples:
         parents=[task_common],
         help="Update a task (only the flags you pass change)",
     )
-    task_update.add_argument("task_id", help="Task id (full UUID)")
+    task_update.add_argument("task_id", help="Task identifier (VIC-42) or full UUID")
     task_update.add_argument("--title", help="New title")
     task_update.add_argument("--description", help="New description")
     task_update.add_argument(
@@ -1846,14 +1848,47 @@ Examples:
     )
     task_update.add_argument("--status", choices=TASK_STATUSES, help="New status")
     task_update.add_argument("--priority", choices=TASK_PRIORITIES, help="New priority")
-    task_update.add_argument("--parent", metavar="TASK_ID", help="New parent task id")
+    task_update.add_argument(
+        "--parent", metavar="TASK", help="New parent task, VIC-42 or UUID"
+    )
     task_update.add_argument("--start", metavar="ISO8601", help="New start date")
     task_update.add_argument("--due", metavar="ISO8601", help="New due date")
+
+    task_comments = task_sub.add_parser(
+        "comments",
+        parents=[task_common],
+        help="Read a task's comment thread",
+    )
+    task_comments.add_argument("task_id", help="Task identifier (VIC-42) or full UUID")
+    task_comments.add_argument(
+        "--activity",
+        action="store_true",
+        help="Also print the generated activity log (status changes, edits)",
+    )
+
+    task_comment = task_sub.add_parser(
+        "comment",
+        parents=[task_common],
+        help="Post a comment on a task (use '-' to read the body from stdin)",
+    )
+    task_comment.add_argument("task_id", help="Task identifier (VIC-42) or full UUID")
+    task_comment.add_argument(
+        "body",
+        help="Comment body (markdown). Pass '-' to read it from stdin instead.",
+    )
+    task_comment.add_argument(
+        "--reply-to",
+        metavar="COMMENT_ID",
+        help=(
+            "Reply to this comment. Threads are one level deep — replying to a "
+            "reply lands in the same thread."
+        ),
+    )
 
     task_delete = task_sub.add_parser(
         "delete", parents=[task_common], help="Delete a task"
     )
-    task_delete.add_argument("task_id", help="Task id (full UUID)")
+    task_delete.add_argument("task_id", help="Task identifier (VIC-42) or full UUID")
     task_delete.add_argument(
         "-y", "--yes", action="store_true", help="Skip the confirmation prompt"
     )

--- a/backend/src/vicoa/commands/task.py
+++ b/backend/src/vicoa/commands/task.py
@@ -1,10 +1,14 @@
-"""``vicoa task`` — list, read, create, update, and delete Vicoa tasks.
+"""``vicoa task`` — list, read, create, update, comment on, and delete tasks.
 
 Built so a running AI agent can manage its user's task backlog without leaving
 the terminal (``vicoa task create "Fix the flaky test"``). Talks to the
 agent-facing server (``agents.vicoa.ai``) with the same Bearer API key every
 other ``vicoa`` command uses, hitting the ``/api/v1/tasks`` endpoints added in
 ``servers/api/tasks.py``.
+
+Every task reference — the positional ``task_id`` on ``get``/``update``/
+``delete``/``comment(s)``, and ``--parent`` — accepts either the identifier the
+user actually sees (``VIC-42``) or a full UUID.
 
 Human-readable tables by default; ``--json`` on every subcommand for agents (or
 scripts) that want to parse the result. Kept dependency-light — no
@@ -17,6 +21,7 @@ import json as _json
 import os
 import sys
 from typing import Any, Optional
+from uuid import UUID
 
 from vicoa.constants import DEFAULT_API_URL
 
@@ -147,12 +152,16 @@ def _print_task_table(tasks: list[dict]) -> None:
     if not tasks:
         print("No tasks found.")
         return
-    header = f"{'ID':<8}  {'STATUS':<12} {'PRIO':<7} {'TITLE':<{_TITLE_W}}"
+    # Both an id and an identifier: the short id is what the other subcommands
+    # take (truncated, so it is a browsing aid either way), while "VIC-42" is
+    # what an agent quotes back to its user and what the web deep-links to.
+    header = f"{'ID':<8}  {'KEY':<9} {'STATUS':<12} {'PRIO':<7} {'TITLE':<{_TITLE_W}}"
     print(header)
     print("-" * len(header))
     for t in tasks:
         print(
             f"{_short(t.get('id')):<8}  "
+            f"{str(t.get('identifier') or '—'):<9} "
             f"{str(t.get('status', '')):<12} "
             f"{str(t.get('priority', '')):<7} "
             f"{_fit(t.get('title', ''), _TITLE_W):<{_TITLE_W}}"
@@ -164,6 +173,10 @@ def _print_task_detail(t: dict) -> None:
     labels = ", ".join(lbl.get("name", "") for lbl in t.get("labels", [])) or "—"
     lines = [
         f"id:          {t.get('id')}",
+        # The speakable identifier ("VIC-42"). Absent for a task that predates
+        # the backfill; print nothing rather than a placeholder that would look
+        # like a real reference someone could quote back.
+        *([f"identifier:  {t['identifier']}"] if t.get("identifier") else []),
         f"title:       {t.get('title')}",
         f"status:      {t.get('status')}",
         f"priority:    {t.get('priority')}",
@@ -179,6 +192,84 @@ def _print_task_detail(t: dict) -> None:
     description = t.get("description")
     if description:
         print(f"\ndescription:\n{description}")
+
+
+def _principal_name(principal: Optional[dict]) -> str:
+    if not principal:
+        return "someone"
+    name = principal.get("name") or "Unknown"
+    # The agent tag matters here in a way it doesn't on the web, where an avatar
+    # already says it: in a terminal "Claude" and "Nick" look identical.
+    return f"{name} (agent)" if principal.get("type") == "agent" else name
+
+
+def _print_comment(c: dict, indent: str = "") -> None:
+    header = f"{indent}{_principal_name(c.get('author'))}  {c.get('created_at', '')}"
+    if c.get("edited_at"):
+        header += "  (edited)"
+    print(header)
+    print(f"{indent}  id: {c.get('id')}")
+    body = c.get("body")
+    if body is None:
+        print(f"{indent}  (deleted)")
+    else:
+        for line in body.splitlines() or [""]:
+            print(f"{indent}  {line}")
+    reactions = c.get("reactions") or []
+    if reactions:
+        print(
+            f"{indent}  "
+            + "  ".join(f"{r.get('emoji')} {r.get('count')}" for r in reactions)
+        )
+    print()
+
+
+def _print_thread(comments: list[dict]) -> None:
+    """Print the thread. Replies are indented under the root they answer.
+
+    The server sends the list already in thread order (each root followed by its
+    replies), so this only has to decide the indent — it never has to sort or
+    walk a tree, and neither does any other client.
+    """
+    if not comments:
+        print("No comments yet.")
+        return
+    for c in comments:
+        _print_comment(c, indent="    " if c.get("parent_comment_id") else "")
+
+
+def _print_activity(activity: list[dict]) -> None:
+    print("--- activity ---")
+    if not activity:
+        print("No activity yet.")
+        return
+    for row in activity:
+        details = row.get("details") or {}
+        change = ""
+        if "from" in details or "to" in details:
+            change = f" ({details.get('from')} -> {details.get('to')})"
+        print(
+            f"{row.get('created_at', '')}  "
+            f"{_principal_name(row.get('actor'))}  "
+            f"{str(row.get('action', '')).replace('_', ' ')}{change}"
+        )
+
+
+def _resolve_parent(args, api_key: str, ref: str) -> str:
+    """Turn a ``--parent`` reference into the UUID the request body needs.
+
+    Path parameters accept "VIC-42" server-side, but ``parent_task_id`` travels
+    in the body as a typed UUID. Rather than loosen that field for every client,
+    the one client that lets a *person* type a parent resolves it here — one
+    extra GET, and only when the value isn't already a UUID.
+    """
+    try:
+        UUID(ref)
+        return ref
+    except (ValueError, AttributeError):
+        pass
+    task = _request(args, api_key, "GET", f"/api/v1/tasks/{ref}")
+    return task["id"]
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +313,7 @@ def _cmd_create(args, api_key: str) -> int:
     if getattr(args, "priority", None):
         body["priority"] = args.priority
     if getattr(args, "parent", None):
-        body["parent_task_id"] = args.parent
+        body["parent_task_id"] = _resolve_parent(args, api_key, args.parent)
     if getattr(args, "start", None):
         body["start_date"] = args.start
     if getattr(args, "due", None):
@@ -250,8 +341,11 @@ def _cmd_update(args, api_key: str) -> int:
         ("due", "due_date"),
     ):
         value = getattr(args, flag, None)
-        if value is not None:
-            body[field] = value
+        if value is None:
+            continue
+        body[field] = (
+            _resolve_parent(args, api_key, value) if flag == "parent" else value
+        )
     if not body:
         print(
             "Nothing to update — pass at least one field "
@@ -264,6 +358,56 @@ def _cmd_update(args, api_key: str) -> int:
         print(_json.dumps(task, indent=2))
     else:
         print(f"Updated task {task.get('id')}: {task.get('title')}")
+    return 0
+
+
+def _cmd_comments(args, api_key: str) -> int:
+    timeline = _request(args, api_key, "GET", f"/api/v1/tasks/{args.task_id}/timeline")
+    if getattr(args, "json", False):
+        print(_json.dumps(timeline, indent=2))
+        return 0
+    _print_thread(timeline.get("comments", []))
+    if getattr(args, "activity", False):
+        _print_activity(timeline.get("activity", []))
+    return 0
+
+
+def _cmd_comment(args, api_key: str) -> int:
+    body = args.body
+    # '-' reads stdin, so an agent can pipe a multi-line markdown report in
+    # rather than fighting its own shell over quoting and newlines.
+    if body == "-":
+        body = sys.stdin.read()
+    body = body.strip()
+    if not body:
+        print("Refusing to post an empty comment.", file=sys.stderr)
+        return 2
+
+    payload: dict[str, Any] = {"body": body}
+    if getattr(args, "reply_to", None):
+        payload["parent_comment_id"] = args.reply_to
+    # When this runs inside a Vicoa session, tell the server which one: if that
+    # session was started from an agent profile the comment is authored by the
+    # agent ("Claude commented"), not by the human whose API key it is.
+    self_id = os.environ.get("VICOA_AGENT_INSTANCE_ID")
+    if self_id:
+        payload["agent_instance_id"] = self_id
+
+    timeline = _request(
+        args,
+        api_key,
+        "POST",
+        f"/api/v1/tasks/{args.task_id}/comments",
+        json=payload,
+    )
+    if getattr(args, "json", False):
+        print(_json.dumps(timeline, indent=2))
+        return 0
+    # Not `comments[-1]`: the list comes back in thread order, so a reply is
+    # spliced under its root rather than appended at the end.
+    comments = timeline.get("comments", [])
+    posted = max(comments, key=lambda c: c.get("created_at") or "", default=None)
+    print(f"Posted comment {posted.get('id')}" if posted else "Posted comment.")
     return 0
 
 
@@ -289,6 +433,8 @@ _HANDLERS = {
     "get": _cmd_get,
     "create": _cmd_create,
     "update": _cmd_update,
+    "comments": _cmd_comments,
+    "comment": _cmd_comment,
     "delete": _cmd_delete,
 }
 
@@ -299,7 +445,7 @@ def run_task_command(args) -> int:
     handler = _HANDLERS.get(sub) if sub else None
     if handler is None:
         print(
-            "usage: vicoa task {ls,get,create,update,delete} ...\n"
+            "usage: vicoa task {ls,get,create,update,comments,comment,delete} ...\n"
             "Run `vicoa task --help` for details.",
             file=sys.stderr,
         )

--- a/backend/tests/test_task_comment_cli.py
+++ b/backend/tests/test_task_comment_cli.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``vicoa task comment`` / ``vicoa task comments``.
+
+The endpoints themselves are covered in ``servers/tests/test_task_endpoints.py``;
+what is only reachable here is the request the CLI *builds* — the stdin body, the
+``--reply-to`` mapping, and the ``VICOA_AGENT_INSTANCE_ID`` pickup that decides
+whether a comment is signed by the agent or by the human whose key it used.
+"""
+
+import io
+import json
+import types
+
+import pytest
+
+from vicoa.commands import task as T
+
+
+def _args(**over):
+    """A namespace shaped like the one argparse hands the handler."""
+    base = {"task_id": "t-1", "json": False, "api_key": "k", "base_url": None}
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def _capture_request(monkeypatch, reply=None):
+    """Swap out the HTTP layer and record what the handler tried to send."""
+    sent = {}
+
+    def fake_request(args, api_key, method, endpoint, *, params=None, json=None):
+        sent.update(method=method, endpoint=endpoint, json=json)
+        return reply if reply is not None else {"comments": [], "activity": []}
+
+    monkeypatch.setattr(T, "_request", fake_request)
+    return sent
+
+
+def _comment(cid, body, parent=None, created_at="2026-09-09T10:00:00Z", author=None):
+    return {
+        "id": cid,
+        "parent_comment_id": parent,
+        "author": author or {"type": "user", "name": "Nick"},
+        "body": body,
+        "reactions": [],
+        "created_at": created_at,
+        "edited_at": None,
+        "deleted_at": None,
+    }
+
+
+class TestPostingAComment:
+    def test_posts_the_body(self, monkeypatch):
+        sent = _capture_request(
+            monkeypatch, {"comments": [_comment("c1", "all green")]}
+        )
+        assert T._cmd_comment(_args(body="all green", reply_to=None), "k") == 0
+        assert sent["method"] == "POST"
+        assert sent["endpoint"] == "/api/v1/tasks/t-1/comments"
+        assert sent["json"]["body"] == "all green"
+        assert "parent_comment_id" not in sent["json"]
+
+    def test_dash_reads_the_body_from_stdin(self, monkeypatch):
+        """So an agent can pipe a multi-line markdown report in rather than
+        fighting its own shell over quoting and newlines."""
+        sent = _capture_request(monkeypatch)
+        monkeypatch.setattr("sys.stdin", io.StringIO("## Done\n\n- fixed the flake\n"))
+        assert T._cmd_comment(_args(body="-", reply_to=None), "k") == 0
+        assert sent["json"]["body"] == "## Done\n\n- fixed the flake"
+
+    def test_empty_body_is_refused_without_a_request(self, monkeypatch):
+        sent = _capture_request(monkeypatch)
+        assert T._cmd_comment(_args(body="   ", reply_to=None), "k") == 2
+        assert sent == {}
+
+    def test_reply_to_becomes_the_parent(self, monkeypatch):
+        sent = _capture_request(monkeypatch)
+        T._cmd_comment(_args(body="because", reply_to="c-root"), "k")
+        assert sent["json"]["parent_comment_id"] == "c-root"
+
+    def test_inside_a_session_it_names_the_session(self, monkeypatch):
+        """The one thing that lets a comment be signed by the agent instead of
+        by the human whose API key it is."""
+        sent = _capture_request(monkeypatch)
+        monkeypatch.setenv("VICOA_AGENT_INSTANCE_ID", "sess-9")
+        T._cmd_comment(_args(body="done", reply_to=None), "k")
+        assert sent["json"]["agent_instance_id"] == "sess-9"
+
+    def test_outside_a_session_it_stays_silent(self, monkeypatch):
+        sent = _capture_request(monkeypatch)
+        monkeypatch.delenv("VICOA_AGENT_INSTANCE_ID", raising=False)
+        T._cmd_comment(_args(body="done", reply_to=None), "k")
+        assert "agent_instance_id" not in sent["json"]
+
+    def test_reports_the_comment_it_just_posted(self, monkeypatch, capsys):
+        """Not `comments[-1]`: the timeline comes back in thread order, so a
+        reply is spliced under its root rather than appended at the end."""
+        _capture_request(
+            monkeypatch,
+            {
+                "comments": [
+                    _comment("root", "why?", created_at="2026-09-09T10:00:00Z"),
+                    _comment(
+                        "new",
+                        "because",
+                        parent="root",
+                        created_at="2026-09-09T11:00:00Z",
+                    ),
+                    _comment("later", "unrelated", created_at="2026-09-09T10:30:00Z"),
+                ]
+            },
+        )
+        T._cmd_comment(_args(body="because", reply_to="root"), "k")
+        assert "Posted comment new" in capsys.readouterr().out
+
+    def test_json_passes_the_timeline_straight_through(self, monkeypatch, capsys):
+        payload = {"comments": [_comment("c1", "hi")], "activity": []}
+        _capture_request(monkeypatch, payload)
+        T._cmd_comment(_args(body="hi", reply_to=None, json=True), "k")
+        assert json.loads(capsys.readouterr().out) == payload
+
+
+class TestReadingTheThread:
+    def test_replies_are_indented_under_their_root(self, monkeypatch, capsys):
+        _capture_request(
+            monkeypatch,
+            {
+                "comments": [
+                    _comment("root", "why?"),
+                    _comment("r1", "because", parent="root"),
+                ],
+                "activity": [],
+            },
+        )
+        T._cmd_comments(_args(activity=False), "k")
+        lines = capsys.readouterr().out.splitlines()
+        assert any(line == "  why?" for line in lines)
+        assert any(line == "      because" for line in lines)
+
+    def test_an_agent_author_is_labelled(self, monkeypatch, capsys):
+        """In a terminal "Claude" and "Nick" look identical without the tag —
+        the web has an avatar doing that job."""
+        _capture_request(
+            monkeypatch,
+            {
+                "comments": [
+                    _comment(
+                        "c1",
+                        "shipped",
+                        author={"type": "agent", "name": "Reviewer"},
+                    )
+                ],
+                "activity": [],
+            },
+        )
+        T._cmd_comments(_args(activity=False), "k")
+        assert "Reviewer (agent)" in capsys.readouterr().out
+
+    def test_a_deleted_comment_shows_a_tombstone(self, monkeypatch, capsys):
+        comment = _comment("c1", None)
+        comment["deleted_at"] = "2026-09-09T12:00:00Z"
+        _capture_request(monkeypatch, {"comments": [comment], "activity": []})
+        T._cmd_comments(_args(activity=False), "k")
+        assert "(deleted)" in capsys.readouterr().out
+
+    def test_activity_is_opt_in(self, monkeypatch, capsys):
+        timeline = {
+            "comments": [],
+            "activity": [
+                {
+                    "actor": {"type": "user", "name": "Nick"},
+                    "action": "status_changed",
+                    "details": {"from": "todo", "to": "done"},
+                    "created_at": "2026-09-09T10:00:00Z",
+                }
+            ],
+        }
+        _capture_request(monkeypatch, timeline)
+        T._cmd_comments(_args(activity=False), "k")
+        assert "status changed" not in capsys.readouterr().out
+
+        _capture_request(monkeypatch, timeline)
+        T._cmd_comments(_args(activity=True), "k")
+        out = capsys.readouterr().out
+        assert "status changed (todo -> done)" in out
+
+
+class TestTaskTable:
+    def test_shows_the_identifier_when_there_is_one(self, capsys):
+        T._print_task_table(
+            [
+                {"id": "aaaabbbbcccc", "identifier": "VIC-42", "title": "x"},
+                {"id": "ddddeeeeffff", "identifier": None, "title": "y"},
+            ]
+        )
+        out = capsys.readouterr().out
+        assert "VIC-42" in out
+        # A task predating the backfill renders without one rather than with a
+        # placeholder that would look like a real reference.
+        assert "—" in out
+
+
+@pytest.mark.parametrize(
+    "principal,expected",
+    [
+        (None, "someone"),
+        ({"type": "user", "name": "Nick"}, "Nick"),
+        ({"type": "agent", "name": "Reviewer"}, "Reviewer (agent)"),
+        ({"type": "system", "name": None}, "Unknown"),
+    ],
+)
+def test_principal_name(principal, expected):
+    assert T._principal_name(principal) == expected


### PR DESCRIPTION
## What & why

Collaboration **P2 — task depth** (plan §3.5 / §8.3). A task was a title, a status and a
place to hang a session off. It had no way to record *why* something moved, no way to say
anything about it, and no name you could speak.

**Identifiers.** `tasks.number` (per-project, allocated with `UPDATE … RETURNING` inside the
insert txn) + `projects.key`, rendering as **VIC-42**. Not display-only: `resolve_task` takes
an identifier *or* a UUID, and every `{task_id}` path param on both routers goes through it —
so `GET /api/v1/tasks/VIC-42`, `/dashboard/tasks/VIC-42` and `vicoa task comment VIC-42` all
resolve. A UUID is a handle neither the user nor the agent can see. Keys are unique per owner,
never globally, so `VIC-1` in another account is a different task and neither can reach the
other. Params are typed `str`, so a typo is a 404 rather than a 422 about UUID format.

**Comments, threaded one level.** `parent_comment_id` always names a root — a reply to a reply
is re-pointed at that reply's root rather than refused, because someone clicking "Reply" under
a nested comment means "answer in this thread". Capping depth in the data rather than in each
client keeps web, CLI and mobile rendering the same shape. `build_timeline` serves the list
already threaded, so a client that only wants to print the conversation walks it straight
through.

**Activity is generated by a SQLAlchemy `after_flush` listener**, never by a call site — task
mutations arrive from the dashboard API, the agent API, the automation runner and the
instance-status sync, and writing a row at each is how a log ends up with holes. The actor is
stamped once per process in the auth dependency, so no endpoint has to remember to.

**Reactions** are open-ended (validated as *an emoji*, not against a list) with server-side
counts and "who reacted".

**Task detail is a real route** now, `/dashboard/tasks/[taskId]`: markdown description,
properties rail, and one timeline interleaving comments, activity and the sessions the task
spawned — a session card absorbs the status churn it caused instead of listing it three times.
One card per thread, replies at the same column as the root, and a permanently-visible reply
row. `task-dialog.tsx` stays as the fast create/edit path.

**`vicoa task comment` / `comments`** so an agent can report back on the task it was started
for instead of only in a transcript its user has to go find. `-` reads the body from stdin.
Authorship is not a flag: the CLI sends `VICOA_AGENT_INSTANCE_ID`, and a session started from
an agent profile signs as that agent — the only path that sets `author_type='agent'`. Edit,
delete and react stay human-facing; an agent quietly revising its own words rewrites the record
the human is reading.

**No WebSocket channel for tasks**, by decision (§9) — refresh-on-focus + a slow poll. Polling
hits the stateless `backend` app; the relay is pinned to `workers=1` and already carries every
daemon socket.

### Deliberately not here

- **Mobile timeline** — deferred out of this phase with a brief of its own. Everything it needs
  ships here and is exercised by two clients; bundling it would have doubled the review surface.
- One unrelated commit rides along: `ee6f148` (nav GitHub icon color, 1 line).

### Deploy order is not optional

`tasks.number`, `projects.key` and `projects.task_counter` land on the ORM models, so every
`db.query(Task)`/`query(Project)` enumerates them. Code deployed ahead of the migration means
`UndefinedColumn` on every query touching those tables — a whole-backend outage, not "the new
feature is inert". **Run `alembic upgrade head` before the backend deploy.**

## How it was tested

- `make test` → **2565 passed, 1 skipped**
- `make lint` → clean (ruff + pyright + WebSocket freeze check)
- `pnpm lint` + `pnpm vitest run` → clean, **812 passed**
- `pnpm build` → clean
- Migration `a3f1c9e27b45` round-tripped `downgrade` → `upgrade` against a real Postgres;
  `alembic revision --autogenerate` afterwards shows no model drift
- New coverage: identifier allocation/backfill/uniqueness, the activity listener, threading
  (reply-to-a-reply flattening, cross-task parent rejected, deleted root still anchors,
  thread ordering), agent-authored comments, reaction summaries, CLI request-building
  (stdin body, `--reply-to`, `VICOA_AGENT_INSTANCE_ID`), and identifier resolution
  (case-insensitivity, whitespace, cross-account isolation, 404-not-422)

- Platforms tested: backend (Postgres via testcontainers), web (Next build + vitest)
- Platforms NOT tested: **no manual browser pass and no screenshots** — the timeline and
  thread layout are covered by unit tests and a production build, not by eyes on the running
  app. Mobile is untouched by this PR.

## Checklist

- [x] One focused change; no unrelated edits bundled in — *except `ee6f148`, noted above*
- [x] Tests added/updated and passing (`make test` / `pnpm test`)
- [x] Lint passes (`make lint`)
- [x] DB schema change includes its migration (`a3f1c9e27b45`)
- [ ] Screenshots/video included for UI changes — **not included; see above**
- [x] I have read the Contributing guide
