### PR TITLE
Desktop updater: auto-download, one-click Install & Restart

### DIFF
--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -1,11 +1,17 @@
 /**
  * Auto-update — electron-updater against GitHub Releases at vicoa-ai/vicoa.
  *
- * Manual download, install-on-restart (the renderer drives the flow):
+ * Auto-download, install-on-restart (one click for the user):
  *   check()          -> 'checking' -> 'available' | 'not-available'
- *   download()       -> 'downloading'(percent) -> 'downloaded'
+ *   (auto)           -> 'downloading'(percent) -> 'downloaded'
  *   quitAndInstall() -> onBeforeInstall() cleanup, then Squirrel.Mac swaps the
  *                       bundle and relaunches.
+ *
+ * electron-updater starts the download itself the moment a check finds a newer
+ * version (autoDownload), so 'available' is transient and the sidebar callout
+ * only appears once the update is ready — the user's single action is
+ * "Install & Restart". autoInstallOnAppQuit means a normal quit after the
+ * download also applies it.
  *
  * Detection is what makes the sidebar callout appear, so checks are triggered
  * from several angles, all rate-limited through maybeCheck(): startup, a 30min
@@ -127,9 +133,9 @@ async function runCheck(): Promise<UpdateStatus> {
 
 /**
  * A fresh check would walk back over work already in flight: it pushes
- * 'checking' (which hides the callout) and then 'available', so an update the
- * user has already downloaded loses its "Restart" state and drops back to
- * "Install & Restart". Ambient checks skip these states entirely.
+ * 'checking' (which hides the callout) and then 'available', so an update that
+ * has already been downloaded loses its ready state and re-downloads before
+ * the callout comes back. Ambient checks skip these states entirely.
  */
 function checkWouldStompProgress(): boolean {
   return (
@@ -166,7 +172,9 @@ export function setupAutoUpdater(options: UpdaterOptions): void {
     return; // dev checkout: bridge is inert (no app-update.yml to check)
   }
 
-  autoUpdater.autoDownload = false;
+  // Download as soon as a check finds a newer version; the renderer never has
+  // to ask (the 'vicoa:update-download' IPC below is kept for the bridge only).
+  autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
   autoUpdater.on('checking-for-update', () => setStatus({ state: 'checking' }));

--- a/apps/web/components/dashboard/desktop-settings.tsx
+++ b/apps/web/components/dashboard/desktop-settings.tsx
@@ -27,7 +27,6 @@ import { getDesktopConfig, type DesktopRuntimeConfig } from '@/lib/runtime-confi
 import { ThemeSelect } from '@/components/plugins/theme-select';
 import {
   checkForUpdates,
-  downloadUpdate,
   getAppVersion,
   getDesktopUpdatesBridge,
   quitAndInstallUpdate,
@@ -678,7 +677,7 @@ function updateStatusLabel(status: UpdateStatus): string {
     case 'checking':
       return 'Checking for updates…';
     case 'available':
-      return `Version ${status.version} available`;
+      return `Version ${status.version} available — downloading…`;
     case 'downloading':
       return `Downloading… ${status.percent}%`;
     case 'downloaded':
@@ -694,8 +693,9 @@ function updateStatusLabel(status: UpdateStatus): string {
 
 /**
  * Version readout + updater controls. Hidden on plain web (no bridge). The
- * button follows the status: Check → Download → Restart to update; the same
- * flow the sidebar SidebarUpdateCallout offers, surfaced in Settings.
+ * button follows the status: Check → (auto-download, progress shown here) →
+ * Restart to update; the same one-click flow the sidebar SidebarUpdateCallout
+ * offers, surfaced in Settings.
  */
 function UpdatesCard() {
   const status = useDesktopUpdateStatus();
@@ -719,16 +719,7 @@ function UpdatesCard() {
           <span className="text-xs text-muted-foreground">{version ?? '—'}</span>
         </SettingsRow>
         <SettingsRow title="Updates" description={updateStatusLabel(status)}>
-          {status.state === 'available' ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="text-xs"
-              onClick={() => void downloadUpdate()}
-            >
-              Download
-            </Button>
-          ) : status.state === 'downloaded' ? (
+          {status.state === 'downloaded' ? (
             <Button
               variant="outline"
               size="sm"
@@ -739,7 +730,7 @@ function UpdatesCard() {
             </Button>
           ) : status.state === 'downloading' ? (
             <span className="text-xs text-muted-foreground">{status.percent}%</span>
-          ) : (
+          ) : status.state === 'available' ? null : (
             <Button
               variant="outline"
               size="sm"

--- a/apps/web/components/dashboard/sidebar-update-callout.tsx
+++ b/apps/web/components/dashboard/sidebar-update-callout.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { Gift, Loader2, RotateCw, TriangleAlert, X } from 'lucide-react';
+import { Gift, TriangleAlert, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getDesktopAuthBridge } from '@/lib/desktop-auth';
 import {
   bannerViewForStatus,
   checkForUpdates,
-  downloadUpdate,
   quitAndInstallUpdate,
   useDesktopUpdateStatus,
   type UpdateBannerView,
@@ -44,10 +43,11 @@ function openChangelog() {
 
 /**
  * Sidebar callout for the desktop auto-updater, styled after Paseo's sidebar
- * card and mounted just above the account row. Reuses the exact status/logic of
- * the former top-of-window banner (see lib/desktop-updates): detect → Install &
- * Restart → progress → Restart, with a user-triggered error/retry path. Renders
- * nothing on web/SSR (null bridge → idle status) or in non-actionable states.
+ * card and mounted just above the account row. The main process downloads a
+ * newer version on its own, so this only appears once the update is ready and
+ * asks for a single click: Install & Restart. A user-triggered failure (the
+ * install itself, or a retry check) shows an error/retry card. Renders nothing
+ * on web/SSR (null bridge → idle status) or in non-actionable states.
  */
 export function SidebarUpdateCallout() {
   const status = useDesktopUpdateStatus();
@@ -58,30 +58,27 @@ export function SidebarUpdateCallout() {
   if (!view) return null;
 
   const handleDismiss = () => {
-    // A failed check hides by clearing the user-acted flag; available/downloaded
-    // snooze this exact version for the session (a newer one re-shows).
+    // A failed action hides by clearing the user-acted flag; a ready update
+    // snoozes this exact version for the session (a newer one re-shows).
     if (view.kind === 'error') {
       setUserActed(false);
       return;
     }
-    if (status.state === 'available' || status.state === 'downloaded') {
-      setDismissedVersion(status.version);
-    }
+    setDismissedVersion(view.version);
   };
 
-  const startDownload = () => {
+  const install = () => {
     setUserActed(true);
-    void downloadUpdate();
+    void quitAndInstallUpdate();
   };
 
   const retry = () => {
+    // Re-check; main auto-downloads again on a hit.
     setUserActed(true);
     void checkForUpdates();
   };
 
   const isError = view.kind === 'error';
-  const dismissible = view.kind !== 'downloading';
-  const descriptionLines = descriptionLinesFor(view);
 
   return (
     <div
@@ -94,95 +91,45 @@ export function SidebarUpdateCallout() {
     >
       <div className="flex items-start gap-2">
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <CalloutIcon kind={view.kind} />
-          <span className="truncate text-xs text-foreground">{titleFor(view)}</span>
-        </div>
-        {dismissible && (
-          <button
-            type="button"
-            aria-label="Dismiss"
-            onClick={handleDismiss}
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
-          >
-            <X className="h-3 w-3" />
-          </button>
-        )}
-      </div>
-
-      {descriptionLines.length > 0 && (
-        <div className="flex flex-col gap-1">
-          {descriptionLines.map((line) => (
-            <p key={line} className="text-[11px] leading-relaxed text-muted-foreground">
-              {line}
-            </p>
-          ))}
-        </div>
-      )}
-
-      {view.kind === 'downloading' && (
-        <div className="flex items-center gap-2">
-          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-foreground/15">
-            <div
-              className="h-full rounded-full bg-foreground transition-[width] duration-300"
-              style={{ width: `${view.percent}%` }}
-            />
-          </div>
-          <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-            {Math.round(view.percent)}%
+          {isError ? (
+            <TriangleAlert className="h-3.5 w-3.5 shrink-0 text-warning" />
+          ) : (
+            <Gift className="h-3.5 w-3.5 shrink-0 text-foreground" />
+          )}
+          <span className="truncate text-xs text-foreground">
+            {isError ? 'Update failed' : 'Update available'}
           </span>
         </div>
-      )}
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={handleDismiss}
+          className="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 hover:text-foreground"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
 
-      {view.kind === 'available' && (
-        <CalloutActions primaryLabel="Install & Restart" onPrimary={startDownload} />
+      <div className="flex flex-col gap-1">
+        {descriptionLinesFor(view).map((line) => (
+          <p key={line} className="text-[11px] leading-relaxed text-muted-foreground">
+            {line}
+          </p>
+        ))}
+      </div>
+
+      {isError ? (
+        <CalloutActions primaryLabel="Retry" onPrimary={retry} />
+      ) : (
+        <CalloutActions primaryLabel="Install & Restart" onPrimary={install} />
       )}
-      {view.kind === 'downloaded' && (
-        <CalloutActions primaryLabel="Restart" onPrimary={() => void quitAndInstallUpdate()} />
-      )}
-      {view.kind === 'error' && <CalloutActions primaryLabel="Retry" onPrimary={retry} />}
     </div>
   );
 }
 
-function CalloutIcon({ kind }: { kind: UpdateBannerView['kind'] }) {
-  const className = 'h-3.5 w-3.5 shrink-0';
-  switch (kind) {
-    case 'downloading':
-      return <Loader2 className={cn(className, 'animate-spin text-muted-foreground')} />;
-    case 'downloaded':
-      return <RotateCw className={cn(className, 'text-foreground')} />;
-    case 'error':
-      return <TriangleAlert className={cn(className, 'text-warning')} />;
-    default:
-      return <Gift className={cn(className, 'text-foreground')} />;
-  }
-}
-
-function titleFor(view: UpdateBannerView): string {
-  switch (view.kind) {
-    case 'downloading':
-      return 'Downloading update';
-    case 'downloaded':
-      return 'Update ready';
-    case 'error':
-      return 'Update failed';
-    default:
-      return 'Update available';
-  }
-}
-
 function descriptionLinesFor(view: UpdateBannerView): string[] {
-  switch (view.kind) {
-    case 'downloading':
-      // Progress is conveyed by the bar + percentage, not prose.
-      return [];
-    case 'downloaded':
-      return [`${formatVersion(view.version)} is ready to install.`, UPGRADE_WARNING];
-    case 'error':
-      return [simplifyErrorMessage(view.message)];
-    default:
-      return [`${formatVersion(view.version)} is ready to install.`, UPGRADE_WARNING];
-  }
+  if (view.kind === 'error') return [simplifyErrorMessage(view.message)];
+  return [`${formatVersion(view.version)} is ready to install.`, UPGRADE_WARNING];
 }
 
 /** What's New (bordered secondary) + the state's primary action, two equal columns. */

--- a/apps/web/lib/desktop-updates.test.ts
+++ b/apps/web/lib/desktop-updates.test.ts
@@ -13,36 +13,29 @@ describe('bannerViewForStatus', () => {
     }
   });
 
-  it('surfaces an available update', () => {
-    expect(bannerViewForStatus({ state: 'available', version: '1.2.0' }, null, false)).toEqual({
-      kind: 'available',
-      version: '1.2.0',
-    });
-  });
-
-  it('hides an available update once that version is dismissed', () => {
-    expect(bannerViewForStatus({ state: 'available', version: '1.2.0' }, '1.2.0', false)).toBeNull();
-  });
-
-  it('re-shows when a newer version arrives after a dismissal', () => {
-    expect(bannerViewForStatus({ state: 'available', version: '1.3.0' }, '1.2.0', false)).toEqual({
-      kind: 'available',
-      version: '1.3.0',
-    });
-  });
-
-  it('shows download progress and clamps is not needed here (main clamps)', () => {
+  it('stays hidden while main auto-downloads (available / downloading)', () => {
+    expect(bannerViewForStatus({ state: 'available', version: '1.2.0' }, null, false)).toBeNull();
     expect(
       bannerViewForStatus({ state: 'downloading', percent: 42, version: '1.2.0' }, null, false),
-    ).toEqual({ kind: 'downloading', percent: 42 });
+    ).toBeNull();
   });
 
-  it('shows a downloaded update, dismissible per version', () => {
+  it('surfaces a downloaded update as the one-click install card', () => {
     expect(bannerViewForStatus({ state: 'downloaded', version: '1.2.0' }, null, false)).toEqual({
       kind: 'downloaded',
       version: '1.2.0',
     });
+  });
+
+  it('hides a downloaded update once that version is dismissed', () => {
     expect(bannerViewForStatus({ state: 'downloaded', version: '1.2.0' }, '1.2.0', false)).toBeNull();
+  });
+
+  it('re-shows when a newer version arrives after a dismissal', () => {
+    expect(bannerViewForStatus({ state: 'downloaded', version: '1.3.0' }, '1.2.0', false)).toEqual({
+      kind: 'downloaded',
+      version: '1.3.0',
+    });
   });
 
   it('only surfaces errors the user triggered (never background checks)', () => {

--- a/apps/web/lib/desktop-updates.ts
+++ b/apps/web/lib/desktop-updates.ts
@@ -1,11 +1,12 @@
 /**
  * Desktop auto-update — renderer side of the preload bridge (src/updater.ts).
  *
- * The Electron main process owns electron-updater; this module mirrors its
+ * The Electron main process owns electron-updater and downloads a newer
+ * version on its own as soon as a check finds one; this module mirrors its
  * status over `window.vicoaDesktopUpdates` and exposes:
  *   - useDesktopUpdateStatus()  — live status via useSyncExternalStore
- *   - check / download / quitAndInstall / getAppVersion action wrappers
- *   - bannerViewForStatus()     — pure derivation of what the banner shows
+ *   - check / quitAndInstall / getAppVersion action wrappers
+ *   - bannerViewForStatus()     — pure derivation of what the callout shows
  *
  * Null bridge on plain web / SSR — every consumer no-ops there.
  */
@@ -100,14 +101,6 @@ export async function checkForUpdates(): Promise<UpdateStatus | null> {
   }
 }
 
-export async function downloadUpdate(): Promise<void> {
-  try {
-    await getDesktopUpdatesBridge()?.download();
-  } catch {
-    // errors surface as a status push; the caller shows the banner/error text
-  }
-}
-
 export async function quitAndInstallUpdate(): Promise<void> {
   await getDesktopUpdatesBridge()?.quitAndInstall();
 }
@@ -127,20 +120,20 @@ export async function getAppVersion(): Promise<string | null> {
 // ---------------------------------------------------------------------------
 
 export type UpdateBannerView =
-  | { kind: 'available'; version: string }
-  | { kind: 'downloading'; percent: number }
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
 /**
- * What the top-of-window banner should show, or null when it stays hidden.
+ * What the sidebar callout should show, or null when it stays hidden.
  *
- * - `checking` / `not-available` / `idle` never surface a banner — that
- *   feedback lives in Settings; the banner is for actionable states only.
- * - `available` / `downloaded` hide once the user dismisses that exact version
- *   (a newer version re-shows).
+ * - `idle` / `checking` / `not-available` never surface — that feedback lives
+ *   in Settings; the callout is for actionable states only.
+ * - `available` / `downloading` stay hidden too: main auto-downloads, so there
+ *   is nothing to click until the update is ready (progress is in Settings).
+ * - `downloaded` hides once the user dismisses that exact version (a newer
+ *   version re-shows).
  * - `error` only shows when the user kicked off the action themselves
- *   (`userActed`), so a failed background check never nags.
+ *   (`userActed`), so a failed background check/download never nags.
  */
 export function bannerViewForStatus(
   status: UpdateStatus,
@@ -148,12 +141,6 @@ export function bannerViewForStatus(
   userActed: boolean,
 ): UpdateBannerView | null {
   switch (status.state) {
-    case 'available':
-      return status.version === dismissedVersion
-        ? null
-        : { kind: 'available', version: status.version };
-    case 'downloading':
-      return { kind: 'downloading', percent: status.percent };
     case 'downloaded':
       return status.version === dismissedVersion
         ? null


### PR DESCRIPTION
## What

The desktop auto-updater used to need two clicks: the sidebar callout appeared on *detect* ("Install & Restart" → actually just started the download), then reappeared on *downloaded* ("Restart"). Now the main process downloads a newer version on its own the moment a check finds one, and the callout only appears once the update is ready, with a single **Install & Restart** action.

## Changes

- **`apps/desktop/src/updater.ts`** — `autoUpdater.autoDownload = true`. `available` becomes a transient state; `autoInstallOnAppQuit` (already on) means a normal quit after the download also applies it. The `vicoa:update-download` IPC + preload `download()` are left in place as bridge contract, unused.
- **`apps/web/lib/desktop-updates.ts`** — `bannerViewForStatus` hides `available` / `downloading` (nothing to click; progress is in Settings) and returns only `downloaded` / user-triggered `error`. Dropped the unused `downloadUpdate` wrapper.
- **`apps/web/components/dashboard/sidebar-update-callout.tsx`** — two states instead of four. Clicking Install now sets `userActed`, so a failed `quitAndInstall` (unsigned build, read-only volume) shows the error/Retry card — the old Restart button never did, so install failures were silent.
- **`apps/web/components/dashboard/desktop-settings.tsx`** — Updates row: no Download button; `available` reads "Version X available — downloading…", `downloading` shows %, `downloaded` shows Restart to update.
- Tests updated (`desktop-updates.test.ts`, 6 cases).

## Verification

- `vitest run lib/desktop-updates.test.ts` — 6 passed
- `apps/web` `pnpm lint` (tsc + theme-color check) — exit 0
- `apps/desktop` `tsc --noEmit` — exit 0
- Manual: packaged a Developer-ID-signed local build at v0.1.23 (`package:release:local`) against the real `vicoa-ai/vicoa` feed to walk detect → auto-download → callout → install into the published 0.1.24. (Running it requires quitting the installed app, which hosts the agent sessions — done out of band.)

## Notes

- Needs a desktop release to take effect; users already on 0.1.24 get the one-step flow on the release *after* this one ships.
- Download is silent in the sidebar (Chrome-style). If a progress hint is wanted, add a `downloading` branch back to `bannerViewForStatus`.