### PR TITLE
Sub-agents: show the work, the files, and the assignment

### DIFF
--- a/apps/mobile/lib/custom_code/widgets/index.dart
+++ b/apps/mobile/lib/custom_code/widgets/index.dart
@@ -14,7 +14,8 @@ export 'subagent_group.dart'
         computeSubagentGrouping,
         subagentToolUseIdOf,
         subagentTypeOf,
-        subagentDescriptionOf;
+        subagentDescriptionOf,
+        subagentStatusOf;
 export 'thinking_group.dart'
     show ThinkingGroup, isThinkingMessage, thinkingDisplayBody;
 export 'custom_date_range_sheet.dart' show CustomDateRangeSheet;

--- a/apps/mobile/lib/custom_code/widgets/subagent_group.dart
+++ b/apps/mobile/lib/custom_code/widgets/subagent_group.dart
@@ -1,8 +1,9 @@
 // Collapsed sub-agent (Task tool) rendering for the agent chat. Child
 // messages carry `message_metadata.subagent = { tool_use_id, subagent_type,
-// description, role }` (see `src/integrations/headless/subagent.py` in
-// vicoa-backend); every message sharing a `tool_use_id` groups under one
-// "Sub-agent: <type>" collapsible header, indented like `ToolUseGroup`.
+// description, role }` — plus `status` on the settled report — (see
+// `backend/src/integrations/headless/subagent.py`); every message sharing a
+// `tool_use_id` groups under one "Sub-agent: <type>" collapsible header,
+// indented like `ToolUseGroup`.
 //
 // Unlike `ToolUseGroup`'s consecutive-run grouping, sub-agent grouping is
 // ANCHORED AT FIRST OCCURRENCE of each `tool_use_id`: Claude can run parallel
@@ -18,6 +19,8 @@ import '/custom_code/widgets/markdown_text_builder.dart'
         buildCollapsibleToolRow,
         buildToolGroupHeader,
         sanitizeToolContent;
+import '/custom_code/widgets/tool_use_group.dart'
+    show describeToolRun, summarizeToolMessage;
 
 /// Reads a message's `message_metadata.subagent.tool_use_id`, or null when
 /// [message] isn't tagged as sub-agent activity (not a Map, no metadata, or a
@@ -56,6 +59,20 @@ String? subagentDescriptionOf(dynamic message) {
   if (subagent is! Map) return null;
   final desc = subagent['description']?.toString().trim();
   return (desc == null || desc.isEmpty) ? null : desc;
+}
+
+/// Reads `message_metadata.subagent.status` — how the run ended (`completed`
+/// / `failed` / `stopped`), or null while it is unsettled or on a client
+/// talking to a backend that predates the field. Only the settled report
+/// carries one, so a run's status is the last non-null value across it.
+String? subagentStatusOf(dynamic message) {
+  if (message is! Map) return null;
+  final metadata = message['message_metadata'];
+  if (metadata is! Map) return null;
+  final subagent = metadata['subagent'];
+  if (subagent is! Map) return null;
+  final status = subagent['status']?.toString().trim();
+  return (status == null || status.isEmpty) ? null : status;
 }
 
 /// Precomputed, anchor-at-first-occurrence bucketing of sub-agent messages by
@@ -146,6 +163,7 @@ class SubagentGroup extends StatefulWidget {
     required this.subagentType,
     this.description,
     required this.contents,
+    this.status,
     required this.expanded,
     required this.onToggle,
     this.onBeforeToggle,
@@ -159,6 +177,10 @@ class SubagentGroup extends StatefulWidget {
 
   /// Sanitized message contents belonging to this sub-agent run, in chat order.
   final List<String> contents;
+
+  /// The run's terminal status (`completed` / `failed` / `stopped`), or null
+  /// while it is still running.
+  final String? status;
   final bool expanded;
   final VoidCallback onToggle;
 
@@ -192,11 +214,25 @@ class _SubagentGroupState extends State<SubagentGroup> {
     });
   }
 
-  String get _label {
+  /// The collapsed header line. Same vocabulary a collapsed [ToolUseGroup]
+  /// uses ("Run 2 commands, edit 2 files"), because a sub-agent that rewrote
+  /// three files otherwise announced itself as one line naming neither the
+  /// work nor the files. [toolContents] is the run's tool-use members only —
+  /// prose and thinking cards aren't actions and would inflate the counts.
+  String _label(List<String> toolContents) {
     final type = widget.subagentType.trim();
-    final header = 'Sub-agent: ${type.isEmpty ? 'agent' : type}';
+    var header = 'Sub-agent: ${type.isEmpty ? 'agent' : type}';
+    // 'completed' is the normal ending and needs no marker; anything else does.
+    final status = widget.status?.trim();
+    if (status != null && status.isNotEmpty && status != 'completed') {
+      header = '$header ($status)';
+    }
     final desc = widget.description?.trim();
-    return (desc == null || desc.isEmpty) ? header : '$header — $desc';
+    if (desc != null && desc.isNotEmpty) header = '$header — $desc';
+    if (toolContents.isEmpty) return header;
+    final runLabel =
+        describeToolRun([for (final c in toolContents) summarizeToolMessage(c)]);
+    return runLabel.isEmpty ? header : '$header · $runLabel';
   }
 
   @override
@@ -214,10 +250,13 @@ class _SubagentGroupState extends State<SubagentGroup> {
       filterProjectRoot: widget.filterProjectRoot,
     );
 
+    final label =
+        _label([for (final c in contents) if (_isToolUseContent(c)) c]);
+
     if (!widget.expanded) {
       return buildToolGroupHeader(
         context,
-        _label,
+        label,
         isLast: true,
         expanded: false,
         onToggle: _toggleRun,
@@ -237,7 +276,7 @@ class _SubagentGroupState extends State<SubagentGroup> {
       children: [
         buildToolGroupHeader(
           context,
-          _label,
+          label,
           isLast: !firstIsTool,
           expanded: true,
           onToggle: _toggleRun,

--- a/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
+++ b/apps/mobile/lib/pages/agent_chat/agent_chat_widget.dart
@@ -1231,6 +1231,13 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
           _model.sanitizeMessageContent(
               _model.messages[i]['content']?.toString() ?? ''),
       ];
+      // Only the settled report carries a status, so the run's is the last
+      // non-null one across its members — it marks the header when the run
+      // ended as anything other than a clean completion.
+      String? runStatus;
+      for (final i in runIndices) {
+        runStatus = custom_widgets.subagentStatusOf(_model.messages[i]) ?? runStatus;
+      }
       final groupKey = custom_widgets.subagentToolUseIdOf(message) ??
           'idx_$messageIndex';
       final agentType = _model.instanceData?['agent_type_name'] ??
@@ -1264,6 +1271,7 @@ class _AgentChatWidgetState extends State<AgentChatWidget> with RouteAware, Tick
                       subagentType: custom_widgets.subagentTypeOf(message),
                       description: custom_widgets.subagentDescriptionOf(message),
                       contents: runContents,
+                      status: runStatus,
                       expanded: _expandedSubagentGroups.contains(groupKey),
                       // Fires before any expand/collapse in this group so the
                       // tapped line stays put instead of being pushed up by

--- a/apps/mobile/test/custom_code/widgets/subagent_group_test.dart
+++ b/apps/mobile/test/custom_code/widgets/subagent_group_test.dart
@@ -12,6 +12,8 @@ Map<String, dynamic> _subagentMsg(
   String toolUseId, {
   String type = 'Explore',
   String? description,
+  String role = 'step',
+  String? status,
 }) =>
     {
       'sender_type': 'AGENT',
@@ -21,7 +23,8 @@ Map<String, dynamic> _subagentMsg(
           'tool_use_id': toolUseId,
           'subagent_type': type,
           'description': description ?? '',
-          'role': 'step',
+          'role': role,
+          if (status != null) 'status': status,
         },
       },
     };
@@ -228,6 +231,21 @@ void main() {
         ),
         isEmpty,
       );
+    });
+  });
+
+  group('subagentStatusOf', () {
+    test('reads the settled report\'s status', () {
+      expect(
+        subagentStatusOf(_subagentMsg('tu-1', role: 'result', status: 'failed')),
+        'failed',
+      );
+    });
+
+    test('is null on a step, an untagged message, and a non-Map', () {
+      expect(subagentStatusOf(_subagentMsg('tu-1')), isNull);
+      expect(subagentStatusOf(_plainMsg('hi')), isNull);
+      expect(subagentStatusOf(null), isNull);
     });
   });
 }

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -2501,6 +2501,8 @@ function AgentInstanceContent() {
                           description={item.description}
                           expanded={expandedToolItems.has(item.key)}
                           onToggle={() => toggleToolItem(item.key)}
+                          agentType={agentType}
+                          projectPath={projectRootPath}
                           renderMessage={(message) => (
                             <MessageItem
                               message={message}

--- a/apps/web/components/dashboard/subagent-group.tsx
+++ b/apps/web/components/dashboard/subagent-group.tsx
@@ -1,20 +1,37 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { Bot, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { MessageResponse } from '@/lib/backend-api';
+import { ToolRunSummary, ToolUseLine, parseToolUse, type ToolUseAgentType } from '@/components/dashboard/tool-use-display';
+import { parseAskUserQuestionPayload } from '@/components/dashboard/ask-user-question-panel';
+import { parseThinkingPayload } from '@/components/dashboard/thinking-card';
+import { subagentGroupStatus } from '@/components/dashboard/subagent-grouping';
 
 /**
  * A sub-agent (Task tool) activity group: a collapsible "Sub-agent: <type>"
- * header wrapping the messages the sub-agent produced while it ran, indented
- * beneath it. Mirrors `ToolUseGroup`'s collapse mechanics and indent classes
- * (tool-use-display.tsx) exactly, but delegates rendering each child message
- * to the caller via `renderMessage` — a sub-agent's children are arbitrary
- * chat messages (text, tool-use, options, ...) that need the full
- * `MessageItem` treatment, not a single-purpose `ToolUseLine`. `MessageItem`
+ * header wrapping what the sub-agent did while it ran.
+ *
+ * The header is deliberately the same row a collapsed `ToolUseGroup` draws —
+ * icon, aggregate action label ("Run 2 commands, edit 2 files"), then a chip
+ * per edited file carrying its `+N -M` and a hover diff preview. A sub-agent
+ * that rewrote three files used to announce itself as one line of text naming
+ * neither the work nor the files, so its edits were invisible until you
+ * expanded the group and then expanded a row inside it.
+ *
+ * Collapsed, it is that one row and nothing else — the same affordance a tool
+ * group has. Expanded, its children render in chat order, ending with the
+ * sub-agent's settled report.
+ *
+ * Rendering each child is delegated to the caller via `renderMessage` — a
+ * sub-agent's children are arbitrary chat messages (text, thinking cards,
+ * options, ...) that need the full `MessageItem` treatment. `MessageItem`
  * lives in the instance page (it needs page-level callbacks/state), so this
- * component stays decoupled from it to avoid a circular import.
+ * component stays decoupled from it to avoid a circular import. Runs of
+ * consecutive tool uses are the exception: they render here as fused
+ * `ToolUseLine`s, exactly like an expanded `ToolUseGroup`, so a sub-agent's
+ * work reads the same as the main agent's.
  */
 export function SubagentGroup({
   messages,
@@ -23,6 +40,8 @@ export function SubagentGroup({
   expanded,
   onToggle,
   renderMessage,
+  agentType,
+  projectPath,
 }: {
   messages: MessageResponse[];
   subagentType: string;
@@ -30,8 +49,38 @@ export function SubagentGroup({
   expanded: boolean;
   onToggle: () => void;
   renderMessage: (message: MessageResponse) => ReactNode;
+  agentType: ToolUseAgentType;
+  /** Project root, so tool-use file paths render relative to it. */
+  projectPath?: string | null;
 }) {
+  // Per-row detail expansion for the fused tool runs. Local state: it resets
+  // if the row is recycled offscreen by the virtual list, which is acceptable
+  // (mirrors `ToolUseGroup`).
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+  const toggleTool = (id: string) =>
+    setExpandedTools((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const status = useMemo(() => subagentGroupStatus(messages), [messages]);
+
+  // Only the tool uses feed the header summary — prose (the report), thinking
+  // cards and question panels aren't actions, and counting them would turn
+  // "2 tool uses" into "5".
+  const summaryItems = useMemo(
+    () =>
+      messages
+        .filter((message) => isFusableToolUse(message, agentType))
+        .map((message) => ({ id: message.id, content: message.content })),
+    [messages, agentType],
+  );
+
   const headerLabel = `Sub-agent: ${subagentType}`;
+  // 'completed' is the normal ending and needs no marker; anything else does.
+  const failure = status && status !== 'completed' ? status : null;
 
   return (
     <div>
@@ -48,6 +97,20 @@ export function SubagentGroup({
             {description}
           </span>
         )}
+        {summaryItems.length > 0 && (
+          <>
+            <span className="shrink-0 text-muted-foreground/40" aria-hidden="true">
+              ·
+            </span>
+            <ToolRunSummary
+              items={summaryItems}
+              agentType={agentType}
+              projectPath={projectPath}
+              showFileChips={!expanded}
+            />
+          </>
+        )}
+        {failure && <span className="shrink-0 text-red-400">{failure}</span>}
         <ChevronRight
           className={cn(
             'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform',
@@ -57,11 +120,65 @@ export function SubagentGroup({
       </button>
       {expanded && (
         <div className="ml-1.5 mt-1.5 space-y-1 border-l border-border/40 pl-2.5">
-          {messages.map((message) => (
-            <div key={message.id}>{renderMessage(message)}</div>
-          ))}
+          {renderChildren(messages, agentType, projectPath, expandedTools, toggleTool, renderMessage)}
         </div>
       )}
     </div>
   );
+}
+
+/**
+ * A child that belongs in a fused tool run. Interactive rows (a question
+ * panel, a permission prompt) and thinking cards look like tool uses but must
+ * render through `MessageItem` to keep their own affordance — the same guard
+ * the instance page applies before collapsing a top-level tool run.
+ */
+function isFusableToolUse(message: MessageResponse, agentType: ToolUseAgentType): boolean {
+  if (message.requires_user_input) return false;
+  if (parseAskUserQuestionPayload(message) !== null) return false;
+  if (parseThinkingPayload(message) !== null) return false;
+  return parseToolUse(message.content, agentType) !== null;
+}
+
+/** Children in chat order, with consecutive tool uses fused into one run. */
+function renderChildren(
+  children: MessageResponse[],
+  agentType: ToolUseAgentType,
+  projectPath: string | null | undefined,
+  expandedTools: Set<string>,
+  toggleTool: (id: string) => void,
+  renderMessage: (message: MessageResponse) => ReactNode,
+): ReactNode[] {
+  const rows: ReactNode[] = [];
+  let run: MessageResponse[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+    rows.push(
+      <div key={`run-${run[0].id}`} className="space-y-1">
+        {run.map((message) => (
+          <ToolUseLine
+            key={message.id}
+            content={message.content}
+            agentType={agentType}
+            expanded={expandedTools.has(message.id)}
+            onToggle={() => toggleTool(message.id)}
+            projectPath={projectPath}
+          />
+        ))}
+      </div>,
+    );
+    run = [];
+  };
+
+  for (const message of children) {
+    if (isFusableToolUse(message, agentType)) {
+      run.push(message);
+      continue;
+    }
+    flush();
+    rows.push(<div key={message.id}>{renderMessage(message)}</div>);
+  }
+  flush();
+  return rows;
 }

--- a/apps/web/components/dashboard/subagent-grouping.test.ts
+++ b/apps/web/components/dashboard/subagent-grouping.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MessageResponse } from '@/lib/backend-api';
-import { groupSubagents, parseSubagentPayload } from './subagent-grouping';
+import { groupSubagents, parseSubagentPayload, subagentGroupStatus } from './subagent-grouping';
 
 const base: MessageResponse = {
   id: 'x',
@@ -20,7 +20,13 @@ const plain = (id: string, content = `content-${id}`): MessageResponse => ({
 const subagentMsg = (
   id: string,
   toolUseId: string,
-  opts: { subagentType?: string; description?: string; content?: string } = {},
+  opts: {
+    subagentType?: string;
+    description?: string;
+    content?: string;
+    role?: string;
+    status?: string;
+  } = {},
 ): MessageResponse => ({
   ...base,
   id,
@@ -30,7 +36,8 @@ const subagentMsg = (
       tool_use_id: toolUseId,
       subagent_type: opts.subagentType ?? 'explore',
       description: opts.description ?? 'Map the codebase',
-      role: 'step',
+      role: opts.role ?? 'step',
+      ...(opts.status ? { status: opts.status } : {}),
     },
   },
 });
@@ -42,6 +49,8 @@ describe('parseSubagentPayload', () => {
       toolUseId: 'task-1',
       subagentType: 'explore',
       description: 'Find X',
+      role: 'step',
+      status: null,
     });
   });
 
@@ -63,7 +72,41 @@ describe('parseSubagentPayload', () => {
       toolUseId: 'task-1',
       subagentType: 'agent',
       description: '',
+      role: 'step',
+      status: null,
     });
+  });
+
+  it('reads the settled report\'s role and status', () => {
+    const msg = subagentMsg('m1', 'task-1', { role: 'result', status: 'failed' });
+    expect(parseSubagentPayload(msg)).toMatchObject({ role: 'result', status: 'failed' });
+  });
+});
+
+describe('subagentGroupStatus', () => {
+  it('reads the settled report\'s status', () => {
+    const messages = [
+      subagentMsg('s1', 'task-1'),
+      subagentMsg('r1', 'task-1', { role: 'result', status: 'failed' }),
+    ];
+    expect(subagentGroupStatus(messages)).toBe('failed');
+  });
+
+  it('is null while the sub-agent is still running', () => {
+    expect(subagentGroupStatus([subagentMsg('s1', 'task-1')])).toBeNull();
+  });
+
+  it('takes the last status when a run somehow reports twice', () => {
+    const messages = [
+      subagentMsg('r1', 'task-1', { role: 'result', status: 'completed' }),
+      subagentMsg('s1', 'task-1'),
+      subagentMsg('r2', 'task-1', { role: 'result', status: 'stopped' }),
+    ];
+    expect(subagentGroupStatus(messages)).toBe('stopped');
+  });
+
+  it('ignores untagged messages', () => {
+    expect(subagentGroupStatus([plain('m1')])).toBeNull();
   });
 });
 

--- a/apps/web/components/dashboard/subagent-grouping.ts
+++ b/apps/web/components/dashboard/subagent-grouping.ts
@@ -5,6 +5,7 @@ import type { MessageResponse } from '@/lib/backend-api';
  *
  * The backend tags every child message a sub-agent produces with
  * `message_metadata.subagent = { tool_use_id, subagent_type, description, role }`
+ * — plus `status` on the settled report —
  * (see `integrations/headless/subagent.py`). `tool_use_id` is the id of the
  * launching `Task` block, so it's the group key: every message stamped with
  * the same `tool_use_id` belongs to the same sub-agent run, however it's
@@ -19,6 +20,10 @@ export interface SubagentPayload {
   toolUseId: string;
   subagentType: string;
   description: string;
+  /** 'step' for work the sub-agent did, 'result' for its settled report. */
+  role: string;
+  /** Terminal status, on the report only: 'completed' | 'failed' | 'stopped'. */
+  status: string | null;
 }
 
 /** Read a message's `message_metadata.subagent` payload, or null when absent
@@ -37,12 +42,34 @@ export function parseSubagentPayload(message: MessageResponse): SubagentPayload 
 
   const subagentTypeRaw = typeof raw.subagent_type === 'string' ? raw.subagent_type.trim() : '';
   const descriptionRaw = typeof raw.description === 'string' ? raw.description : '';
+  const roleRaw = typeof raw.role === 'string' ? raw.role.trim() : '';
+  const statusRaw = typeof raw.status === 'string' ? raw.status.trim() : '';
 
   return {
     toolUseId,
     subagentType: subagentTypeRaw || 'agent',
     description: descriptionRaw,
+    role: roleRaw || 'step',
+    status: statusRaw || null,
   };
+}
+
+/**
+ * How a sub-agent run ended: `'completed'` | `'failed'` | `'stopped'`, or null
+ * while it is still running (or against a backend predating the field).
+ *
+ * Only the settled report carries a status, so this is the last non-null one
+ * in the run — a re-announced task's later report supersedes the earlier one.
+ * The group header marks anything other than a clean completion; the run's
+ * messages otherwise render in chat order, exactly like a tool run.
+ */
+export function subagentGroupStatus(messages: MessageResponse[]): string | null {
+  let status: string | null = null;
+  for (const message of messages) {
+    const payload = parseSubagentPayload(message);
+    if (payload?.status) status = payload.status;
+  }
+  return status;
 }
 
 export type SubagentBucketItem =

--- a/apps/web/components/dashboard/tool-use-display.tsx
+++ b/apps/web/components/dashboard/tool-use-display.tsx
@@ -224,6 +224,106 @@ const LONG_DESCRIPTION_CHARS = 80;
 /** Cap on edited-file chips shown inline on a collapsed group before "+N more". */
 const MAX_INLINE_FILE_CHIPS = 4;
 
+/** One tool-use message, reduced to what a run summary needs. */
+export interface ToolRunItem {
+  /** Stable identity for the chip list across virtualization (a message id). */
+  id: string;
+  content: string;
+}
+
+/**
+ * What a collapsed run of tool uses says about itself: the aggregate action
+ * label, and — when the run edited files — a chip per file carrying its
+ * `+N -M` and a hover diff preview, so the changed files are visible without
+ * expanding anything.
+ *
+ * Shared by `ToolUseGroup` and `SubagentGroup` so a sub-agent's collapsed
+ * header reads in exactly the same vocabulary as a top-level tool run; before
+ * this, a sub-agent that rewrote three files announced itself as one line of
+ * text naming neither the work nor the files.
+ *
+ * Renders as a fragment (no wrapper) — the caller owns the row.
+ */
+export function ToolRunSummary({
+  items,
+  agentType,
+  projectPath,
+  showFileChips,
+}: {
+  items: ToolRunItem[];
+  agentType: ToolUseAgentType;
+  projectPath?: string | null;
+  /** Chips are for the collapsed state; expanded rows show their own diffs. */
+  showFileChips: boolean;
+}) {
+  const { query: findQuery } = useFindHighlight();
+  const contents = useMemo(() => items.map((item) => item.content), [items]);
+
+  // "Run 2 commands, edit 2 files, read a file" — distinct tools, first-use order.
+  const runLabel = useMemo(() => describeToolRun(contents, agentType), [contents, agentType]);
+
+  // Same label minus the edit segments — edits are shown inline as file chips,
+  // so the collapsed row reads "Run a command · foo.ts +3 -1 · …" ('' if only
+  // edits). Only used when the run has edits and is collapsed.
+  const nonEditLabel = useMemo(
+    () => describeToolRun(contents, agentType, { excludeFileEdits: true }),
+    [contents, agentType],
+  );
+
+  // Files this run edited, in order. Keyed by message id for a stable list
+  // across virtualization.
+  const editedFiles = useMemo(
+    () =>
+      items
+        .map((item) => ({ id: item.id, edit: editedFileFromContent(item.content, agentType) }))
+        .filter((entry): entry is { id: string; edit: EditedFileSummary } => entry.edit !== null),
+    [items, agentType],
+  );
+
+  if (!showFileChips || editedFiles.length === 0) {
+    if (!runLabel) return null;
+    return (
+      <span className="min-w-0 truncate text-muted-foreground" title={runLabel}>
+        <HighlightedText text={runLabel} query={findQuery} />
+      </span>
+    );
+  }
+
+  const inlineFiles = editedFiles.slice(0, MAX_INLINE_FILE_CHIPS);
+  const overflowCount = editedFiles.length - inlineFiles.length;
+
+  return (
+    <>
+      {nonEditLabel && <span className="shrink-0 text-muted-foreground">{nonEditLabel},</span>}
+      <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+        {inlineFiles.map(({ id, edit }, index) => {
+          // Prefix the file with its tool name ("Edit"/"Write"/…), but only
+          // when it changes — a run of same-tool files shares one label:
+          // "Edit foo.ts bar.ts", "Edit foo.ts Write baz.ts".
+          const showToolLabel = index === 0 || edit.toolName !== inlineFiles[index - 1].edit.toolName;
+          return (
+            <span key={id} className="flex min-w-0 items-center gap-1.5">
+              {showToolLabel && <span className="shrink-0 text-muted-foreground">{edit.toolName}</span>}
+              <FileChip
+                inline
+                fileName={edit.fileName}
+                fullPath={edit.fullPath}
+                diffStat={edit.diffStat}
+                diffContent={edit.diffContent}
+                agentType={agentType}
+                projectPath={projectPath}
+              />
+            </span>
+          );
+        })}
+      </div>
+      {overflowCount > 0 && (
+        <span className="shrink-0 text-muted-foreground/70">+{overflowCount} more</span>
+      )}
+    </>
+  );
+}
+
 /** One tool use: a single-line summary row, expandable when there's detail. */
 export function ToolUseLine({
   content,
@@ -381,39 +481,15 @@ export function ToolUseGroup({
   // Per-tool expansion inside an expanded group. Local state: it resets if
   // the row is recycled offscreen by the virtual list, which is acceptable.
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
-  const { query: findQuery } = useFindHighlight();
 
-  // "Run 2 commands, edit 2 files, read a file" — distinct tools, first-use order.
-  const runLabel = useMemo(
-    () => describeToolRun(messages.map((message) => message.content), agentType),
-    [messages, agentType],
-  );
-
-  // Same label minus the edit segments — edits are shown inline as file chips,
-  // so the collapsed row reads "Run a command · foo.ts +3 -1 · …" ('' if only
-  // edits). Only used when the group has edits and is collapsed.
-  const nonEditLabel = useMemo(
-    () =>
-      describeToolRun(messages.map((message) => message.content), agentType, {
-        excludeFileEdits: true,
-      }),
-    [messages, agentType],
+  const summaryItems = useMemo(
+    () => messages.map((message) => ({ id: message.id, content: message.content })),
+    [messages],
   );
 
   // The single icon that stands in for the whole collapsed run.
   const groupIconName = useMemo(
     () => representativeToolName(toolNamesInRun(messages.map((message) => message.content), agentType)),
-    [messages, agentType],
-  );
-
-  // Files this run edited, in order — surfaced as chips under the collapsed
-  // header so the changed files (and their diffs, on hover) are visible without
-  // expanding. Keyed by message id for a stable list across virtualization.
-  const editedFiles = useMemo(
-    () =>
-      messages
-        .map((message) => ({ id: message.id, edit: editedFileFromContent(message.content, agentType) }))
-        .filter((entry): entry is { id: string; edit: EditedFileSummary } => entry.edit !== null),
     [messages, agentType],
   );
 
@@ -429,12 +505,6 @@ export function ToolUseGroup({
     );
   }
 
-  // Collapsed groups with edits list the files inline in the header row; the
-  // rest of the run ("Run a command") stays as a label beside them.
-  const showInlineEdits = !expanded && editedFiles.length > 0;
-  const inlineFiles = editedFiles.slice(0, MAX_INLINE_FILE_CHIPS);
-  const overflowCount = editedFiles.length - inlineFiles.length;
-
   return (
     <div>
       <button
@@ -444,42 +514,12 @@ export function ToolUseGroup({
         className="flex w-full min-w-0 items-center gap-1.5 rounded -mx-0.5 px-0.5 py-0.5 text-left cursor-pointer hover:bg-muted/40"
       >
         <ToolIcon name={groupIconName} />
-        {showInlineEdits ? (
-          <>
-            {nonEditLabel && <span className="shrink-0 text-muted-foreground">{nonEditLabel},</span>}
-            <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-              {inlineFiles.map(({ id, edit }, index) => {
-                // Prefix the file with its tool name ("Edit"/"Write"/…), but
-                // only when it changes — a run of same-tool files shares one
-                // label: "Edit foo.ts bar.ts", "Edit foo.ts Write baz.ts".
-                const showToolLabel = index === 0 || edit.toolName !== inlineFiles[index - 1].edit.toolName;
-                return (
-                  <span key={id} className="flex min-w-0 items-center gap-1.5">
-                    {showToolLabel && (
-                      <span className="shrink-0 text-muted-foreground">{edit.toolName}</span>
-                    )}
-                    <FileChip
-                      inline
-                      fileName={edit.fileName}
-                      fullPath={edit.fullPath}
-                      diffStat={edit.diffStat}
-                      diffContent={edit.diffContent}
-                      agentType={agentType}
-                      projectPath={projectPath}
-                    />
-                  </span>
-                );
-              })}
-            </div>
-            {overflowCount > 0 && (
-              <span className="shrink-0 text-muted-foreground/70">+{overflowCount} more</span>
-            )}
-          </>
-        ) : (
-          <span className="min-w-0 truncate text-muted-foreground" title={runLabel}>
-            <HighlightedText text={runLabel} query={findQuery} />
-          </span>
-        )}
+        <ToolRunSummary
+          items={summaryItems}
+          agentType={agentType}
+          projectPath={projectPath}
+          showFileChips={!expanded}
+        />
         <ChevronRight
           className={cn(
             'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform',

--- a/backend/src/integrations/headless/claude_code.py
+++ b/backend/src/integrations/headless/claude_code.py
@@ -45,7 +45,11 @@ from vicoa.session_ws_client import SessionMessagesWsClient
 from vicoa.utils import derive_ws_url, get_project_path
 from integrations.headless.session_lifecycle import instance_update_requests_stop
 from integrations.utils.heartbeat import AsyncSessionHeartbeat
-from integrations.headless.format_tools import format_tool_use
+from integrations.headless.format_tools import (
+    format_background_task_notification,
+    format_tool_use,
+    subagent_label,
+)
 from integrations.headless import auq
 from integrations.headless import permission as permission_module
 from integrations.headless import control_command
@@ -59,7 +63,11 @@ from integrations.headless.claude_model_catalog import build_claude_available_mo
 from integrations.headless.permission import (
     format_dict_as_markdown as _format_dict_as_markdown,  # re-exported for tests
 )
-from integrations.headless.subagent import SubAgentTracker, build_metadata
+from integrations.headless.subagent import (
+    AGENT_TASK_TYPES as _AGENT_TASK_TYPES,
+    SubAgentTracker,
+    build_metadata,
+)
 from integrations.headless.thinking import build_thinking_metadata
 
 try:
@@ -123,15 +131,14 @@ _CLAUDE_LIMITS_FETCH_INTERVAL = 60.0
 # running either way — this only bounds how long the run loop stays parked.
 _INTERRUPT_RESULT_TIMEOUT = 15.0
 
-# Task types the CLI reports through ``task_started`` that mean delegated
-# *agent* work — a Task-tool sub-agent or a workflow. Those are the ones a Stop
-# has to reach and the ones whose completion wakes the parent for a follow-up
-# turn. A background shell (``Bash(run_in_background=True)`` on a dev server)
-# rides the same frames but may never reach a terminal status, so tracking one
-# would defer the awaiting-input settle forever — and a Stop would kill the
-# user's dev server. Mirrors the SDK's own ``DEFERRING_TASK_TYPES``. A missing
-# ``task_type`` (older CLI) stays tracked, i.e. the previous behaviour.
-_AGENT_TASK_TYPES = frozenset({"local_agent", "local_workflow"})
+# ``_AGENT_TASK_TYPES`` (imported above from ``integrations.headless.subagent``)
+# names the task types that mean delegated *agent* work. Those are the ones a
+# Stop has to reach and the ones whose completion wakes the parent for a
+# follow-up turn. A background shell (``Bash(run_in_background=True)`` on a dev
+# server) rides the same frames but may never reach a terminal status, so
+# tracking one would defer the awaiting-input settle forever — and a Stop would
+# kill the user's dev server. A missing ``task_type`` (older CLI) stays tracked,
+# i.e. the previous behaviour.
 
 # Overall budget for the ``stop_task`` sweep an interrupt fires at the
 # background sub-agents. Each stop is a control round-trip to the CLI; they go
@@ -1366,10 +1373,13 @@ class HeadlessClaudeRunner:
             return
         for block in message.content:
             if isinstance(block, ToolUseBlock) and block.name in ("Task", "Agent"):
+                block_input = block.input or {}
                 self._subagent_tracker.remember_task(
                     block.id,
-                    (block.input or {}).get("subagent_type", "agent"),
-                    (block.input or {}).get("description", ""),
+                    # Same label the launching tool row shows, so the row and
+                    # the group header beneath it agree.
+                    subagent_label(block_input) or "agent",
+                    block_input.get("description", ""),
                 )
 
     def _track_task_lifecycle(self, message) -> None:
@@ -1393,6 +1403,13 @@ class HeadlessClaudeRunner:
         """
         if isinstance(message, TaskStartedMessage):
             task_type = getattr(message, "task_type", None)
+            # Remember the announcement either way: the matching
+            # ``task_notification`` carries no ``task_type``, and it is the
+            # frame that has to decide whether it's a sub-agent report or a
+            # backgrounded shell finishing (see ``_send_subagent_result``).
+            self._subagent_tracker.observe_task_started(
+                message.task_id, task_type, getattr(message, "tool_use_id", None)
+            )
             if task_type is not None and task_type not in _AGENT_TASK_TYPES:
                 return
             self._pending_background_tasks.add(message.task_id)
@@ -1924,19 +1941,44 @@ class HeadlessClaudeRunner:
         We forward this copy rather than the tool_result because it carries the
         ``task_id``/``status`` and none of the tool_result's internal plumbing
         (the "agentId: … use SendMessage to continue" block).
+
+        Not every settled task is a sub-agent, though: a backgrounded shell
+        settles through the very same frame as ``local_bash``. Those used to
+        land here too and, with no ``Task`` block to label them, fell back to
+        the ``("agent", "")`` sentinel — so a slow ``git push`` rendered as a
+        "Sub-agent: agent" card holding the Bash call's one-line description.
+        They're routed to a plain background-task tool row instead.
         """
         tool_use_id = message.tool_use_id
         summary = (message.summary or "").strip()
-        if not tool_use_id or not summary:
+        if not summary:
+            return
+
+        if not self._subagent_tracker.is_agent_task(message.task_id, tool_use_id):
+            await self.send_to_vicoa(
+                format_background_task_notification(summary, message.status)
+            )
+            return
+
+        if not tool_use_id:
             return
 
         subagent_type, description = self._subagent_tracker.label_for(tool_use_id)
+        # The status also rides the metadata (new clients mark the group header
+        # with it), but it stays in the body too: a client that predates the
+        # metadata field would otherwise show a failed run as a normal one.
         if message.status != "completed":
             summary = f"⚠️ Sub-agent {message.status}\n\n{summary}"
 
         await self.send_to_vicoa(
             summary,
-            build_metadata(tool_use_id, subagent_type, description, role="result"),
+            build_metadata(
+                tool_use_id,
+                subagent_type,
+                description,
+                role="result",
+                status=message.status,
+            ),
         )
 
     async def _maybe_handle_subagent_message(self, message) -> bool:

--- a/backend/src/integrations/headless/format_tools.py
+++ b/backend/src/integrations/headless/format_tools.py
@@ -116,6 +116,42 @@ def _format_edit_diff(
     return "\n".join(diff_lines)
 
 
+def subagent_label(tool_input: Dict[str, Any]) -> str:
+    """What to call the sub-agent a ``Task``/``Agent`` call launches.
+
+    An explicit ``name`` on the call wins over the agent type: a fan-out of
+    five ``Explore``s otherwise reads as five identical rows. Falls back to
+    ``subagent_type``, then to "" for the caller to default.
+    """
+    for key in ("name", "subagent_type"):
+        value = str(tool_input.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def format_background_task_notification(summary: str, status: Any = None) -> str:
+    """A settled *non-agent* task — a backgrounded shell — as a tool-use row.
+
+    Claude announces a backgrounded ``Bash`` (explicit, or auto-backgrounded
+    once it outruns the foreground timeout) through the same
+    ``task_started``/``task_notification`` frames a Task-tool sub-agent uses,
+    so its report has to land somewhere. It is not sub-agent activity, so it
+    renders as an ordinary collapsible tool row rather than a sub-agent card —
+    matching how paseo maps the same frame onto a synthetic ``task_notification``
+    tool call. The first line labels the row; anything after it becomes the
+    expandable body.
+    """
+    text = (summary or "").strip()
+    lines = text.split("\n")
+    label = lines[0].strip() or "Background task finished"
+    body = "\n".join(lines[1:]).strip()
+    state = str(status or "").strip().lower()
+    suffix = "" if state in ("", "completed") else f" ({state})"
+    header = f"🔧 Using tool: Background task - `{label}`{suffix}"
+    return f"{header}\n\n{body}" if body else header
+
+
 def format_tool_use(tool_name: str, tool_input: Dict[str, Any]) -> str:
     """Format a tool use into a human-readable message.
 
@@ -129,15 +165,28 @@ def format_tool_use(tool_name: str, tool_input: Dict[str, Any]) -> str:
     # Agent / Task - delegates work to specialized subagents
     if tool_name in ("Agent", "Task"):
         description = tool_input.get("description", "task")
-        subagent_type = tool_input.get("subagent_type", "")
+        subagent_type = subagent_label(tool_input)
         model = tool_input.get("model", "")
         meta = []
         if subagent_type:
             meta.append(f"agent: {subagent_type}")
         if model:
             meta.append(f"model: {model}")
+        if tool_input.get("run_in_background"):
+            meta.append("background")
         suffix = f" ({', '.join(meta)})" if meta else ""
-        return f"🔧 Using tool: Agent - `{description}`{suffix}"
+        header = f"🔧 Using tool: Agent - `{description}`{suffix}"
+
+        # The prompt is the only place that says what this sub-agent was
+        # actually asked to do, and it was being dropped everywhere: this row
+        # showed the one-line description, and the child ``UserMessage`` that
+        # repeats it is skipped along with every other sub-agent tool result.
+        # So a reader saw the answers to a question never shown. It rides the
+        # row's collapsible body, the same way Edit's diff does.
+        prompt = str(tool_input.get("prompt") or "").strip()
+        if prompt:
+            return f"{header}\n\n{prompt}"
+        return header
 
     # Bash - execute shell commands
     elif tool_name == "Bash":

--- a/backend/src/integrations/headless/subagent.py
+++ b/backend/src/integrations/headless/subagent.py
@@ -5,12 +5,42 @@ the launching Task block's id; that id is the group key threaded into
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+
+# Task types the CLI announces through ``task_started`` that mean delegated
+# *agent* work — a Task-tool sub-agent or a workflow.
+#
+# A backgrounded shell (``Bash(run_in_background=True)``, or one the CLI
+# auto-backgrounds when it outruns the foreground timeout) rides the *exact
+# same* task frames as ``local_bash``, and all three carry a ``tool_use_id``.
+# So the presence of an id is not a discriminator: keying off it alone is what
+# made every slow ``git push`` render as a "Sub-agent: agent" card holding one
+# line of text. ``task_type`` is the CLI's own answer to the question.
+#
+# Mirrors the SDK's ``DEFERRING_TASK_TYPES`` and paseo's
+# ``isProviderSubagentTask``.
+AGENT_TASK_TYPES = frozenset({"local_agent", "local_workflow"})
 
 
 class SubAgentTracker:
+    """Which launched tasks are sub-agents, and what to call them.
+
+    Two independent facts are remembered, from two different frames:
+
+    * the ``Task``/``Agent`` **tool blocks** seen on the stream — the source of
+      the label (``subagent_type`` / ``description``). Having seen one at all
+      also proves that ``tool_use_id`` belongs to delegated agent work.
+    * the ``task_started`` **announcements** — the source of ``task_type``,
+      which is what separates a sub-agent from a backgrounded shell.
+      ``task_notification`` (where a finished task reports back) carries no
+      ``task_type`` of its own, so it has to be looked up by ``task_id``.
+    """
+
     def __init__(self) -> None:
         self._tasks: Dict[str, Tuple[str, str]] = {}
+        # task_id -> task_type / tool_use_id, both from ``task_started``.
+        self._task_types: Dict[str, str] = {}
+        self._tool_use_by_task: Dict[str, str] = {}
 
     def remember_task(
         self, tool_use_id: str, subagent_type: str, description: str
@@ -20,18 +50,59 @@ class SubAgentTracker:
     def label_for(self, tool_use_id: str) -> Tuple[str, str]:
         return self._tasks.get(tool_use_id, ("agent", ""))
 
+    def knows(self, tool_use_id: Optional[str]) -> bool:
+        """True when ``tool_use_id`` is a ``Task``/``Agent`` block we saw launch."""
+        return bool(tool_use_id) and tool_use_id in self._tasks
+
+    def observe_task_started(
+        self,
+        task_id: Optional[str],
+        task_type: Optional[str],
+        tool_use_id: Optional[str],
+    ) -> None:
+        """Record a ``task_started`` announcement so its later
+        ``task_notification`` can be classified."""
+        if not task_id:
+            return
+        if task_type:
+            self._task_types[task_id] = task_type
+        if tool_use_id:
+            self._tool_use_by_task[task_id] = tool_use_id
+
+    def is_agent_task(
+        self, task_id: Optional[str], tool_use_id: Optional[str] = None
+    ) -> bool:
+        """Is this settled task a sub-agent, or a backgrounded shell?
+
+        ``task_type`` from the matching ``task_started`` is authoritative when
+        the CLI announced one. Releases predating ``task_type`` announce
+        nothing to go on, so fall back to having actually seen the launching
+        ``Task``/``Agent`` tool block — only delegated agent work produces one.
+        """
+        task_type = self._task_types.get(task_id or "")
+        if task_type:
+            return task_type in AGENT_TASK_TYPES
+        return self.knows(tool_use_id or self._tool_use_by_task.get(task_id or ""))
+
 
 def build_metadata(
-    tool_use_id: str, subagent_type: str, description: str, role: str = "step"
+    tool_use_id: str,
+    subagent_type: str,
+    description: str,
+    role: str = "step",
+    status: Optional[str] = None,
 ) -> dict:
-    return {
-        "subagent": {
-            "tool_use_id": tool_use_id,
-            "subagent_type": subagent_type or "agent",
-            "description": description or "",
-            "role": role,
-        }
+    payload = {
+        "tool_use_id": tool_use_id,
+        "subagent_type": subagent_type or "agent",
+        "description": description or "",
+        "role": role,
     }
+    # Only the settled report carries one; clients key the failure treatment
+    # off its presence, so don't stamp a null onto every step.
+    if status:
+        payload["status"] = status
+    return {"subagent": payload}
 
 
-__all__ = ["SubAgentTracker", "build_metadata"]
+__all__ = ["AGENT_TASK_TYPES", "SubAgentTracker", "build_metadata"]

--- a/backend/src/integrations/headless/tests/test_format_tools.py
+++ b/backend/src/integrations/headless/tests/test_format_tools.py
@@ -7,7 +7,11 @@ break the dashboard's tool-call rendering.
 
 from __future__ import annotations
 
-from integrations.headless.format_tools import format_tool_use
+from integrations.headless.format_tools import (
+    format_background_task_notification,
+    format_tool_use,
+    subagent_label,
+)
 
 
 def test_bash_uses_backticked_command():
@@ -155,3 +159,78 @@ def test_unknown_tool_picks_common_param():
 def test_unknown_tool_with_no_recognized_param():
     out = format_tool_use("WeirdTool", {"unrelated": True})
     assert out == "🔧 Using tool: WeirdTool"
+
+
+# --- Agent / Task ----------------------------------------------------------
+
+
+def test_agent_row_carries_the_prompt_as_its_body():
+    """The assignment is the only record of what the sub-agent was asked to do
+    — the child ``UserMessage`` repeating it is dropped with the other
+    sub-agent tool results — so it rides the row's collapsible body."""
+    out = format_tool_use(
+        "Agent",
+        {
+            "description": "Map the auth flow",
+            "subagent_type": "Explore",
+            "prompt": "Find every call site of ensure_local_user.",
+        },
+    )
+    assert out == (
+        "🔧 Using tool: Agent - `Map the auth flow` (agent: Explore)\n\n"
+        "Find every call site of ensure_local_user."
+    )
+
+
+def test_agent_row_without_a_prompt_stays_one_line():
+    out = format_tool_use(
+        "Agent", {"description": "Map the auth flow", "subagent_type": "Explore"}
+    )
+    assert out == "🔧 Using tool: Agent - `Map the auth flow` (agent: Explore)"
+
+
+def test_agent_row_marks_a_background_launch():
+    out = format_tool_use(
+        "Agent",
+        {
+            "description": "Watch CI",
+            "subagent_type": "Explore",
+            "model": "opus",
+            "run_in_background": True,
+        },
+    )
+    assert out == (
+        "🔧 Using tool: Agent - `Watch CI` (agent: Explore, model: opus, background)"
+    )
+
+
+def test_subagent_label_prefers_an_explicit_name():
+    assert (
+        subagent_label({"name": "reviewer", "subagent_type": "Explore"}) == "reviewer"
+    )
+    assert subagent_label({"subagent_type": "Explore"}) == "Explore"
+    assert subagent_label({"name": "  ", "subagent_type": "Explore"}) == "Explore"
+    assert subagent_label({}) == ""
+
+
+# --- Background task notifications -----------------------------------------
+
+
+def test_background_task_notification_is_a_one_line_tool_row():
+    out = format_background_task_notification("Sync main", "completed")
+    assert out == "🔧 Using tool: Background task - `Sync main`"
+
+
+def test_background_task_notification_keeps_the_rest_as_a_body():
+    out = format_background_task_notification("Watch CI\n\nexit code 0", "completed")
+    assert out == "🔧 Using tool: Background task - `Watch CI`\n\nexit code 0"
+
+
+def test_background_task_notification_reports_a_non_completed_status():
+    out = format_background_task_notification("Watch CI", "failed")
+    assert out == "🔧 Using tool: Background task - `Watch CI` (failed)"
+
+
+def test_background_task_notification_without_a_summary_still_labels_itself():
+    out = format_background_task_notification("   ", None)
+    assert out == "🔧 Using tool: Background task - `Background task finished`"

--- a/backend/src/integrations/headless/tests/test_subagent.py
+++ b/backend/src/integrations/headless/tests/test_subagent.py
@@ -331,7 +331,9 @@ async def test_receive_loop_diverts_children_and_keeps_main_stream_flat(make_run
 # ---------------------------------------------------------------------------
 
 
-def _task_started(task_id: str, tool_use_id: str) -> TaskStartedMessage:
+def _task_started(
+    task_id: str, tool_use_id: str, task_type: str | None = None
+) -> TaskStartedMessage:
     return TaskStartedMessage(
         subtype="task_started",
         data={},
@@ -340,6 +342,7 @@ def _task_started(task_id: str, tool_use_id: str) -> TaskStartedMessage:
         uuid="u-start",
         session_id="sdk-sess-1",
         tool_use_id=tool_use_id,
+        task_type=task_type,
     )
 
 
@@ -485,6 +488,7 @@ async def test_subagent_result_is_forwarded_tagged(make_runner):
         "subagent_type": "Explore",
         "description": "map",
         "role": "result",
+        "status": "completed",
     }
 
 
@@ -494,15 +498,20 @@ async def test_failed_subagent_result_is_marked(make_runner):
     sends = []
 
     async def _capture(content, message_metadata=None):
-        sends.append(content)
+        sends.append((content, message_metadata))
 
     runner.send_to_vicoa = _capture  # type: ignore
+    runner._remember_tasks_in_message(_assistant_with_task("tu-1", "Explore", "map"))
 
     await runner._send_subagent_result(
         _task_notification("task-1", "tu-1", "ran out of context", status="failed")
     )
 
-    assert sends[-1] == "⚠️ Sub-agent failed\n\nran out of context"
+    content, metadata = sends[-1]
+    # The status rides the metadata for the header, and stays in the body so a
+    # client predating that field still shows the run as failed.
+    assert content == "⚠️ Sub-agent failed\n\nran out of context"
+    assert metadata["subagent"]["status"] == "failed"
 
 
 @pytest.mark.asyncio
@@ -514,11 +523,133 @@ async def test_empty_subagent_summary_is_not_forwarded(make_runner):
         sends.append(content)
 
     runner.send_to_vicoa = _capture  # type: ignore
+    runner._remember_tasks_in_message(_assistant_with_task("tu-1", "Explore", "map"))
 
     await runner._send_subagent_result(_task_notification("task-1", "tu-1", "   "))
-    await runner._send_subagent_result(_task_notification("task-1", "", "non-empty"))
 
     assert sends == []
+
+
+@pytest.mark.asyncio
+async def test_background_shell_notification_is_not_a_subagent(make_runner):
+    """A backgrounded Bash settles through the same ``task_notification`` frame
+    a sub-agent does. It used to be tagged with the ``("agent", "")`` sentinel
+    and render as a "Sub-agent: agent" card holding one line — the Bash call's
+    own description. It is a plain tool row instead."""
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore
+    runner._track_task_lifecycle(_task_started("task-1", "tu-bash", "local_bash"))
+
+    await runner._send_subagent_result(
+        _task_notification("task-1", "tu-bash", "Sync main")
+    )
+
+    content, metadata = sends[-1]
+    assert content == "🔧 Using tool: Background task - `Sync main`"
+    assert metadata is None
+
+
+@pytest.mark.asyncio
+async def test_failed_background_shell_notification_reports_its_status(make_runner):
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore
+    runner._track_task_lifecycle(_task_started("task-1", "tu-bash", "local_bash"))
+
+    await runner._send_subagent_result(
+        _task_notification("task-1", "tu-bash", "Watch CI", status="failed")
+    )
+
+    assert sends[-1][0] == "🔧 Using tool: Background task - `Watch CI` (failed)"
+
+
+@pytest.mark.asyncio
+async def test_announced_agent_task_is_tagged_without_a_seen_task_block(make_runner):
+    """``task_type`` is authoritative on its own: a sub-agent whose launching
+    Task block never reached us (a resumed session) is still a sub-agent."""
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore
+    runner._track_task_lifecycle(_task_started("task-1", "tu-1", "local_agent"))
+
+    await runner._send_subagent_result(
+        _task_notification("task-1", "tu-1", "Found 3 call sites.")
+    )
+
+    content, metadata = sends[-1]
+    assert content == "Found 3 call sites."
+    # No Task block was seen, so the label falls back to the sentinel — but the
+    # message is still grouped as sub-agent activity.
+    assert metadata["subagent"]["role"] == "result"
+    assert metadata["subagent"]["tool_use_id"] == "tu-1"
+
+
+@pytest.mark.asyncio
+async def test_task_type_less_cli_still_tags_a_known_task_block(make_runner):
+    """Releases predating ``task_type`` announce nothing to classify on, so the
+    fallback is having actually seen the ``Task`` block."""
+    runner = make_runner()
+    sends = []
+
+    async def _capture(content, message_metadata=None):
+        sends.append((content, message_metadata))
+
+    runner.send_to_vicoa = _capture  # type: ignore
+    runner._remember_tasks_in_message(_assistant_with_task("tu-1", "Explore", "map"))
+    runner._track_task_lifecycle(_task_started("task-1", "tu-1"))
+
+    await runner._send_subagent_result(
+        _task_notification("task-1", "tu-1", "Found 3 call sites.")
+    )
+
+    assert sends[-1][1]["subagent"]["subagent_type"] == "Explore"
+
+
+def test_tracker_classifies_by_task_type():
+    t = SubAgentTracker()
+    t.observe_task_started("task-agent", "local_agent", "tu-a")
+    t.observe_task_started("task-flow", "local_workflow", "tu-w")
+    t.observe_task_started("task-bash", "local_bash", "tu-b")
+
+    assert t.is_agent_task("task-agent", "tu-a") is True
+    assert t.is_agent_task("task-flow", "tu-w") is True
+    assert t.is_agent_task("task-bash", "tu-b") is False
+
+
+def test_tracker_classifies_unannounced_tasks_by_seen_task_block():
+    t = SubAgentTracker()
+    t.remember_task("tu-1", "Explore", "map the code")
+
+    assert t.is_agent_task("task-1", "tu-1") is True
+    assert t.is_agent_task("task-2", "tu-unknown") is False
+    assert t.is_agent_task(None, None) is False
+
+
+def test_tracker_resolves_tool_use_id_from_the_announcement():
+    """``task_notification`` may omit ``tool_use_id``; ``task_started`` carries
+    it, so the announcement is what links the two."""
+    t = SubAgentTracker()
+    t.remember_task("tu-1", "Explore", "map the code")
+    t.observe_task_started("task-1", None, "tu-1")
+
+    assert t.is_agent_task("task-1", None) is True
+
+
+def test_build_metadata_omits_absent_status():
+    assert "status" not in build_metadata("tu-1", "Explore", "map")["subagent"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

A sub-agent's activity in the transcript read as one anonymous line. Three separate gaps, found while looking at two real sessions.

### 1. Backgrounded shells were masquerading as sub-agents

Claude Code announces a backgrounded `Bash` — explicit `run_in_background`, **or one the CLI auto-backgrounds when it outruns the foreground timeout** — through the same `task_started` / `task_notification` frames a Task-tool sub-agent uses. Verified on the wire with an SDK probe:

| what | `task_type` | `subagent_type` | `tool_use_id` |
|---|---|---|---|
| Task sub-agent | `local_agent` | yes | yes |
| Workflow | `local_workflow` | no | yes |
| backgrounded shell | `local_bash` | no | **yes** |

All three carry a `tool_use_id`, so its presence is not a discriminator. `_send_subagent_result` forwarded *every* notification and fell back to the `("agent", "")` sentinel when it had no `Task` block to label it with — so a slow `git push` rendered as a **"Sub-agent: agent" card holding one line of text**, the Bash call's own `description`. One release session showed ten of those and contained zero sub-agents; I resolved each `tool_use_id` back through the raw CLI transcript to confirm (`toolu_01DfD7…` = `Bash {"command": "git checkout main && git pull", "description": "Sync main"}`).

`task_type` is the CLI's own answer, but only `task_started` carries it, so `SubAgentTracker` now remembers it by `task_id` for the notification to look up. Releases predating `task_type` fall back to having actually seen the launching `Task`/`Agent` tool block. Non-agent notifications render as an ordinary collapsible tool row (a wrench, matching how paseo maps the same frame onto a synthetic `task_notification` tool call).

### 2. A sub-agent's edits were invisible

A collapsed `ToolUseGroup` names the work (*"Run 2 commands, edit 2 files"*) and lists each edited file as a chip with its `+N -M` and a hover diff preview. `SubagentGroup` drew a bare `Sub-agent: <type>` line, so a sub-agent that rewrote three files named neither the work nor the files — you had to expand the group, then expand a row inside it. The data was always there (a sub-agent's `Edit` arrives with full `old_string`/`new_string`; the diff was being generated and thrown away by the renderer).

That header rendering is now a shared `ToolRunSummary` that `ToolUseGroup` and `SubagentGroup` both use, so the two read in one vocabulary. Runs of consecutive tool uses inside an expanded group fuse into one run the way the main stream's do (mobile already did this; web didn't). **Collapsed, the group is still one row and nothing else, like any tool group.**

### 3. The assignment was dropped

The `Agent` tool row printed only `description`, and the child `UserMessage` that repeats the prompt is skipped along with every other sub-agent tool result — so the transcript showed answers to a question the reader never saw. The prompt now rides that row's collapsible body, the way Edit's diff does.

Also: the run's terminal status rides `message_metadata.subagent.status` so the header can mark a failed run (kept in the message body too, so a client predating the field doesn't silently show a failed run as a normal one), and an explicit `name` on the call wins over `subagent_type` so a fan-out of five `Explore`s isn't five identical rows.

## How it was tested

**Backend** — `make lint` clean (ruff + pyright + WebSocket freeze check); `pytest src/integrations` → **811 passed**. New coverage for the classification (`local_bash` → tool row, `local_agent` → tagged, pre-`task_type` CLI → falls back to the seen `Task` block, `task_id`→`tool_use_id` resolution) and for the new formatters.

**Web** — `tsc --noEmit` clean, `pnpm lint` clean, `vitest` → **817 passed**, `pnpm build` green. New coverage for `subagentGroupStatus` and the `role`/`status` payload parsing.

**Mobile** — `flutter analyze` reports **no issues** in `subagent_group.dart`; the file-set total (26) is unchanged from `main`. `flutter test` → **285 passed**; the 8 failures in `agent_config_sheet_test.dart` (Supabase not initialised) are pre-existing and identical on `main`.

**End to end** — drove a real sub-agent through the actual formatting path against the live SDK (`Agent` → `Read` → `Edit`), and confirmed each POST:

```
--- PLAIN
🔧 Using tool: Agent - `Edit beta to BETA` (agent: general-purpose)

In the file /tmp/subprobe/f.txt, change the text 'beta' to 'BETA'.
...

--- SUB[general-purpose/step]
🔧 Using tool: **Edit** - `/tmp/subprobe/f.txt`

```diff
- beta
+ BETA
```

--- SUB[general-purpose/result]
Done. **Before:** … **After:** …
```

- Platforms tested: backend (unit + live SDK), web/desktop (types, lint, unit, production build)
- Platforms NOT tested: mobile on a device — the Dart is analysed and unit-tested, but the collapsed header's new run-summary label hasn't been rendered on real hardware

## Checklist

- [x] One focused change; no unrelated edits bundled in
- [x] Tests added/updated and passing (`make test` / `pnpm test` / `flutter test`)
- [x] Lint passes (`make lint` / `flutter analyze`)
- [x] DB schema change includes its migration (n/a — no schema change)
- [ ] Screenshots/video included for UI changes
- [x] I have read the [Contributing guide](../CONTRIBUTING.md), including the contribution/license terms
