### PR TITLE
Chat: open agent file links in the files panel, never the browser

### DIFF
--- a/apps/desktop/src/window.ts
+++ b/apps/desktop/src/window.ts
@@ -192,10 +192,23 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
 
   // ---- External link handling ----------------------------------------------
   const appOrigin = new URL(options.url).origin;
-  win.webContents.setWindowOpenHandler((details) => {
-    if (/^https?:/i.test(details.url)) {
-      void shell.openExternal(details.url);
+  /** Our own renderer (`http://localhost:<port>`) must never be handed to the
+   *  OS browser: that browser has none of this app's session state, so the page
+   *  it lands on demands a sign-in it cannot finish ("Desktop bridge
+   *  unavailable"). A same-origin URL reaching here at all means a link the
+   *  renderer meant to keep in-app — drop it rather than launch a browser.
+   *  See vicoa-ai/vicoa#46. */
+  const openExternally = (url: string): void => {
+    if (!/^https?:/i.test(url)) return;
+    try {
+      if (new URL(url).origin === appOrigin) return;
+    } catch {
+      return;
     }
+    void shell.openExternal(url);
+  };
+  win.webContents.setWindowOpenHandler((details) => {
+    openExternally(details.url);
     return { action: 'deny' };
   });
   win.webContents.on('will-navigate', (event, url) => {
@@ -207,9 +220,7 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
       // unparseable URL: fall through to block
     }
     event.preventDefault();
-    if (/^https?:/i.test(url)) {
-      void shell.openExternal(url);
-    }
+    openExternally(url);
   });
 
   // ---- Windows custom-title-bar maximize state ------------------------------

--- a/apps/web/app/dashboard/agents/[instanceId]/page.tsx
+++ b/apps/web/app/dashboard/agents/[instanceId]/page.tsx
@@ -27,6 +27,8 @@ import { SubagentGroup } from '@/components/dashboard/subagent-group';
 import { MessageItem, resolveAgentType, DateSeparator, ThinkingIndicator, vibingMessages, getMessageVisibleText } from '@/components/dashboard/chat-message-item';
 import { ChatFindBar } from '@/components/dashboard/chat-find-bar';
 import { FindHighlightProvider } from '@/components/dashboard/chat-find-context';
+import { FileLinkProvider } from '@/components/dashboard/file-link-context';
+import type { WorkspaceFileLink } from '@/lib/message-links';
 import { groupSubagents } from '@/components/dashboard/subagent-grouping';
 import { getChatItemSearchText } from '@/lib/chat-search';
 import { buildForkTranscript, saveForkContext } from '@/lib/fork-session';
@@ -250,7 +252,7 @@ function AgentInstanceContent() {
   // through `openFileRequest`, whose bumped nonce makes the panel open it even
   // when it's already mounted / already showing another file.
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
-  const [openFileRequest, setOpenFileRequest] = useState<{ path: string; nonce: number } | null>(
+  const [openFileRequest, setOpenFileRequest] = useState<{ path: string; nonce: number; line?: number } | null>(
     null,
   );
   // Focus-mode chat peek (design A): temporarily reveal the chat beneath the
@@ -1600,10 +1602,20 @@ function AgentInstanceContent() {
   // Open a file picked in the ⌘P finder: reveal the panel and hand it the path.
   // The bumped nonce makes the panel open it whether it was closed (opens on
   // mount) or already showing something else.
-  const handleOpenSearchedFile = useCallback((path: string) => {
+  const handleOpenSearchedFile = useCallback((path: string, line?: number) => {
     panel.setOpen(true);
-    setOpenFileRequest((prev) => ({ path, nonce: (prev?.nonce ?? 0) + 1 }));
+    setOpenFileRequest((prev) => ({ path, line, nonce: (prev?.nonce ?? 0) + 1 }));
   }, [panel]);
+
+  // Same, for a file path an agent cited as a link in its message. Only offered
+  // once the session has a machine to read the file from — otherwise the links
+  // render as plain text rather than as clicks that would fail (see
+  // components/dashboard/file-link-context.tsx).
+  const handleOpenLinkedFile = useCallback(
+    (file: WorkspaceFileLink) => handleOpenSearchedFile(file.path, file.line),
+    [handleOpenSearchedFile],
+  );
+  const canOpenLinkedFiles = !!instance?.machine_id && !!instance?.project;
 
   // ⌘P opens the file finder. Session-scoped and gated on a reachable machine —
   // the finder reads the live project index off the daemon, and picking a file
@@ -2359,6 +2371,11 @@ function AgentInstanceContent() {
       </div> */}
 
       {/* Messages Area - virtualized via react-virtuoso */}
+      <FileLinkProvider
+        cwd={instance?.project ?? null}
+        homeDir={instance?.home_dir ?? null}
+        openFile={canOpenLinkedFiles ? handleOpenLinkedFile : null}
+      >
       <FindHighlightProvider query={findOpen ? findNeedle : ''} activeKey={findActiveKey}>
       <div className="relative flex-1 min-h-0">
         {!hasMessageItems ? (
@@ -2611,6 +2628,7 @@ function AgentInstanceContent() {
         )}
       </div>
       </FindHighlightProvider>
+      </FileLinkProvider>
 
       {/* Git Changes Button */}
       {/* {instance.git_diff && (() => {

--- a/apps/web/components/dashboard/file-link-context.tsx
+++ b/apps/web/components/dashboard/file-link-context.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import type { WorkspaceFileLink } from '@/lib/message-links';
+
+interface FileLinkValue {
+  /** The session's working directory on the agent's machine, if known. */
+  cwd: string | null;
+  /** That machine's home directory, so `~/…` links can be expanded. */
+  homeDir: string | null;
+  /** Reveal a workspace file in the files panel. `null` on surfaces that have
+   *  no panel to open into (the task timeline, previews), where a file link
+   *  renders as plain text rather than as a click that goes nowhere. */
+  openFile: ((file: WorkspaceFileLink) => void) | null;
+}
+
+const FileLinkContext = createContext<FileLinkValue>({
+  cwd: null,
+  homeDir: null,
+  openFile: null,
+});
+
+/**
+ * Tells the message renderer which workspace the messages below it describe, so
+ * the file paths agents cite can be resolved and opened in-app instead of being
+ * handed to the browser as if they were web links (vicoa-ai/vicoa#46).
+ */
+export function FileLinkProvider({
+  cwd,
+  homeDir,
+  openFile,
+  children,
+}: {
+  cwd: string | null;
+  homeDir: string | null;
+  openFile: ((file: WorkspaceFileLink) => void) | null;
+  children: ReactNode;
+}) {
+  const value = useMemo(() => ({ cwd, homeDir, openFile }), [cwd, homeDir, openFile]);
+  return <FileLinkContext.Provider value={value}>{children}</FileLinkContext.Provider>;
+}
+
+export function useFileLinks(): FileLinkValue {
+  return useContext(FileLinkContext);
+}

--- a/apps/web/components/files-git-panel/cm-scroll.ts
+++ b/apps/web/components/files-git-panel/cm-scroll.ts
@@ -50,3 +50,16 @@ export function scrollToAnchor(view: EditorView, anchor: ScrollAnchor): void {
     effects: EditorView.scrollIntoView(pos, { y: 'start', yMargin: -Math.max(0, anchor.offset) }),
   });
 }
+
+/** Put `line` (1-based, clamped) in the middle of the viewport and drop the
+ *  cursor on it — "jump to line 42" from a file link in the chat, as opposed to
+ *  {@link scrollToAnchor}'s "put me back where I was". Centring is what makes
+ *  the jump readable: the cited line arrives with its context around it. */
+export function revealLine(view: EditorView, line: number): void {
+  const total = view.state.doc.lines;
+  const pos = view.state.doc.line(Math.max(1, Math.min(line, total))).from;
+  view.dispatch({
+    selection: { anchor: pos },
+    effects: EditorView.scrollIntoView(pos, { y: 'center' }),
+  });
+}

--- a/apps/web/components/files-git-panel/file-editor.tsx
+++ b/apps/web/components/files-git-panel/file-editor.tsx
@@ -7,7 +7,7 @@ import { indentWithTab } from '@codemirror/commands';
 import { basicSetup } from 'codemirror';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { languageExtensionForPath } from './cm-languages';
-import { SCROLL_PERSIST_MS, scrollToAnchor, topAnchor } from './cm-scroll';
+import { SCROLL_PERSIST_MS, revealLine, scrollToAnchor, topAnchor } from './cm-scroll';
 import { CM_SCROLLBAR_FIREFOX, CM_SCROLLBAR_WEBKIT, PANEL_BG } from './styles';
 import { resolvedThemeNow, useIsDarkTheme } from '@/lib/hooks/use-resolved-theme';
 
@@ -31,6 +31,14 @@ export interface FileEditorProps {
    * where the tab was last left. Read once when the editor is created. */
   initialScrollLine?: number;
   initialScrollOffset?: number;
+  /** Jump to a 1-based line and centre it — a file link clicked in the chat.
+   * Unlike `initialScroll*` this is honoured for the whole life of the editor,
+   * so a second link into an already-open file still moves; the `nonce` is what
+   * re-fires it for a repeat click on the same line. */
+  revealLineRequest?: { line: number; nonce: number };
+  /** Fired once `revealLineRequest` has been applied, so the owner can drop it
+   * and stop it re-firing when this editor is later rebuilt for the same file. */
+  onRevealed?: () => void;
   /** Reports the top scroll anchor (debounced while scrolling, and flushed when
    * the editor is torn down) so the parent can remember it. `path` is the file
    * this editor was created for, so a scroll-then-switch attributes correctly. */
@@ -69,6 +77,8 @@ export function FileEditor({
   onSave,
   initialScrollLine,
   initialScrollOffset,
+  revealLineRequest,
+  onRevealed,
   onScrollAnchor,
 }: FileEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,10 +88,12 @@ export function FileEditor({
   const onChangeRef = useRef(onChange);
   const onSaveRef = useRef(onSave);
   const onScrollAnchorRef = useRef(onScrollAnchor);
+  const onRevealedRef = useRef(onRevealed);
   const initialAnchorRef = useRef({ line: initialScrollLine, offset: initialScrollOffset });
   onChangeRef.current = onChange;
   onSaveRef.current = onSave;
   onScrollAnchorRef.current = onScrollAnchor;
+  onRevealedRef.current = onRevealed;
   initialAnchorRef.current = { line: initialScrollLine, offset: initialScrollOffset };
 
   // The editor is built once per file and re-themed in place (effect at the
@@ -179,6 +191,18 @@ export function FileEditor({
       annotations: External.of(true),
     });
   }, [value]);
+
+  // Jump to a line asked for from outside (a file link in the chat). Keyed on
+  // the nonce so the same line can be requested again; it also fires on mount,
+  // which is what covers a link into a file that wasn't open yet.
+  const revealNonce = revealLineRequest?.nonce;
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || !revealLineRequest) return;
+    revealLine(view, revealLineRequest.line);
+    onRevealedRef.current?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealNonce, path]);
 
   useEffect(() => {
     viewRef.current?.dispatch({

--- a/apps/web/components/files-git-panel/file-viewer.tsx
+++ b/apps/web/components/files-git-panel/file-viewer.tsx
@@ -68,6 +68,8 @@ export function FileViewer({
   wrap,
   markdownSource = false,
   diffSideBySide = false,
+  revealLine,
+  onRevealed,
   onDraftChange,
   onSave,
   onScrollAnchor,
@@ -85,6 +87,14 @@ export function FileViewer({
    * remember it per tab. Wired for the editor, diff and read-only source
    * surfaces; rendered previews (no line mapping) don't participate. */
   onScrollAnchor?: (path: string, line: number, offset: number) => void;
+  /** Jump to a 1-based line and keep it centred — a file link clicked in the
+   * chat. The `nonce` re-fires it for the same line, and re-applying it on a
+   * tab that is already open is the whole point (the `initialScroll*` anchors
+   * are read once, at mount). Honoured by the two source surfaces; a rendered
+   * markdown preview has no lines to jump to. */
+  revealLine?: { line: number; nonce: number };
+  /** Fired once the jump has happened, so the panel can drop the request. */
+  onRevealed?: () => void;
   /** Publishes the diff surface's change-navigation handle to the panel (only
    * meaningful in diff mode; `null` on any other surface / teardown). */
   onDiffNav?: (nav: DiffNav | null) => void;
@@ -234,6 +244,8 @@ export function FileViewer({
         wrap={wrap}
         initialScrollLine={state.scrollLine}
         initialScrollOffset={state.scrollOffset}
+        revealLineRequest={revealLine}
+        onRevealed={onRevealed}
         onScrollAnchor={onScrollAnchor}
         onChange={onDraftChange ?? (() => {})}
         onSave={onSave ?? (() => {})}
@@ -248,6 +260,8 @@ export function FileViewer({
       wrap={wrap}
       initialScrollLine={state.scrollLine}
       initialScrollOffset={state.scrollOffset}
+      revealLine={revealLine}
+      onRevealed={onRevealed}
       onScrollAnchor={onScrollAnchor}
     />
   );
@@ -259,6 +273,8 @@ function TextFileBody({
   wrap,
   initialScrollLine,
   initialScrollOffset,
+  revealLine,
+  onRevealed,
   onScrollAnchor,
 }: {
   result: NonNullable<FileViewState['result']>;
@@ -266,6 +282,8 @@ function TextFileBody({
   wrap: boolean;
   initialScrollLine?: number;
   initialScrollOffset?: number;
+  revealLine?: { line: number; nonce: number };
+  onRevealed?: () => void;
   onScrollAnchor?: (path: string, line: number, offset: number) => void;
 }) {
   const lines = result.content.split('\n');
@@ -334,6 +352,24 @@ function TextFileBody({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path]);
+
+  // Jump to a requested line (a file link clicked in the chat), centred so the
+  // surrounding code is visible. Keyed on the nonce so clicking the same link
+  // twice re-centres, and so it fires on mount for a freshly-opened tab too.
+  const revealNonce = revealLine?.nonce;
+  const onRevealedRef = useRef(onRevealed);
+  onRevealedRef.current = onRevealed;
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !revealLine) return;
+    const row = el.querySelector<HTMLElement>(`[data-line="${revealLine.line}"]`);
+    if (!row) return;
+    const top =
+      row.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop;
+    el.scrollTop = Math.max(0, top - el.clientHeight / 3);
+    onRevealedRef.current?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealNonce, path]);
 
   return (
     <div ref={scrollRef} className={`h-full overflow-auto font-mono text-xs ${SCROLL_STYLE}`}>

--- a/apps/web/components/files-git-panel/files-git-panel.tsx
+++ b/apps/web/components/files-git-panel/files-git-panel.tsx
@@ -109,11 +109,12 @@ interface FilesGitPanelProps {
    * handler wasn't listening) still open a fresh terminal tab: the page sets the
    * ref and opens the panel, and the freshly-mounted panel runs the action. */
   pendingAction?: { current: PanelPendingAction | null };
-  /** Open a specific project file, e.g. from the ⌘P file finder. The `nonce`
-   * bumps per request so repeat-opening the same path still fires; reactive
-   * (unlike `pendingAction`) so it works whether the panel was already open or
-   * is being opened by this same request. */
-  openFileRequest?: { path: string; nonce: number } | null;
+  /** Open a specific project file, e.g. from the ⌘P file finder or a file link
+   * in an agent message. The `nonce` bumps per request so repeat-opening the
+   * same path still fires; reactive (unlike `pendingAction`) so it works whether
+   * the panel was already open or is being opened by this same request. `line`
+   * scrolls a freshly-opened tab to that 1-based line. */
+  openFileRequest?: { path: string; nonce: number; line?: number } | null;
 }
 
 function basename(path: string): string {
@@ -1084,15 +1085,26 @@ export function FilesGitPanel({ machineId, cwd, homeDir, instanceId, panel, over
   // request that opened the panel is still the current prop. Mirrors
   // `openFromTree` (clear the visible terminal, then open in edit mode).
   const lastOpenFileNonce = useRef(0);
+  // The line to jump to once that file's surface is up, for a request that
+  // carried one (a file link in the chat). Held here rather than on the tab
+  // because it is a one-shot navigation, not remembered scroll position — the
+  // surface clears it via `onRevealed`, so re-showing the tab later restores
+  // where the user actually left off, not the line they arrived at.
+  const [revealLine, setRevealLine] = useState<
+    { path: string; line: number; nonce: number } | null
+  >(null);
   useEffect(() => {
     if (!openFileRequest || openFileRequest.nonce === lastOpenFileNonce.current) return;
     lastOpenFileNonce.current = openFileRequest.nonce;
     if (!splitActive) setActiveTerminal(instanceId, null);
-    files.openFile(openFileRequest.path, { preview: false });
+    const { path, line, nonce } = openFileRequest;
+    setRevealLine(line ? { path, line, nonce } : null);
+    files.openFile(path, { preview: false, scrollLine: line });
     // `files`/`setActiveTerminal` are stable enough; the nonce guard makes a
     // spurious re-run a no-op, so key the effect on the request identity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openFileRequest, instanceId, splitActive]);
+  const clearRevealLine = useCallback(() => setRevealLine(null), []);
   // Commit the staged set; the history pane below shows the new commit, so
   // refresh it on success (the hook already refreshes the working-tree status).
   const handleCommit = () => {
@@ -1575,6 +1587,12 @@ export function FilesGitPanel({ machineId, cwd, homeDir, instanceId, panel, over
                 wrap={true}
                 markdownSource={markdownSource}
                 diffSideBySide={diffSideBySide}
+                revealLine={
+                  revealLine && revealLine.path === activeFile.path
+                    ? { line: revealLine.line, nonce: revealLine.nonce }
+                    : undefined
+                }
+                onRevealed={clearRevealLine}
                 onDraftChange={(content) => files.updateDraft(activeFile.path, content)}
                 onSave={() => files.saveFile(activeFile.path)}
                 onScrollAnchor={files.setScrollAnchor}

--- a/apps/web/components/files-git-panel/markdown-preview.tsx
+++ b/apps/web/components/files-git-panel/markdown-preview.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/atom-one-dark.css';
+import { messageUrlTransform, parseMessageLink } from '@/lib/message-links';
 
 // The app repoints `font-mono` to a sans face, so pin the real monospace family
 // for code (same reason the chat renderer does).
@@ -18,6 +19,7 @@ export function MarkdownPreview({ content }: { content: string }) {
   return (
     <div className="px-4 py-3 text-sm leading-relaxed text-foreground/90">
       <ReactMarkdown
+        urlTransform={messageUrlTransform}
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[[rehypeHighlight, { detect: true, ignoreMissing: true }]]}
         components={{
@@ -26,9 +28,19 @@ export function MarkdownPreview({ content }: { content: string }) {
           h3: ({ children }) => <h3 className="mt-3 mb-1.5 text-base font-semibold text-foreground first:mt-0">{children}</h3>,
           h4: ({ children }) => <h4 className="mt-3 mb-1 text-sm font-semibold text-foreground first:mt-0">{children}</h4>,
           p: ({ children }) => <p className="my-2">{children}</p>,
-          a: ({ href, children }) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline underline-offset-2 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{children}</a>
-          ),
+          a: ({ href, children }) => {
+            // Only a real web URL may leave the app. A README's relative links
+            // and `#anchor`s point inside the repo, and sending those to the
+            // browser lands the user in a sign-in flow (vicoa-ai/vicoa#46);
+            // this preview has no file context to resolve them against, so they
+            // render as plain text instead.
+            if (parseMessageLink(href, { cwd: null, homeDir: null }).kind !== 'external') {
+              return <span className="text-muted-foreground underline decoration-dotted underline-offset-2">{children}</span>;
+            }
+            return (
+              <a href={href} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline underline-offset-2 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">{children}</a>
+            );
+          },
           ul: ({ children }) => <ul className="my-2 list-disc pl-5 space-y-1">{children}</ul>,
           ol: ({ children }) => <ol className="my-2 list-decimal pl-5 space-y-1">{children}</ol>,
           li: ({ children }) => <li className="leading-relaxed">{children}</li>,

--- a/apps/web/components/files-git-panel/use-files-tab.ts
+++ b/apps/web/components/files-git-panel/use-files-tab.ts
@@ -61,7 +61,17 @@ interface UseFilesTabApi {
    * it, so a new tab defaults to `'edit'` and an already-open tab keeps its mode.
    * `opts.preview` (single click) reuses the one preview slot; omitting it (double
    * click) opens/commits a permanent tab. */
-  openFile: (path: string, opts?: { mode?: 'edit' | 'diff'; preview?: boolean }) => void;
+  openFile: (
+    path: string,
+    opts?: {
+      mode?: 'edit' | 'diff';
+      preview?: boolean;
+      /** Where a *freshly-opened* tab should start (session restore, or a file
+       *  link that named a line). An already-open tab keeps its position. */
+      scrollLine?: number;
+      scrollOffset?: number;
+    },
+  ) => void;
   activateFile: (path: string | null) => void;
   /** Remember the top scroll anchor of a tab (line + sub-line px offset), so
    * re-showing it (or reopening the session) restores the scroll position. */

--- a/apps/web/components/ui/message-markdown.tsx
+++ b/apps/web/components/ui/message-markdown.tsx
@@ -5,6 +5,8 @@ import remarkGfm from 'remark-gfm';
 import 'highlight.js/styles/atom-one-dark.css';
 import { diffLineBackgroundClass, formatDiffLines, formatTaskNotifications, normalizeCommandOutput } from '@/components/ui/message-markdown-utils';
 import { makeFindHighlightPlugin } from '@/lib/find-highlight';
+import { messageUrlTransform, parseMessageLink } from '@/lib/message-links';
+import { useFileLinks } from '@/components/dashboard/file-link-context';
 
 interface MessageMarkdownProps {
   children: string;
@@ -21,7 +23,13 @@ interface MessageMarkdownProps {
 const CHAT_CODE_FONT_FAMILY =
   'var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace';
 
+/** Shared by the two clickable link presentations (web URL, workspace file). */
+const LINK_CLASS = 'text-blue-600 hover:text-blue-800 underline text-sm';
+
 function MessageMarkdownImpl({ children, agentType, highlightQuery }: MessageMarkdownProps) {
+  // Which workspace (if any) the file paths in this message refer to. Empty
+  // outside a session, which makes every local path render as plain text.
+  const fileLinks = useFileLinks();
   // Plain alphabetic sentinel: hljs's markdown highlighter parses `__x__` as
   // bold and `_x_` as italic, which fragments the placeholder across multiple
   // text nodes and breaks restoreNode's string-replacement walk. Underscores
@@ -214,6 +222,7 @@ function MessageMarkdownImpl({ children, agentType, highlightQuery }: MessageMar
   return (
     <div className="font-mono">
       <ReactMarkdown
+        urlTransform={messageUrlTransform}
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[
           [rehypeHighlight, { detect: true, ignoreMissing: true }],
@@ -379,7 +388,40 @@ function MessageMarkdownImpl({ children, agentType, highlightQuery }: MessageMar
             {children}
           </td>
         ),
-        a: ({ children, href }) => <a href={href} className="text-blue-600 hover:text-blue-800 underline text-sm" target="_blank" rel="noopener noreferrer">{children}</a>,
+        a: ({ children, href }) => {
+          // Agents cite files as markdown links; only a real web URL may leave
+          // the app. See lib/message-links.ts and vicoa-ai/vicoa#46.
+          const link = parseMessageLink(href, fileLinks);
+          if (link.kind === 'external') {
+            return <a href={link.href} className={LINK_CLASS} target="_blank" rel="noopener noreferrer">{children}</a>;
+          }
+          if (link.kind === 'file' && fileLinks.openFile) {
+            const openFile = fileLinks.openFile;
+            const file = link.file;
+            return (
+              <button
+                type="button"
+                onClick={() => openFile(file)}
+                title={file.line ? `Open ${file.path}:${file.line}` : `Open ${file.path}`}
+                className={`${LINK_CLASS} inline p-0 text-left align-baseline bg-transparent cursor-pointer`}
+              >
+                {children}
+              </button>
+            );
+          }
+          return (
+            <span
+              className="text-sm text-muted-foreground underline decoration-dotted underline-offset-2"
+              title={
+                link.kind === 'outside'
+                  ? `${link.path} is outside this session's workspace`
+                  : undefined
+              }
+            >
+              {children}
+            </span>
+          );
+        },
         hr: () => <hr className="my-3 border-0 border-t border-border" />,
         blockquote: ({ children }) => <blockquote className="border-l-4 border-border pl-3 italic text-muted-foreground text-sm leading-relaxed mb-2">{children}</blockquote>,
         input: ({ type, checked, disabled }) => {

--- a/apps/web/lib/message-links.test.ts
+++ b/apps/web/lib/message-links.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect } from 'vitest';
+import {
+  messageUrlTransform,
+  parseMessageLink,
+  type MessageLink,
+  type WorkspaceContext,
+} from './message-links';
+
+const POSIX: WorkspaceContext = { cwd: '/Users/nick/proj', homeDir: '/Users/nick' };
+const WINDOWS: WorkspaceContext = { cwd: 'C:\\Users\\Nick\\proj', homeDir: 'C:\\Users\\Nick' };
+
+/** The file a link resolves to, or the non-file verdict, for terse assertions. */
+function resolve(href: string, ctx: WorkspaceContext = POSIX): MessageLink {
+  return parseMessageLink(messageUrlTransform(href), ctx);
+}
+
+describe('messageUrlTransform', () => {
+  test('keeps web URLs, file: URLs and paths', () => {
+    for (const url of [
+      'https://vicoa.ai/docs',
+      'http://localhost:3000',
+      'mailto:hi@vicoa.ai',
+      'file:///Users/nick/proj/src/a.ts',
+      'src/a.ts',
+      './a.ts',
+      '../sibling/a.ts',
+      'a.ts:42',
+      'C:/Users/Nick/proj/a.ts',
+      '#section',
+    ]) {
+      expect(messageUrlTransform(url)).toBe(url);
+    }
+  });
+
+  test('strips dangerous schemes', () => {
+    expect(messageUrlTransform('javascript:alert(1)')).toBe('');
+    expect(messageUrlTransform('data:text/html,<script>')).toBe('');
+    expect(messageUrlTransform('vbscript:msgbox')).toBe('');
+  });
+});
+
+describe('parseMessageLink — web URLs', () => {
+  test('http(s) and mailto stay external', () => {
+    expect(resolve('https://vicoa.ai/docs')).toEqual({
+      kind: 'external',
+      href: 'https://vicoa.ai/docs',
+    });
+    expect(resolve('mailto:hi@vicoa.ai')).toEqual({ kind: 'external', href: 'mailto:hi@vicoa.ai' });
+  });
+
+  test('a stripped javascript: href is inert, not a link to the current page', () => {
+    expect(resolve('javascript:alert(1)')).toEqual({ kind: 'inert' });
+  });
+
+  test('in-document fragments and protocol-relative URLs are inert', () => {
+    expect(resolve('#installation')).toEqual({ kind: 'inert' });
+    expect(resolve('//evil.example/x')).toEqual({ kind: 'inert' });
+  });
+});
+
+describe('parseMessageLink — workspace files', () => {
+  test('relative paths resolve against the working directory', () => {
+    expect(resolve('src/foo.ts')).toEqual({ kind: 'file', file: { path: 'src/foo.ts' } });
+    expect(resolve('./src/foo.ts')).toEqual({ kind: 'file', file: { path: 'src/foo.ts' } });
+    expect(resolve('src/./nested/../foo.ts')).toEqual({ kind: 'file', file: { path: 'src/foo.ts' } });
+    expect(resolve('README.md')).toEqual({ kind: 'file', file: { path: 'README.md' } });
+  });
+
+  test('absolute paths inside the working directory are relativised', () => {
+    expect(resolve('/Users/nick/proj/src/foo.ts')).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts' },
+    });
+  });
+
+  test('file: URLs are decoded', () => {
+    expect(resolve('file:///Users/nick/proj/src/foo.ts')).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts' },
+    });
+    expect(resolve('file:///Users/nick/proj/src/my%20file.ts')).toEqual({
+      kind: 'file',
+      file: { path: 'src/my file.ts' },
+    });
+  });
+
+  test('~ expands to the machine home directory', () => {
+    expect(resolve('~/proj/src/foo.ts')).toEqual({ kind: 'file', file: { path: 'src/foo.ts' } });
+  });
+
+  test('a tilde-stored project still matches an absolute link into it', () => {
+    // How sessions actually store `project` — see vicoa-ai/vicoa#46.
+    const tilde: WorkspaceContext = { cwd: '~/projects/vicoa-ai/vicoa', homeDir: '/Users/nick' };
+    expect(resolve('/Users/nick/projects/vicoa-ai/vicoa/text.txt', tilde)).toEqual({
+      kind: 'file',
+      file: { path: 'text.txt' },
+    });
+    expect(resolve('/Users/nick/projects/vicoa-ai/vicoa/text.txt:1', tilde)).toEqual({
+      kind: 'file',
+      file: { path: 'text.txt', line: 1 },
+    });
+    expect(resolve('~/projects/vicoa-ai/vicoa/apps/web/lib/x.ts', tilde)).toEqual({
+      kind: 'file',
+      file: { path: 'apps/web/lib/x.ts' },
+    });
+    expect(resolve('/Users/nick/projects/other/x.ts', tilde)).toEqual({
+      kind: 'outside',
+      path: '/Users/nick/projects/other/x.ts',
+    });
+  });
+
+  test('tilde on both sides still matches with no home directory known', () => {
+    const noHome: WorkspaceContext = { cwd: '~/projects/app', homeDir: null };
+    expect(resolve('~/projects/app/src/foo.ts', noHome)).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts' },
+    });
+  });
+
+  test('Windows paths and drive letters survive, case-insensitively', () => {
+    expect(resolve('C:\\Users\\Nick\\proj\\src\\foo.ts', WINDOWS)).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts' },
+    });
+    expect(resolve('file:///c:/users/nick/proj/src/foo.ts', WINDOWS)).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts' },
+    });
+    expect(resolve('src\\foo.ts', WINDOWS)).toEqual({ kind: 'file', file: { path: 'src/foo.ts' } });
+  });
+});
+
+describe('parseMessageLink — line references', () => {
+  test('the shapes agents emit all yield the line', () => {
+    for (const href of [
+      'src/foo.ts#L42',
+      'src/foo.ts#42',
+      'src/foo.ts#L42-L57',
+      'src/foo.ts:42',
+      'src/foo.ts:42:7',
+      'file:///Users/nick/proj/src/foo.ts#L42',
+    ]) {
+      expect(resolve(href)).toEqual({ kind: 'file', file: { path: 'src/foo.ts', line: 42 } });
+    }
+  });
+
+  test('a bare filename with a line ref is a path, not a URL scheme', () => {
+    expect(resolve('foo.ts:42')).toEqual({ kind: 'file', file: { path: 'foo.ts', line: 42 } });
+  });
+
+  test('a named fragment is dropped rather than read as a line', () => {
+    expect(resolve('docs/guide.md#getting-started')).toEqual({
+      kind: 'file',
+      file: { path: 'docs/guide.md' },
+    });
+  });
+
+  test('a Windows drive colon is not a line separator', () => {
+    expect(resolve('C:\\Users\\Nick\\proj\\src\\foo.ts:42', WINDOWS)).toEqual({
+      kind: 'file',
+      file: { path: 'src/foo.ts', line: 42 },
+    });
+  });
+});
+
+describe('parseMessageLink — refusals', () => {
+  test('paths outside the working directory are reported, never followed', () => {
+    expect(resolve('/etc/passwd')).toEqual({ kind: 'outside', path: '/etc/passwd' });
+    expect(resolve('../other-project/secrets.env')).toEqual({
+      kind: 'outside',
+      path: '../other-project/secrets.env',
+    });
+    expect(resolve('~/.ssh/id_rsa')).toEqual({ kind: 'outside', path: '~/.ssh/id_rsa' });
+    expect(resolve('file://host/share/x.txt')).toEqual({ kind: 'inert' });
+  });
+
+  test('the working directory itself is not a file', () => {
+    expect(resolve('/Users/nick/proj')).toEqual({ kind: 'inert' });
+    expect(resolve('./')).toEqual({ kind: 'inert' });
+  });
+
+  test('bare words are prose, not paths', () => {
+    expect(resolve('somewhere')).toEqual({ kind: 'inert' });
+  });
+
+  test('without a working directory nothing is openable', () => {
+    expect(resolve('src/foo.ts', { cwd: null, homeDir: null })).toEqual({ kind: 'inert' });
+  });
+});

--- a/apps/web/lib/message-links.ts
+++ b/apps/web/lib/message-links.ts
@@ -1,0 +1,248 @@
+/**
+ * What a link inside an agent message actually points at.
+ *
+ * Agents (Codex especially) cite the files they touched as ordinary markdown
+ * links — `[src/foo.ts](src/foo.ts)`, `[foo.ts:42](file:///repo/src/foo.ts#L42)`
+ * — and those are NOT web links. Rendering them as `<a target="_blank">` sends
+ * the click to the browser: relative hrefs resolve against the dashboard's own
+ * origin, and `file:` hrefs are stripped to `href=""` by react-markdown's URL
+ * sanitiser, which means "reopen the current page". On desktop the Electron
+ * window handler then hands that URL to the OS browser, which has none of the
+ * app's session state, so the user lands in a sign-in flow that cannot finish
+ * ("Desktop bridge unavailable"). See vicoa-ai/vicoa#46.
+ *
+ * So every href is classified here first, and only genuine web URLs are allowed
+ * to leave the app.
+ */
+
+import { toAbsolutePath } from '@/lib/utils';
+
+/** A file inside the session's workspace, as the files panel wants it. */
+export interface WorkspaceFileLink {
+  /** Project-relative POSIX path, e.g. `src/foo.ts`. Never empty. */
+  path: string;
+  /** 1-based line the link pointed at, when it carried one. */
+  line?: number;
+}
+
+export type MessageLink =
+  /** A real web URL — safe to open in the browser. */
+  | { kind: 'external'; href: string }
+  /** A file under the session's working directory. */
+  | { kind: 'file'; file: WorkspaceFileLink }
+  /** A local path, but not under the working directory — refuse to follow it. */
+  | { kind: 'outside'; path: string }
+  /** Fragments, empty hrefs, unknown schemes: render as plain text. */
+  | { kind: 'inert' };
+
+export interface WorkspaceContext {
+  /** The session's working directory on the agent's machine. Often stored
+   *  tilde-prefixed (`~/projects/app`), so it is expanded here too — not just
+   *  the link — or an absolute link into that very directory reads as being
+   *  outside it. */
+  cwd: string | null;
+  /** That machine's home directory, so `~/…` can be expanded. */
+  homeDir: string | null;
+}
+
+/** Schemes that may be handed to the OS browser. */
+const WEB_SCHEME = /^(?:https?|mailto):/i;
+/** `scheme:` at the head of a URL, per RFC 3986. */
+const SCHEME = /^([a-z][a-z0-9+.\-]*):/i;
+/** `C:\…` / `c:/…` — a Windows drive, not a URL scheme. */
+const WINDOWS_DRIVE = /^[a-z]:[\\/]/i;
+/** `foo.ts:42`, `foo.ts:42:7` — a bare filename carrying a line reference. The
+ *  leading run parses as a URL scheme but is a path; only digits may follow. */
+const FILENAME_WITH_LINE = /^[a-z][a-z0-9+.\-]*:\d+(?::\d+)?$/i;
+
+/**
+ * react-markdown's `urlTransform`, widened by `file:` and `name:line`.
+ *
+ * The default drops any scheme outside its allowlist, which turns a
+ * `file:///…` href into `''` — indistinguishable from "no href" by the time the
+ * `a` renderer sees it, and `<a href="" target="_blank">` reopens the current
+ * page. Keeping those intact lets {@link parseMessageLink} recognise them and
+ * keep the click inside the app. Everything else (notably `javascript:`) is
+ * still stripped, with the same colon-before-slash/query/hash reasoning as
+ * upstream so relative paths survive.
+ */
+export function messageUrlTransform(url: string): string {
+  const colon = url.indexOf(':');
+  if (colon === -1) return url;
+  const slash = url.indexOf('/');
+  const question = url.indexOf('?');
+  const hash = url.indexOf('#');
+  // A colon that comes after a `/`, `?` or `#` belongs to the path, not a scheme.
+  if (
+    (slash !== -1 && colon > slash) ||
+    (question !== -1 && colon > question) ||
+    (hash !== -1 && colon > hash)
+  ) {
+    return url;
+  }
+  if (WINDOWS_DRIVE.test(url) || FILENAME_WITH_LINE.test(url)) return url;
+  const scheme = url.slice(0, colon + 1);
+  return WEB_SCHEME.test(scheme) || /^file:$/i.test(scheme) ? url : '';
+}
+
+/** Collapse `.`/`..` segments and duplicate slashes. `..` may escape the root,
+ *  which the caller detects as a leading `..` segment. */
+function normalizeSegments(path: string): string {
+  const out: string[] = [];
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop();
+      else out.push('..');
+      continue;
+    }
+    out.push(segment);
+  }
+  return out.join('/');
+}
+
+/** Backslashes → slashes, trailing separator dropped (except a bare root). */
+function toPosix(path: string): string {
+  const slashed = path.replace(/\\/g, '/');
+  return slashed.length > 1 ? slashed.replace(/\/+$/, '') : slashed;
+}
+
+/** Anchored at a root of its own, rather than at the working directory: `/x`,
+ *  `C:\x`, or a `~` that had no home directory to expand against. */
+function isRooted(path: string): boolean {
+  return path.startsWith('/') || WINDOWS_DRIVE.test(path) || path === '~' || path.startsWith('~/');
+}
+
+/** Collapse `.`/`..` in a rooted path, keeping whichever root it carries. */
+function normalizeRooted(path: string): string {
+  if (WINDOWS_DRIVE.test(path)) {
+    return `${path.slice(0, 2)}/${normalizeSegments(path.slice(2))}`;
+  }
+  if (isRooted(path) && path.startsWith('~')) {
+    const rest = normalizeSegments(path.slice(1));
+    return rest ? `~/${rest}` : '~';
+  }
+  return `/${normalizeSegments(path)}`;
+}
+
+/**
+ * `child` expressed relative to `parent`, or null when it isn't under it.
+ * `parent` itself yields `''` — a directory, which callers treat as no file.
+ * Windows paths (a drive-lettered root) compare case-insensitively.
+ */
+function relativeTo(parent: string, child: string): string | null {
+  const fold = (s: string) => (WINDOWS_DRIVE.test(parent) ? s.toLowerCase() : s);
+  const p = fold(parent).replace(/\/+$/, '');
+  const c = fold(child);
+  if (c === p) return '';
+  if (!c.startsWith(`${p}/`)) return null;
+  return child.slice(p.length + 1);
+}
+
+/**
+ * Strip a trailing line reference and return it.
+ *
+ * Understood: `#L42`, `#L42-L57`, `#42`, `:42`, `:42:7` — the shapes agents and
+ * editors actually emit. A `#section` fragment is not a line and is dropped
+ * along with the rest (an anchor into a source file has nowhere to go).
+ */
+function splitLineRef(raw: string): { path: string; line?: number } {
+  let path = raw;
+  let line: number | undefined;
+
+  const hash = path.indexOf('#');
+  if (hash !== -1) {
+    const fragment = path.slice(hash + 1);
+    path = path.slice(0, hash);
+    const m = /^L?(\d+)(?:[-,]L?\d+)?$/i.exec(fragment);
+    if (m) line = Number(m[1]);
+  }
+  if (line === undefined) {
+    const m = /^(.*?[^:]):(\d+)(?::\d+)?$/.exec(path);
+    // Never mistake a drive letter (`C:`) for a line separator.
+    if (m && !/(?:^|[\\/])[a-z]$/i.test(m[1])) {
+      path = m[1];
+      line = Number(m[2]);
+    }
+  }
+  return { path, line: line !== undefined && line > 0 ? line : undefined };
+}
+
+/** A bare `foo` is more likely prose than a path; require a separator or a
+ *  file extension before treating a relative href as a local file. */
+function looksLikePath(path: string): boolean {
+  return path.includes('/') || /\.[A-Za-z0-9]{1,12}$/.test(path);
+}
+
+/** Decode a `file:` URL (including `file:///C:/…`) to a plain path. */
+function pathFromFileUrl(href: string): string | null {
+  // Tolerate `file:/x`, `file://x` and `file:///x` alike; a non-empty authority
+  // (a UNC host) is not something the daemon can open, so refuse it.
+  const m = /^file:(?:\/\/([^/]*))?(\/.*)?$/i.exec(href);
+  if (!m || m[1]) return null;
+  const raw = m[2];
+  if (!raw) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    decoded = raw;
+  }
+  // `/C:/Users/…` → `C:/Users/…`
+  return /^\/[a-z]:[\\/]/i.test(decoded) ? decoded.slice(1) : decoded;
+}
+
+/**
+ * Classify one markdown link from an agent message.
+ *
+ * `href` is what react-markdown handed the `a` renderer, i.e. already through
+ * {@link messageUrlTransform}.
+ */
+export function parseMessageLink(
+  href: string | undefined,
+  { cwd, homeDir }: WorkspaceContext,
+): MessageLink {
+  const raw = (href ?? '').trim();
+  // Empty (a stripped `javascript:`) or a pure in-document fragment: there is
+  // nothing to navigate to, and following it would reopen the current page.
+  if (raw === '' || raw.startsWith('#')) return { kind: 'inert' };
+  // Protocol-relative (`//host/x`) is a web URL we can't vouch for, not a path.
+  if (raw.startsWith('//')) return { kind: 'inert' };
+
+  let candidate = raw;
+  const scheme = SCHEME.exec(raw);
+  if (scheme && !WINDOWS_DRIVE.test(raw) && !FILENAME_WITH_LINE.test(raw)) {
+    if (WEB_SCHEME.test(raw)) return { kind: 'external', href: raw };
+    if (!/^file$/i.test(scheme[1])) return { kind: 'inert' };
+    const fromUrl = pathFromFileUrl(raw);
+    if (fromUrl === null) return { kind: 'inert' };
+    candidate = fromUrl;
+  }
+
+  const { path: rawPath, line } = splitLineRef(candidate);
+  if (rawPath === '') return { kind: 'inert' };
+
+  // Without a working directory there is no panel to open the file in.
+  if (!cwd) return { kind: 'inert' };
+  // Both sides go through the same `~` expansion, so a tilde-stored project and
+  // an absolute link into it still meet. With no home directory to expand
+  // against they stay tilde-prefixed — which still compares correctly as long
+  // as both sides are.
+  const path = toPosix(toAbsolutePath(rawPath, homeDir) ?? rawPath);
+  const root = toPosix(toAbsolutePath(cwd, homeDir) ?? cwd);
+  if (!isRooted(path) && !looksLikePath(path)) return { kind: 'inert' };
+
+  let relative: string | null;
+  if (isRooted(path)) {
+    relative = relativeTo(root, normalizeRooted(path));
+  } else {
+    const joined = normalizeSegments(path);
+    // `../` climbing out of the project survives normalisation as a leading
+    // `..`, which is exactly the "outside the workspace" case.
+    relative = joined.startsWith('..') ? null : joined;
+  }
+
+  if (relative === null) return { kind: 'outside', path: rawPath };
+  if (relative === '') return { kind: 'inert' }; // the project root itself
+  return { kind: 'file', file: { path: relative, ...(line ? { line } : {}) } };
+}


### PR DESCRIPTION
Fixes #46

## What was happening

Codex cites the files it touched as ordinary markdown links — `[text.txt](/Users/nick/proj/text.txt)`, `[foo.ts:42](file:///…/foo.ts#L42)`. The chat renderer (`message-markdown.tsx`) turned every `<a>` into `target="_blank"`, and two things then went wrong at once:

- react-markdown's default URL sanitiser strips `file:` to `href=""`, which the browser reads as "reopen the current page";
- relative / absolute paths resolve against the dashboard's own origin.

Either way the Electron `setWindowOpenHandler` saw `http://localhost:<port>/…`, matched `^https?:`, and handed it to the **OS browser** — which has none of the app's session state. `desktop-auth-gate` sent it to `/desktop-welcome` → `/desktop-signin`, and with no preload bridge in a plain browser that page can only say *"Desktop bridge unavailable"*. The reporter was right that they were already signed in; the browser that opened simply wasn't the app.

## What changes

**`apps/web/lib/message-links.ts`** (new, pure, 20 tests) classifies every href before it is rendered: `external` (http/https/mailto), `file` (under the session's working directory, project-relative path + optional line), `outside`, or `inert` (`#anchors`, stripped `javascript:`, bare words). It understands `file:///…` incl. `file:///C:/…`, Windows backslashes and drive-letter case, `~/`, URL-encoded names, and the line-ref shapes agents actually emit (`#L42`, `#42`, `#L42-L57`, `:42`, `:42:7`) without mistaking a drive colon for one. `messageUrlTransform` replaces react-markdown's sanitiser so `file:` and `foo.ts:42` survive while `javascript:` / `data:` are still dropped.

One thing a real session surfaced: `agent_instances.project` is stored tilde-prefixed (`~/projects/vicoa-ai/vicoa`) while the agent cites absolute paths, so **both** sides go through the existing `toAbsolutePath(…, homeDir)` before comparing — otherwise every link reads as "outside the workspace".

**Only `external` links keep `target="_blank"`.** A `file` link becomes a button that opens the file in the files panel through a small `FileLinkProvider` context (same pattern as `chat-find-context`) → the existing `openFileRequest` path. Line references jump to the line and centre it — including on a tab that is already open (`revealLine` in `cm-scroll.ts`; the request is cleared via `onRevealed` so re-showing the tab later restores the user's own scroll position). `outside` / `inert` render as plain text; a path outside the workspace gets a tooltip saying so. Outside a session (task timeline, no machine) there is no provider, so file links are text there too.

**Two same-shaped holes closed alongside:**
- `files-git-panel/markdown-preview.tsx` — a previewed README's relative links and `#anchors` went to the browser the same way.
- `apps/desktop/src/window.ts` — the shell now refuses to `shell.openExternal` its **own origin** at all. A same-origin URL reaching that handler is always a link the renderer meant to keep in-app; launching a browser at it is what turned a dead click into a sign-in prompt.

## Not in this PR

- Mobile (Flutter) — the issue mentions it as a "could"; separate codebase.
- Backtick code spans like `` `path/to/file.ts:1` `` stay plain text. Only markdown links are clickable; making code spans path-aware is a separate call (higher false-positive risk).
- Line jumps apply to the editor and read-only source surfaces; diff mode and rendered markdown preview don't participate.

## Verification

- `apps/web`: `tsc --noEmit` clean, `check-theme-colors` clean, `next build` succeeds, vitest **857/857**.
- `apps/desktop`: `tsc --noEmit` clean.
- The exact link from the reporter's scenario (`[text.txt](/Users/nick/projects/vicoa-ai/vicoa/text.txt)` against a `~/…` project) is a unit test.
