### PR TITLE
New session: say why the composer is blocked, and measure it

### DIFF
--- a/apps/web/app/(login)/desktop-signin/page.tsx
+++ b/apps/web/app/(login)/desktop-signin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Loader2 } from 'lucide-react';
@@ -12,6 +12,11 @@ import {
   readDesktopAuthNonce,
   storeDesktopAuthNonce,
 } from '@/lib/desktop-auth';
+import {
+  trackSignInCancelled,
+  trackSignInRetried,
+  trackSignInWaiting,
+} from '@/lib/desktop-telemetry';
 import { useDesktopAuthCallback } from '../use-desktop-auth-callback';
 import { DRAG_REGION } from '@/lib/app-region';
 
@@ -32,6 +37,13 @@ export default function DesktopSignInPage() {
   const router = useRouter();
   const [phase, setPhase] = useState<'waiting' | 'connecting' | 'error'>('waiting');
   const [error, setError] = useState<string | null>(null);
+
+  // "We are waiting for the deep link" — the half of the sign-in hole that
+  // `desktop_onboarding_signin_started` alone cannot see. Mount-scoped, not
+  // action-scoped: reaching this screen IS the fact worth recording.
+  useEffect(() => {
+    trackSignInWaiting();
+  }, []);
 
   useDesktopAuthCallback((status) => {
     if (status.kind === 'connecting') {
@@ -54,6 +66,7 @@ export default function DesktopSignInPage() {
   // of truth — a pending callback stays valid), minting a fresh one only when
   // none exists.
   const openBrowser = useCallback(() => {
+    trackSignInRetried(phase === 'error');
     const bridge = getDesktopAuthBridge();
     if (!bridge) {
       setPhase('error');
@@ -66,9 +79,10 @@ export default function DesktopSignInPage() {
     setError(null);
     const mode = new URLSearchParams(window.location.search).get('mode');
     void bridge.openExternal(desktopAuthUrl(nonce, mode));
-  }, []);
+  }, [phase]);
 
   const cancel = useCallback(() => {
+    trackSignInCancelled();
     clearDesktopAuthNonce();
     router.push('/desktop-welcome');
   }, [router]);

--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -36,6 +36,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  resetNewSessionGuards,
+  trackNewSessionViewed,
+  trackSessionCreateFailed,
+  trackSubmitBlocked,
+  type MachineState,
+  type SessionCreateFailure,
+  type SubmitBlockedReason,
+} from '@/lib/desktop-telemetry';
 import { toAbsolutePath } from '@/lib/utils';
 import {
   isMachineOnline as isMachineOnlineShared,
@@ -171,6 +180,33 @@ const LIFTED_DROPDOWN_CLASSES =
   'w-[var(--radix-dropdown-menu-trigger-width)] py-1 font-mono ' +
   'border border-foreground/15 shadow-xl';
 const LIFTED_DROPDOWN_SIDE_OFFSET = 8;
+
+/**
+ * What to say when the composer can't submit, per surface.
+ *
+ * Split by surface because the original copy was web-only: "Run `vicoa daemon`
+ * to connect this machine" is unactionable in the desktop app, where the daemon
+ * is bundled and supervised by Electron. The user has no such command and
+ * should never need one.
+ */
+const SUBMIT_BLOCKED_COPY: Record<SubmitBlockedReason, { web: string; desktop: string }> = {
+  no_api: {
+    web: 'Unable to reach the API. Check that you are still signed in.',
+    desktop: 'Unable to reach the API. Check that you are still signed in.',
+  },
+  no_machine: {
+    web: 'No machines connected. Run `vicoa daemon` on a machine to connect it.',
+    desktop: 'Waiting for this machine to connect. The Vicoa daemon is still starting up.',
+  },
+  machine_offline: {
+    web: 'This machine is offline. Sessions can only be started on online machines.',
+    desktop: 'This machine is offline because the Vicoa daemon stopped. Restarting Vicoa reconnects it.',
+  },
+  no_directory: {
+    web: 'Choose a folder to work in before starting a session.',
+    desktop: 'Choose a folder to work in before starting a session.',
+  },
+};
 
 /** Setup chips above the prompt box (machine · directory · worktree).
     Same surface as the prompt box; hover ≈ the dropdown-item highlight
@@ -773,6 +809,36 @@ function NewSessionContent() {
 
   useEffect(() => { loadMachines(); }, [loadMachines]);
 
+  // What the picker actually resolved to, as a single value both the telemetry
+  // and the submit guard can read. Kept in a ref as well as derived at render
+  // because `handleSubmit` needs it from inside a callback without taking a
+  // dependency on every liveness tick.
+  const machineState: MachineState =
+    machines.length === 0 ? 'none' : machines.some(isMachineOnline) ? 'online' : 'offline';
+  const machineStateRef = useRef(machineState);
+  machineStateRef.current = machineState;
+
+  // Which shell this is. Runtime (not the compile-time NEXT_PUBLIC flag) because
+  // this page is served by the same bundle on web and desktop.
+  const isDesktop = !!getDesktopConfig();
+
+  // `submitBlockedReason` is derived far below, with the other render values —
+  // this ref lets `handleSubmit` read it without taking a dependency on every
+  // liveness tick.
+  const submitBlockedRef = useRef<SubmitBlockedReason | null>(null);
+
+  // Fires once, after the FIRST machine fetch settles — mount-time would report
+  // `none` for everybody, since the list is empty on the first render. This is
+  // the missing top of the activation funnel: of the people who reach this
+  // screen, how many are looking at a machine they can actually launch on.
+  useEffect(() => {
+    if (isLoadingMachines || !api) return;
+    trackNewSessionViewed(machineState, machines.length);
+  }, [isLoadingMachines, api, machineState, machines.length]);
+
+  // Re-arm the once-per-mount guards so a later visit is measured again.
+  useEffect(() => resetNewSessionGuards, []);
+
   // Realtime machine list over the shared WebSocket: a daemon connecting or
   // heartbeating broadcasts a `machine-update`, which we fold into the list at
   // once instead of waiting up to 30s for the poll. Reconnect (e.g. tab
@@ -1267,7 +1333,18 @@ function NewSessionContent() {
   }, [prompt, slashCommands]);
 
   const handleSubmit = useCallback(async () => {
-    if (!api || !selectedMachineId || !directory.trim() || isSubmitting) return;
+    if (isSubmitting) return;
+    // A blocked press is a real event, not a no-op. The reason is already on
+    // screen, in the banner directly above the composer, so the press adds no new
+    // UI — but the send button stays clickable rather than `disabled` so the
+    // press is measurable at all: a disabled button fires no onClick, which is
+    // why this leak was invisible for seven weeks.
+    const blocked = submitBlockedRef.current;
+    if (blocked) {
+      trackSubmitBlocked(blocked, machineStateRef.current);
+      return;
+    }
+    if (!api || !selectedMachineId || !directory.trim()) return;
 
     // The picker greys out profiles an out-of-date machine can't carry, but the
     // machine can be switched *after* one is chosen. Refuse rather than spawn an
@@ -1344,6 +1421,7 @@ function NewSessionContent() {
         },
       );
       if (result.error) {
+        trackSessionCreateFailed('spawn_error');
         setErrorMessage(String(result.error));
         setIsSubmitting(false);
         return;
@@ -1463,15 +1541,20 @@ function NewSessionContent() {
       openCreatedSession(router, startPath, `/dashboard/agents/${newInstanceId}`);
     } catch (error) {
       let message = 'Failed to start session. Please verify the daemon is running.';
+      let reason: SessionCreateFailure = 'unknown';
       if (error instanceof RpcError) {
         if (error.code === 'no_handler') {
           message = 'That machine is offline. Make sure the Vicoa daemon is running.';
+          reason = 'machine_offline';
         } else if (error.code === 'timeout') {
           message = "The daemon didn't respond in time. It may be busy — try again.";
+          reason = 'daemon_timeout';
         } else if (error.code === 'target_disconnected') {
           message = 'The daemon disconnected before responding. Try again in a moment.';
+          reason = 'daemon_disconnected';
         }
       }
+      trackSessionCreateFailed(reason);
       setErrorMessage(message);
       setIsSubmitting(false);
     }
@@ -1525,11 +1608,28 @@ function NewSessionContent() {
   const currentMachine = machines.find((m) => m.machine_id === selectedMachineId) || null;
   const recentDirectories = currentMachine ? getRecentDirectories(currentMachine) : [];
   const isOnline = currentMachine ? isMachineOnline(currentMachine) : false;
-  // Derived empty-machine notice — recomputed every render (incl. the liveness
-  // tick), so it clears the instant a daemon connects and reappears when the
-  // last one drops. Suppressed while a real error banner is showing.
-  const showNoMachinesNotice =
-    !!api && !isLoadingMachines && machines.length === 0 && !errorMessage;
+  /**
+   * The one reason the composer can't submit, in precedence order — recomputed
+   * every render (incl. the liveness tick), so it clears the instant a daemon
+   * connects and returns when the last one drops.
+   *
+   * `null` while the first machine fetch is in flight: showing "no machines" for
+   * the second before the list arrives is what made the screen read as broken on
+   * a slow start. Suppressed while a real error banner is showing, which is
+   * strictly more specific.
+   */
+  const submitBlockedReason: SubmitBlockedReason | null = (() => {
+    if (isLoadingMachines || errorMessage) return null;
+    if (!api) return 'no_api';
+    if (machines.length === 0 || !selectedMachineId) return 'no_machine';
+    if (!isOnline) return 'machine_offline';
+    if (!directory.trim()) return 'no_directory';
+    return null;
+  })();
+  submitBlockedRef.current = submitBlockedReason;
+  const blockedMessage = submitBlockedReason
+    ? SUBMIT_BLOCKED_COPY[submitBlockedReason][isDesktop ? 'desktop' : 'web']
+    : null;
   const canSubmit = !isSubmitting && !!api && !!selectedMachineId && !!directory.trim() && isOnline;
 
   // Live Claude plan usage (Session/Weekly limits) for the selected machine,
@@ -1650,30 +1750,10 @@ function NewSessionContent() {
         </div>
       </div>
 
-      {/* Main area — banners at the top, hero centered in the remaining space.
-          All selectors live as chips around the prompt box below. */}
+      {/* Main area: just the hero, centered. Banners live down in the composer,
+          next to the controls they are about. */}
       <div className="flex-1 min-h-0 overflow-y-auto p-6 pb-32 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-thumb]:rounded-full dark:[&::-webkit-scrollbar-thumb]:bg-muted-foreground/20">
         <div className="max-w-4xl mx-auto flex h-full flex-col">
-          {(errorMessage || showNoMachinesNotice || (currentMachine && !isOnline)) && (
-            <div className="space-y-4">
-              {errorMessage && (
-                <div className="bg-destructive/10 text-destructive text-sm px-3 py-2 rounded-lg font-mono">
-                  {errorMessage}
-                </div>
-              )}
-              {showNoMachinesNotice && (
-                <div className="bg-muted text-muted-foreground text-sm px-3 py-2 rounded-lg font-mono">
-                  No machines connected. Run{' '}
-                  <code className="text-foreground">vicoa daemon</code> to connect this machine.
-                </div>
-              )}
-              {currentMachine && !isOnline && (
-                <div className="bg-orange-500/10 text-orange-600 dark:text-orange-500 text-sm px-3 py-2 rounded-lg font-mono">
-                  This machine is currently offline. Sessions can only be started on online machines.
-                </div>
-              )}
-            </div>
-          )}
           <div className="flex flex-1 flex-col items-center justify-center gap-6 px-6">
             <Image
               src="/images/vicoa-light.webp"
@@ -1703,6 +1783,30 @@ function NewSessionContent() {
       {/* Chat-style input pinned to bottom */}
       <div className="flex-shrink-0 p-4">
         <div className="max-w-4xl mx-auto">
+          {/* Why the composer can't submit, immediately above the machine chip it
+              is usually about. It used to sit at the top of the scrolling pane,
+              a full viewport away from the control it explains — on a short
+              window the composer looked dead with the reason off-screen. */}
+          {(errorMessage || blockedMessage) && (
+            <div className="mb-3 space-y-2">
+              {errorMessage && (
+                <div className="bg-destructive/10 text-destructive text-sm px-3 py-2 rounded-lg font-mono">
+                  {errorMessage}
+                </div>
+              )}
+              {blockedMessage && (
+                <div
+                  className={
+                    submitBlockedReason === 'machine_offline'
+                      ? 'bg-orange-500/10 text-orange-600 dark:text-orange-500 text-sm px-3 py-2 rounded-lg font-mono'
+                      : 'bg-muted text-muted-foreground text-sm px-3 py-2 rounded-lg font-mono'
+                  }
+                >
+                  {blockedMessage}
+                </div>
+              )}
+            </div>
+          )}
           {/* Setup chips: machine · working dir · worktree (when supported) */}
           <div className="mb-2 flex flex-wrap items-center gap-1.5">
             <DropdownMenu>
@@ -1957,7 +2061,7 @@ function NewSessionContent() {
                   onKeyDown={handleKeyDown}
                   placeholder="Type messages, @files, /skills or commands"
                   rows={1}
-                  disabled={isSubmitting || !canSubmit}
+                  disabled={isSubmitting}
                   className="w-full bg-transparent border-0 py-2 px-2 text-sm resize-none focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 leading-5 placeholder:text-muted-foreground/30"
                   style={{
                     height: '36px',
@@ -2197,8 +2301,11 @@ function NewSessionContent() {
                   type="button"
                   size="icon"
                   onClick={handleSubmit}
-                  disabled={!canSubmit}
-                  className="shrink-0 rounded-full w-7 h-7 p-0 border-0 focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:border-transparent focus-visible:outline-none"
+                  disabled={isSubmitting}
+                  aria-disabled={!canSubmit}
+                  className={`shrink-0 rounded-full w-7 h-7 p-0 border-0 focus:outline-none focus:ring-0 focus-visible:ring-0 focus-visible:border-transparent focus-visible:outline-none ${
+                    canSubmit ? '' : 'opacity-50'
+                  }`}
                 >
                   {isSubmitting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ArrowUp className="h-3.5 w-3.5" />}
                 </Button>

--- a/apps/web/lib/desktop-telemetry.ts
+++ b/apps/web/lib/desktop-telemetry.ts
@@ -85,6 +85,18 @@ type EventMap = {
   desktop_onboarding_intro_step_viewed: { step_index: number; step_id: string };
   desktop_onboarding_intro_completed: { skipped: boolean; steps_completed: number };
   desktop_onboarding_signin_started: { method: 'browser_handoff' };
+  /**
+   * The waiting screen mounted — i.e. the browser handoff got as far as "we are
+   * now waiting for the deep link". Without it, `signin_started` with no
+   * `signin_returned` is a single undifferentiated hole (29 people in the first
+   * seven weeks): it cannot distinguish "the browser never opened" from "the
+   * browser opened and they gave up". This event splits that hole in two.
+   */
+  desktop_onboarding_signin_waiting: Record<string, never>;
+  /** "Browser didn't open? Try again" / "Try again" pressed. */
+  desktop_onboarding_signin_retried: { after_error: boolean };
+  /** "Cancel sign-in" pressed — an explicit abandon, as opposed to vanishing. */
+  desktop_onboarding_signin_cancelled: Record<string, never>;
   desktop_onboarding_signin_returned: { outcome: SignInOutcome };
   desktop_onboarding_scan_viewed: Record<string, never>;
   desktop_onboarding_scan_completed: ScanPayload & { phase: 'found' | 'empty' };
@@ -101,6 +113,35 @@ type EventMap = {
   checkout_failed: { plan: 'pro'; interval: BillingInterval; status: number | null };
   first_web_message_sent: Record<string, never>;
   first_desktop_message_sent: Record<string, never>;
+
+  // ── The new-session screen (the stretch between onboarding and activation) ─
+  //
+  // Half of everyone who finishes desktop onboarding never creates a session,
+  // and until these events there was NOTHING emitted between
+  // `desktop_onboarding_completed` and `session_created` — the largest leak in
+  // the product had no diagnostic surface at all. Unprefixed on purpose: the
+  // screen and its failure modes are identical on web, so `source` splits them
+  // (same doctrine as `session_created` / `checkout_started`).
+  /**
+   * The new-session screen resolved its machine list. Fires once per mount,
+   * AFTER the first `listMachines` settles — a mount-time capture would report
+   * `none` for everyone, since the list is always empty on the first render.
+   */
+  new_session_viewed: { machine_state: MachineState; machine_count: number };
+  /**
+   * The user pressed send and nothing happened. `handleSubmit` returns early
+   * when there is no machine / no directory / no prompt, with no toast and no
+   * disabled-state explanation — which is exactly what a rageclick looks like
+   * from the inside (17 desktop users rage-clicked this screen's dead zone in
+   * the first seven weeks). Fires at most once per reason per mount, so a
+   * five-click burst is one event, not five.
+   */
+  session_submit_blocked: { reason: SubmitBlockedReason; machine_state: MachineState };
+  /**
+   * Session creation was attempted and failed. `reason` is a stable code, never
+   * the user-facing copy, so the shape survives message rewording.
+   */
+  session_create_failed: { reason: SessionCreateFailure };
 
   // ── Desktop-only ──────────────────────────────────────────────────────────
   /**
@@ -157,6 +198,18 @@ export function trackIntroCompleted(skipped: boolean, stepsCompleted: number): v
 // ── Sign-in handoff ─────────────────────────────────────────────────────────
 
 export type SignInOutcome = 'success' | 'mismatch' | 'error';
+
+export function trackSignInWaiting(): void {
+  capture('desktop_onboarding_signin_waiting');
+}
+
+export function trackSignInRetried(afterError: boolean): void {
+  capture('desktop_onboarding_signin_retried', { after_error: afterError });
+}
+
+export function trackSignInCancelled(): void {
+  capture('desktop_onboarding_signin_cancelled');
+}
 
 export function trackSignInStarted(): void {
   // `method` is a constant today, but the browser handoff is not the only
@@ -260,6 +313,70 @@ export function trackCheckoutStarted(interval: BillingInterval): void {
  */
 export function trackCheckoutFailed(interval: BillingInterval, status: number | null): void {
   capture('checkout_failed', { plan: 'pro', interval, status });
+}
+
+// ── New-session screen ──────────────────────────────────────────────────────
+
+/**
+ * What the machine picker resolved to.
+ *
+ * `none` — the account has no machine at all. On desktop this is the damning
+ * one: the daemon is bundled and supervised by Electron, so a desktop user in
+ * this state is looking at copy that tells them to run `vicoa daemon`, a
+ * command they do not have and should never need.
+ * `offline` — machines exist but none is connected.
+ * `online` — at least one machine is reachable.
+ */
+export type MachineState = 'none' | 'offline' | 'online';
+
+/**
+ * Why the composer cannot submit. Ordered by precedence: the first one that
+ * applies is the one the user is shown and the one that is captured, so a
+ * machine that is both absent and offline reports the actionable reason.
+ */
+export type SubmitBlockedReason =
+  | 'no_api'
+  | 'no_machine'
+  | 'machine_offline'
+  | 'no_directory';
+
+/** Stable failure codes for session creation — never the user-facing string. */
+export type SessionCreateFailure =
+  | 'spawn_error'
+  | 'machine_offline'
+  | 'daemon_timeout'
+  | 'daemon_disconnected'
+  | 'unknown';
+
+/**
+ * Once-per-mount guards. The point of these events is "did this person hit this
+ * wall", not "how many times did they click it" — and a rageclick is by
+ * definition a burst, so an ungated capture would report the loudest user
+ * rather than the widest problem.
+ */
+let newSessionViewFired = false;
+const submitBlockedFired = new Set<SubmitBlockedReason>();
+
+/** Call from the new-session screen's unmount so a revisit re-arms the guards. */
+export function resetNewSessionGuards(): void {
+  newSessionViewFired = false;
+  submitBlockedFired.clear();
+}
+
+export function trackNewSessionViewed(state: MachineState, machineCount: number): void {
+  if (newSessionViewFired) return;
+  newSessionViewFired = true;
+  capture('new_session_viewed', { machine_state: state, machine_count: machineCount });
+}
+
+export function trackSubmitBlocked(reason: SubmitBlockedReason, state: MachineState): void {
+  if (submitBlockedFired.has(reason)) return;
+  submitBlockedFired.add(reason);
+  capture('session_submit_blocked', { reason, machine_state: state });
+}
+
+export function trackSessionCreateFailed(reason: SessionCreateFailure): void {
+  capture('session_create_failed', { reason });
 }
 
 // ── Onboarding complete ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Half of everyone who finishes desktop onboarding never creates a session — 245 finished, 120 created a session, 72 sent a message, and 111 of the 245 did nothing at all afterwards on any surface. Nothing was emitted between `desktop_onboarding_completed` and `session_created`, so the largest leak in the product had no diagnostic surface at all.

Two reasons it stayed invisible, both fixed here.

**The composer was silently disabled.** `disabled` sat on both the textarea and the send button, so with no connected machine the user could not type, and clicking the button fired no `onClick` — no feedback to them, no event to us. 17 desktop users rage-clicked this screen's dead zone in the first seven weeks, clustered around "Refresh machines", "Restart" and an `%LOCALAPPDATA%` install path, i.e. people whose bundled daemon had not come up.

**The one explanation was a viewport away.** The notice sat at the TOP of the scrolling pane while the control it explains sits at the BOTTOM — off-screen on a short window. And it was web-only copy: *"Run `vicoa daemon` to connect this machine"* is unactionable in the desktop app, where the daemon is bundled and supervised by Electron. The user has no such command and never needs one.

## What changed

- Derive ONE `submitBlockedReason` (`no_api` → `no_machine` → `machine_offline` → `no_directory`, first match wins) in place of three independently conditioned notices, and **move its banner into the composer**, directly above the machine chip it is usually about.
- Branch the copy by surface, so desktop is never told to run a CLI it does not ship.
- Let the textarea be typed into while blocked — composing while the daemon boots is useful and the draft persists. Mentions and the file pickers keep their own `isOnline` gates.
- Give the send button `aria-disabled` rather than `disabled`, so a blocked press is measurable at all.

## New events

All in the typed catalog in `lib/desktop-telemetry.ts`, so a typo is a build error rather than an event that quietly goes nowhere.

| Event | Props |
|---|---|
| `new_session_viewed` | `machine_state` (`none`/`offline`/`online`), `machine_count` |
| `session_submit_blocked` | `reason`, `machine_state` |
| `session_create_failed` | `reason` (`spawn_error`/`machine_offline`/`daemon_timeout`/`daemon_disconnected`/`unknown`) |
| `desktop_onboarding_signin_waiting` / `_retried` / `_cancelled` | `after_error` on `_retried` |

The first three are unprefixed and split by the `source` super property, same doctrine as `session_created`: the screen and its failure modes are identical on web.

The signin trio splits the browser-handoff hole — 29 people in seven weeks emitted `desktop_onboarding_signin_started` and then nothing, with no way to tell "the browser never opened" from "it opened and they gave up".

`new_session_viewed` fires once per mount **after** the first `listMachines` settles; a mount-time capture would report `none` for everyone, since the list is always empty on the first render. `session_submit_blocked` is guarded once per reason per mount, so a five-click burst is one event rather than a report on the loudest user.

## Testing

`pnpm lint` (tsc + theme-color check) and `pnpm build` both exit 0.

Renderer-only, so desktop needs a release for the fix to land there; web picks it up on the next deploy.

Full analysis this came out of: `product-analytics/onboarding/2026-09-10-desktop-funnel-paywall.md` in the umbrella repo.
