### PR TITLE
Backend dev-setup: pip-only venv, no uv requirement

### DIFF
--- a/.vicoa/config.json
+++ b/.vicoa/config.json
@@ -11,8 +11,8 @@
       "cp \"$VICOA_ROOT_PATH/apps/mobile/env.json\" \"$VICOA_WORKTREE_PATH/apps/mobile/env.json\" && echo 'copied apps/mobile/env.json'",
       "echo '--- pnpm install (apps/web) ---'",
       "cd \"$VICOA_WORKTREE_PATH/apps/web\" && pnpm install",
-      "echo '--- backend venv (python 3.11) ---'",
-      "cd \"$VICOA_WORKTREE_PATH/backend\" && { [ -d .venv ] || \"$(command -v python3.11 || command -v python3)\" -m venv .venv; } && ./.venv/bin/python -m pip install -q --upgrade pip && ./.venv/bin/python -m pip install -q -r src/backend/requirements.txt -r src/servers/requirements.txt -r requirements-dev.txt && echo 'backend venv ready'",
+      "echo '--- backend venv (scripts/dev-setup.sh) ---'",
+      "\"$VICOA_WORKTREE_PATH/backend/scripts/dev-setup.sh\"",
       "echo '--- linking backend/postgres-data -> main (shared dev DB) ---'",
       "[ -d \"$VICOA_ROOT_PATH/backend/postgres-data\" ] && ln -sfn \"$VICOA_ROOT_PATH/backend/postgres-data\" \"$VICOA_WORKTREE_PATH/backend/postgres-data\" && echo 'linked postgres-data -> main' || echo 'skip: main DB not initialized yet'",
       "echo '=== vicoa worktree setup done ==='"

--- a/backend/scripts/dev-setup.sh
+++ b/backend/scripts/dev-setup.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 # One-shot backend dev-environment setup for a fresh checkout or worktree.
 #
-# OPTIONAL and opt-in: run this only in a worktree where you actually work on
-# the backend. It is intentionally NOT part of the automatic worktree setup
-# (.vicoa/config.json) because installing the Python deps is slow and most
-# worktrees never touch the backend.
+# Needs nothing but a Python interpreter (3.10+, per pyproject; 3.12 preferred
+# to match CI and the Dockerfile) — no uv, pyenv, or other tooling. Creates a
+# stdlib .venv, installs runtime + dev deps with pip via `make dev-install`,
+# and installs the local package editable. Idempotent — safe to re-run; it
+# reuses an existing .venv, including one created by `uv venv` (which ships
+# without pip; ensurepip bootstraps one).
 #
-# Creates a .venv on the project's target Python (3.12), installs runtime +
-# dev deps, and installs the local package editable. Idempotent — safe to
-# re-run; it reuses an existing .venv.
+# The automatic worktree setup (.vicoa/config.json) calls this script, so the
+# venv logic lives in exactly one place.
 #
-# Usage:  ./scripts/dev-setup.sh    (from the backend/ directory)
+# Usage:  ./scripts/dev-setup.sh                          (from backend/)
+#         VICOA_PYTHON=/path/to/python3.12 ./scripts/dev-setup.sh
 
-set -e
+set -eu
 
-PYTHON_VERSION="3.12"
+MIN_PYTHON="3.10"   # pyproject requires-python
 
 # Resolve backend/ so the script works no matter where it is called from.
 BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -22,29 +24,74 @@ cd "$BACKEND_DIR"
 
 echo "=== backend dev-setup ($BACKEND_DIR) ==="
 
-if ! command -v uv > /dev/null 2>&1; then
-    echo "Error: 'uv' is not installed."
-    echo "Install it (https://docs.astral.sh/uv/) or create the venv manually:"
-    echo "  python3.${PYTHON_VERSION#3.} -m venv .venv && source .venv/bin/activate && make dev-install && pip install -e ."
-    exit 1
-fi
+# 1) pick an interpreter: explicit override, then versioned names (preferred
+#    first), then whatever `python3` is on PATH — which is often conda or a
+#    system Python, hence the version check below.
+find_python() {
+    if [ -n "${VICOA_PYTHON:-}" ]; then
+        echo "$VICOA_PYTHON"
+        return
+    fi
+    local candidate
+    for candidate in python3.12 python3.11 python3.10 python3; do
+        if command -v "$candidate" > /dev/null 2>&1; then
+            command -v "$candidate"
+            return
+        fi
+    done
+}
 
-# 1) venv on the project's target Python (uv auto-downloads 3.12 if missing).
+python_ok() {
+    "$1" -c "import sys; sys.exit(0 if sys.version_info >= tuple(map(int, '$MIN_PYTHON'.split('.'))) else 1)" 2> /dev/null
+}
+
+# 2) create the venv (or reuse it), and make sure it can run pip.
 if [ ! -d .venv ]; then
-    echo "--- creating .venv on Python $PYTHON_VERSION ---"
-    uv venv --python "$PYTHON_VERSION" .venv
+    PY="$(find_python)"
+    if [ -z "$PY" ]; then
+        echo "Error: no python3 found on PATH. Install Python $MIN_PYTHON+ or set VICOA_PYTHON=/path/to/python."
+        exit 1
+    fi
+    if ! python_ok "$PY"; then
+        echo "Error: $PY is $("$PY" --version 2>&1); need Python $MIN_PYTHON+ (set VICOA_PYTHON to pick another)."
+        exit 1
+    fi
+    echo "--- creating .venv with $PY ($("$PY" --version 2>&1)) ---"
+    "$PY" -m venv .venv
 else
-    echo "--- reusing existing .venv ---"
+    echo "--- reusing existing .venv ($(./.venv/bin/python --version 2>&1)) ---"
+    if ! python_ok ./.venv/bin/python; then
+        echo "Error: .venv is on $(./.venv/bin/python --version 2>&1), need $MIN_PYTHON+. Delete backend/.venv and re-run."
+        exit 1
+    fi
 fi
 
-# 2) install into the venv. Activation persists for the rest of THIS script
+# A venv made by `uv venv` has no pip, and a bare `pip` would then fall
+# through to whatever global pip is on PATH and install into the wrong place.
+# Stdlib ensurepip bootstraps one into the venv.
+if ! ./.venv/bin/python -m pip --version > /dev/null 2>&1; then
+    echo "--- .venv has no pip; bootstrapping with ensurepip ---"
+    ./.venv/bin/python -m ensurepip --upgrade
+fi
+./.venv/bin/python -m pip install -q --upgrade pip
+
+# 3) install into the venv. Activation persists for the rest of THIS script
 #    (PATH points pip/python at .venv), but not into your interactive shell.
-#    Guard the sourcing against 'set -e'/unset-var quirks in older activate
-#    scripts.
+#    Guard the sourcing against unset-var quirks in older activate scripts.
 set +u
 # shellcheck disable=SC1091
 source .venv/bin/activate
 set -u
+
+# `make dev-install` runs a bare `pip`; refuse to continue unless that is the
+# venv's pip.
+case "$(command -v pip)" in
+    "$BACKEND_DIR"/.venv/*) ;;
+    *)
+        echo "Error: 'pip' resolves to $(command -v pip), not $BACKEND_DIR/.venv/bin/pip."
+        exit 1
+        ;;
+esac
 
 echo "--- make dev-install ---"
 make dev-install


### PR DESCRIPTION
## What

`backend/scripts/dev-setup.sh` no longer requires `uv`. It needs only a Python 3.10+ interpreter and uses a stdlib venv + `make dev-install` (pip) — the same path CI, the Dockerfile and the Makefile already use.

`.vicoa/config.json`'s worktree setup now calls the script instead of carrying its own copy of the venv logic.

## Why

The old script used `uv venv` and then `make dev-install` (bare `pip`) inside it. A uv venv ships without pip, so that `pip` fell through to the global one on PATH and installed into the wrong environment. That was the failure mode of the worktree setup step today.

## Script behaviour

- Interpreter search `python3.12 → 3.11 → 3.10 → python3`, overridable with `VICOA_PYTHON=/path`; version is verified ≥ 3.10 (`pyproject` `requires-python`) — `python3` alone is often conda or a system Python.
- Reuses an existing `.venv`; if it has no pip (uv-created), bootstraps one with stdlib `ensurepip`.
- After activation, refuses to continue unless `pip` resolves inside `.venv`.
- Then `make dev-install` + `pip install -e .` as before. Makefile unchanged.

## Tested

- Against a uv-created, pip-less `.venv`: ensurepip path taken, pip lands in `.venv`, editable `vicoa` points at the worktree.
- Re-run: idempotent, no ensurepip.
- Wrong-version interpreter via `VICOA_PYTHON`: rejected with a clear error.
- `rm -rf .venv` + fresh run: creates venv on python3.11, `make test-unit` from it → 2346 passed, 1 skipped.
- `.vicoa/config.json` step `eval`'d exactly as the worktree harness runs it: passes.
- `bash -n` + `shellcheck` clean.
