### PR TITLE
Composer: paste a clipboard image as an attachment

### DIFF
--- a/apps/web/app/dashboard/agents/new-session/page.tsx
+++ b/apps/web/app/dashboard/agents/new-session/page.tsx
@@ -89,6 +89,7 @@ import { DesktopCollapsedLead, DesktopWindowControlsSpacer } from '@/components/
 import { comboInline, getShortcutCombo, matchesShortcut } from '@/lib/desktop-shortcuts';
 import { getDesktopShellBridge } from '@/lib/desktop-shell';
 import { collectComposerDrop, folderPathToMention } from '@/lib/chat-drop';
+import { collectComposerPaste, pasteTargetIsEditable } from '@/lib/chat-paste';
 import { FolderRefChip } from '@/components/folder-ref-chip';
 import { ForkContextChip } from '@/components/dashboard/fork-context-chip';
 import { postInstanceMessage } from '@/lib/agent-instance-api';
@@ -1293,6 +1294,32 @@ function NewSessionContent() {
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [addPickedFiles]);
 
+  // Ctrl/⌘+V of a screenshot attaches it, under the same caps as the picker.
+  // A clipboard carrying text still pastes text (see `collectComposerPaste`).
+  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const { files, handled } = collectComposerPaste(event.clipboardData);
+    if (!handled) return;
+    event.preventDefault();
+    addPickedFiles(files);
+  }, [addPickedFiles]);
+
+  // Same document-level fallback as the session composer: a screenshot is taken
+  // in another app, so the window often has nothing focused when the user
+  // pastes. Never takes a paste aimed at a field that accepts typing.
+  useEffect(() => {
+    if (isSubmitting) return;
+    const onDocumentPaste = (event: ClipboardEvent) => {
+      if (event.defaultPrevented || pasteTargetIsEditable(event.target)) return;
+      const { files, handled } = collectComposerPaste(event.clipboardData);
+      if (!handled) return;
+      event.preventDefault();
+      addPickedFiles(files);
+      textareaRef.current?.focus({ preventScroll: true });
+    };
+    document.addEventListener('paste', onDocumentPaste);
+    return () => document.removeEventListener('paste', onDocumentPaste);
+  }, [isSubmitting, addPickedFiles]);
+
   // Add desktop-resolved folder paths from a drop as chips (deduped), the same
   // shape the "Add folder" action produces — expanded to @path/ on submit.
   const addDroppedFolderRefs = useCallback((paths: string[]) => {
@@ -2059,6 +2086,7 @@ function NewSessionContent() {
                   openMentionSignal={mentionSignal}
                   onMentionOpenChange={(open) => { if (open) setShowSlashCommands(false); }}
                   onKeyDown={handleKeyDown}
+                  onPaste={handlePaste}
                   placeholder="Type messages, @files, /skills or commands"
                   rows={1}
                   disabled={isSubmitting}

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -25,6 +25,7 @@ import { shouldShowStopButton } from '@/lib/chat-composer';
 import { getDesktopConfig } from '@/lib/runtime-config';
 import { comboInline, getShortcutCombo, matchesShortcut } from '@/lib/desktop-shortcuts';
 import { folderPathToMention } from '@/lib/chat-drop';
+import { collectComposerPaste, pasteTargetIsEditable } from '@/lib/chat-paste';
 import { FolderRefChip } from '@/components/folder-ref-chip';
 import { getDesktopShellBridge } from '@/lib/desktop-shell';
 
@@ -312,6 +313,36 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
     // Allow re-picking the same file later.
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [addFilesToPending]);
+
+  // Ctrl/⌘+V of a screenshot attaches it, through the same caps and the same
+  // eager upload as the picker. A clipboard carrying text still pastes text —
+  // `collectComposerPaste` owns that call; here we only honour its verdict.
+  const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const { files, handled } = collectComposerPaste(event.clipboardData);
+    if (!handled) return;
+    event.preventDefault();
+    addFilesToPending(files);
+  }, [addFilesToPending]);
+
+  // The screenshot was taken in another app, so the user comes back to a window
+  // where nothing is focused and hits paste. Catch that at the document level
+  // and route it to the composer — but never over a field that takes typing
+  // (the terminal's helper textarea, a search box), and never over a paste some
+  // other handler already consumed.
+  const pasteAcceptEnabled = !disabled && canSendMessage && !isSending;
+  useEffect(() => {
+    if (!pasteAcceptEnabled) return;
+    const onDocumentPaste = (event: ClipboardEvent) => {
+      if (event.defaultPrevented || pasteTargetIsEditable(event.target)) return;
+      const { files, handled } = collectComposerPaste(event.clipboardData);
+      if (!handled) return;
+      event.preventDefault();
+      addFilesToPending(files);
+      focusTextarea();
+    };
+    document.addEventListener('paste', onDocumentPaste);
+    return () => document.removeEventListener('paste', onDocumentPaste);
+  }, [pasteAcceptEnabled, addFilesToPending, focusTextarea]);
 
   // "Add folder" / desktop folder-drop: add the folder(s) as chips (deduped by
   // absolute path). They become `@path/` text in `handleSendMessage`.
@@ -818,6 +849,7 @@ export const ChatInput = memo(forwardRef<ChatInputHandle, ChatInputProps>(functi
               scrollbarColor: 'hsl(var(--border)) transparent',
             }}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             rows={1}
           />
         </div>

--- a/apps/web/lib/chat-paste.test.ts
+++ b/apps/web/lib/chat-paste.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectComposerPaste,
+  nameClipboardFile,
+  pasteTargetIsEditable,
+  type ClipboardTransfer,
+} from './chat-paste';
+
+/** A `DataTransfer` stand-in shaped like the one a `paste` event carries. */
+function transfer(opts: {
+  text?: string;
+  items?: { kind: string; file: File | null }[];
+  files?: File[];
+  throwOnGetData?: boolean;
+}): ClipboardTransfer {
+  return {
+    getData: () => {
+      if (opts.throwOnGetData) throw new Error('no clipboard access');
+      return opts.text ?? '';
+    },
+    items: (opts.items ?? []).map((it) => ({ kind: it.kind, getAsFile: () => it.file })),
+    files: opts.files ?? [],
+  };
+}
+
+const NOW = new Date(2026, 8, 11, 14, 30, 5); // 2026-09-11 14:30:05 local
+
+function png(name: string, bytes = 8): File {
+  return new File([new Uint8Array(bytes)], name, { type: 'image/png' });
+}
+
+describe('collectComposerPaste', () => {
+  it('takes a screenshot off an otherwise-empty clipboard', () => {
+    const result = collectComposerPaste(
+      transfer({ items: [{ kind: 'file', file: png('image.png') }] }),
+      NOW,
+    );
+    expect(result.handled).toBe(true);
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].name).toBe('pasted-image-20260911-143005.png');
+    expect(result.files[0].type).toBe('image/png');
+  });
+
+  it('leaves a plain text paste to the browser', () => {
+    const result = collectComposerPaste(transfer({ text: 'hello' }), NOW);
+    expect(result).toEqual({ files: [], handled: false });
+  });
+
+  // Copying a range out of Excel/Numbers/Figma puts both a bitmap and the text
+  // on the clipboard; the text is what the user meant.
+  it('prefers text when the clipboard carries text and an image', () => {
+    const result = collectComposerPaste(
+      transfer({ text: 'a\tb', items: [{ kind: 'file', file: png('image.png') }] }),
+      NOW,
+    );
+    expect(result).toEqual({ files: [], handled: false });
+  });
+
+  it('keeps a real filename from a copied file', () => {
+    const result = collectComposerPaste(
+      transfer({ items: [{ kind: 'file', file: png('screenshot-of-bug.png') }] }),
+      NOW,
+    );
+    expect(result.files[0].name).toBe('screenshot-of-bug.png');
+  });
+
+  it('ignores string items and null files', () => {
+    const result = collectComposerPaste(
+      transfer({
+        items: [
+          { kind: 'string', file: null },
+          { kind: 'file', file: null },
+        ],
+      }),
+      NOW,
+    );
+    expect(result).toEqual({ files: [], handled: false });
+  });
+
+  it('falls back to the flat file list when items is empty', () => {
+    const result = collectComposerPaste(transfer({ files: [png('image.png')] }), NOW);
+    expect(result.handled).toBe(true);
+    expect(result.files[0].name).toBe('pasted-image-20260911-143005.png');
+  });
+
+  it('takes every image when several are on the clipboard', () => {
+    const result = collectComposerPaste(
+      transfer({
+        items: [
+          { kind: 'file', file: png('a.png') },
+          { kind: 'file', file: png('b.png') },
+        ],
+      }),
+      NOW,
+    );
+    expect(result.files.map((f) => f.name)).toEqual(['a.png', 'b.png']);
+  });
+
+  it('survives a clipboard that refuses getData', () => {
+    const result = collectComposerPaste(
+      transfer({ throwOnGetData: true, items: [{ kind: 'file', file: png('image.png') }] }),
+      NOW,
+    );
+    expect(result.handled).toBe(true);
+  });
+
+  it('handles a missing transfer', () => {
+    expect(collectComposerPaste(null, NOW)).toEqual({ files: [], handled: false });
+    expect(collectComposerPaste(undefined, NOW)).toEqual({ files: [], handled: false });
+  });
+});
+
+describe('nameClipboardFile', () => {
+  it.each([
+    ['image/png', 'pasted-image-20260911-143005.png'],
+    ['image/jpeg', 'pasted-image-20260911-143005.jpg'],
+    ['image/gif', 'pasted-image-20260911-143005.gif'],
+    ['image/webp', 'pasted-image-20260911-143005.webp'],
+    ['image/svg+xml', 'pasted-image-20260911-143005.svg'],
+  ])('names a %s clipboard bitmap %s', (mime, expected) => {
+    const file = new File([new Uint8Array(4)], 'image.png', { type: mime });
+    expect(nameClipboardFile(file, NOW).name).toBe(expected);
+  });
+
+  it('falls back to the mime subtype for an unknown type', () => {
+    const file = new File([new Uint8Array(4)], '', { type: 'image/heic' });
+    expect(nameClipboardFile(file, NOW).name).toBe('pasted-image-20260911-143005.heic');
+  });
+
+  it('preserves the file contents', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'image.png', { type: 'image/png' });
+    const renamed = nameClipboardFile(file, NOW);
+    expect(new Uint8Array(await renamed.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+  });
+});
+
+describe('pasteTargetIsEditable', () => {
+  const el = (tagName: string, extra: Record<string, unknown> = {}) =>
+    ({ tagName, closest: () => null, ...extra }) as unknown as EventTarget;
+
+  it('claims nothing when the paste landed on plain markup', () => {
+    expect(pasteTargetIsEditable(el('DIV'))).toBe(false);
+    expect(pasteTargetIsEditable(el('BODY'))).toBe(false);
+    expect(pasteTargetIsEditable(null)).toBe(false);
+  });
+
+  // xterm types into a helper <textarea>; taking its paste would break terminal
+  // paste outright.
+  it('defers to fields that take typing', () => {
+    expect(pasteTargetIsEditable(el('TEXTAREA'))).toBe(true);
+    expect(pasteTargetIsEditable(el('INPUT'))).toBe(true);
+    expect(pasteTargetIsEditable(el('SELECT'))).toBe(true);
+  });
+
+  it('defers to contenteditable, directly or by ancestor', () => {
+    expect(pasteTargetIsEditable(el('DIV', { isContentEditable: true }))).toBe(true);
+    expect(
+      pasteTargetIsEditable(el('SPAN', { closest: (s: string) => (s.includes('contenteditable') ? {} : null) })),
+    ).toBe(true);
+  });
+
+  it('tolerates a target that is not an element', () => {
+    // A paste can target the document itself, which has no `tagName`.
+    expect(pasteTargetIsEditable({} as EventTarget)).toBe(false);
+    expect(pasteTargetIsEditable({ nodeType: 9 } as unknown as EventTarget)).toBe(false);
+  });
+});

--- a/apps/web/lib/chat-paste.ts
+++ b/apps/web/lib/chat-paste.ts
@@ -1,0 +1,133 @@
+/**
+ * Clipboard paste onto the chat composer.
+ *
+ * The case that matters is a screenshot (Win+Shift+S, ⌘⇧4, Print Screen): the
+ * OS puts a bitmap on the clipboard and nothing else, so Ctrl/⌘+V into the
+ * prompt box should attach it instead of doing nothing. The transfer is the
+ * same `DataTransfer` a drop carries, so the files land in the same upload
+ * pipeline as `chat-drop.ts` (see `MAX_ATTACHMENTS_PER_MESSAGE`).
+ *
+ * Text pasting must not regress, which decides the one ambiguous case: a
+ * clipboard that holds BOTH text and an image. Copying a range out of Excel,
+ * Numbers or Figma does exactly that — the payload the user meant is the text,
+ * and the bitmap is a rendering of it. So text wins whenever there is text, and
+ * files are only taken from an otherwise-textless clipboard. That is also the
+ * screenshot case, which is the one being asked for.
+ */
+
+/** The slice of `DataTransfer` this module reads — spelled structurally so a
+ * test can hand it a literal. */
+export interface ClipboardTransfer {
+  getData(format: string): string;
+  items?: ArrayLike<{ kind: string; getAsFile(): File | null }> | null;
+  files?: ArrayLike<File> | null;
+}
+
+export interface ClipboardPaste {
+  /** Files to hand to the composer's attachment pipeline. */
+  files: File[];
+  /** True when this paste was consumed as an attachment, so the caller should
+   * `preventDefault()` — otherwise the browser's own text paste must run. */
+  handled: boolean;
+}
+
+/** Extensions for the raster types a clipboard realistically produces; anything
+ * else falls back to the mime subtype. */
+const MIME_EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+  'image/tiff': 'tiff',
+  'image/svg+xml': 'svg',
+};
+
+function extensionFor(mimeType: string): string {
+  const known = MIME_EXTENSIONS[mimeType];
+  if (known) return known;
+  const subtype = mimeType.split('/')[1] ?? '';
+  const cleaned = subtype.split('+')[0].replace(/[^a-z0-9]/gi, '').toLowerCase();
+  return cleaned || 'bin';
+}
+
+/** Chromium hands every clipboard bitmap the same placeholder name, so a
+ * session with three pasted screenshots is three attachments called
+ * "image.png". Anything else — a file copied in Finder/Explorer — keeps the
+ * name the user knows it by. */
+function isPlaceholderName(name: string): boolean {
+  return name === '' || /^image\.[a-z0-9]+$/i.test(name);
+}
+
+function pasteTimestamp(now: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
+  );
+}
+
+/** Give a clipboard bitmap a name that means something in a message list and in
+ * the agent's prompt ("pasted-image-20260911-143005.png"). */
+export function nameClipboardFile(file: File, now: Date = new Date()): File {
+  if (!isPlaceholderName(file.name)) return file;
+  const name = `pasted-image-${pasteTimestamp(now)}.${extensionFor(file.type)}`;
+  return new File([file], name, { type: file.type, lastModified: file.lastModified });
+}
+
+/**
+ * Inspect a composer paste.
+ *
+ * Must be called synchronously from the `paste` handler: the item list is only
+ * valid for the duration of the event.
+ */
+export function collectComposerPaste(
+  dt: ClipboardTransfer | null | undefined,
+  now: Date = new Date(),
+): ClipboardPaste {
+  if (!dt) return { files: [], handled: false };
+
+  // Text wins outright (see the header). `getData` throws on nothing in any
+  // engine we ship on, but a paste handler that throws eats the paste.
+  let text = '';
+  try {
+    text = dt.getData('text/plain') ?? '';
+  } catch {
+    text = '';
+  }
+  if (text.length > 0) return { files: [], handled: false };
+
+  const files: File[] = [];
+  const items = dt.items ? Array.from(dt.items) : [];
+  for (const item of items) {
+    if (item.kind !== 'file') continue;
+    const file = item.getAsFile();
+    if (file) files.push(nameClipboardFile(file, now));
+  }
+  // Some engines leave `items` empty for a synthesized transfer; the flat file
+  // list is the fallback (this is what `chat-drop.ts` does for drops).
+  if (files.length === 0 && dt.files) {
+    for (const file of Array.from(dt.files)) files.push(nameClipboardFile(file, now));
+  }
+
+  return { files, handled: files.length > 0 };
+}
+
+const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+/**
+ * Does this paste already belong to something that takes typing?
+ *
+ * Used by the composer's document-level fallback, which exists because a
+ * screenshot is taken in *another* app: the user comes back to a window where
+ * nothing is focused and presses Ctrl/⌘+V. That fallback must not steal a paste
+ * from the terminal (xterm types into a helper `<textarea>`), a search box, or
+ * any other field — those own their own clipboard behaviour.
+ */
+export function pasteTargetIsEditable(target: EventTarget | null): boolean {
+  const el = target as (Element & { isContentEditable?: boolean }) | null;
+  if (!el || typeof el.tagName !== 'string') return false;
+  if (EDITABLE_TAGS.has(el.tagName.toUpperCase())) return true;
+  if (el.isContentEditable) return true;
+  return typeof el.closest === 'function' && el.closest('[contenteditable="true"]') !== null;
+}


### PR DESCRIPTION
Closes #48

## What

Ctrl/⌘+V of a clipboard image now attaches it in the session composer (`chat-input.tsx`) and the new-session prompt, feeding the existing attachment pipeline — so a pasted screenshot gets the same 5-per-message / 25 MB caps with their flash messages, the same thumbnail chip with ✕, the same eager upload with click-to-retry, and unchanged delivery to Codex / Claude / ACP agents. No backend change.

**Desktop** gets it for free: the Electron shell's renderer *is* `apps/web`, and its Edit menu uses the stock `role: 'paste'` on every platform with a plain sandboxed renderer — nothing intercepts the event.

## Behaviour decisions

- **Text wins.** A clipboard holding text pastes text, always. This decides the one ambiguous case: copying a range out of Excel / Numbers / Figma puts both the text and a bitmap on the clipboard, and the text is what the user meant. Files are only claimed from an otherwise-textless clipboard — which is exactly the screenshot case (Win+Shift+S, ⌘⇧⌃4, Print Screen). Normal text pasting is untouched.
- **Named screenshots.** Chromium hands every clipboard bitmap the name `image.png`; they become `pasted-image-20260911-143005.png`, so three pasted screenshots aren't three identically-named attachments. A file copied in Finder/Explorer keeps its real name.
- **Document-level fallback.** The screenshot was taken in *another* app, so the user often comes back to a window where nothing is focused and hits paste. A `document` listener routes that to the composer — but never over a field that takes typing (`pasteTargetIsEditable`: the terminal's xterm helper `<textarea>`, a search box, contenteditable), and never over a paste some other handler already consumed. Gated on the same conditions that enable the composer.

## Verification

- `lib/chat-paste.test.ts`: 20 unit tests (text-wins, renaming per mime, Finder-file name kept, `items` → `files` fallback, `getData` throwing, editable-target guard). Full web suite 837 passed; `pnpm lint` and `pnpm build` green.
- **Electron 43 (same version the shell pins), real clipboard screenshot**, a bare window with the shell's exact `webPreferences` (`sandbox`, `contextIsolation`) and `role: 'paste'` menu: `webContents.paste()` — the call the ⌘V / Ctrl+V menu accelerator makes — delivered `types: ["Files"]`, `text/plain: ""`, one `file:image/png` item, both into a focused textarea (composer path) and with nothing focused (document fallback). Attached as `pasted-image-…png`, textarea left empty.
- Headed Chrome, real ⌘V keystroke, real PNG on the macOS clipboard: same result.

No new UI — the chip, preview and remove button are the existing attachment UI, so no screenshots.

## Manual test

1. Take a screenshot to the clipboard (Win+Shift+S / ⌘⇧⌃4).
2. In a session, press Ctrl/⌘+V with the composer focused → thumbnail chip appears, ✕ removes it.
3. Click somewhere neutral (the message list), press Ctrl/⌘+V again → still attaches, composer takes focus.
4. Click into the Terminal tab, Ctrl/⌘+V → pastes into the terminal as before, nothing attached.
5. Copy some text, Ctrl/⌘+V into the composer → plain text paste, nothing attached.
6. Type a prompt, paste an image, send → agent receives both.

## Not in this PR

- **Mobile.** Flutter's `Clipboard` is text-only; image paste needs a native plugin (`pasteboard` / `super_clipboard`), a `contextMenuBuilder` override for the OS paste button, a `PasteTextIntent` override for hardware ⌘V, and a store release. Separate piece of work.
- The task comment composer, which deliberately has no attachments.
