### PR TITLE
Chat: stop bare URLs from swallowing glued punctuation and bold closers

### DIFF
--- a/apps/web/components/ui/message-markdown-utils.test.ts
+++ b/apps/web/components/ui/message-markdown-utils.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from 'vitest';
-import { extractMessageOptions, formatDiffLines } from '@/components/ui/message-markdown-utils';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { describe, expect, test } from 'vitest';
+import { delimitBareUrls, extractMessageOptions, formatDiffLines } from '@/components/ui/message-markdown-utils';
 
 test('merges verbose diff while preserving context lines', () => {
   const input = [
@@ -81,4 +85,99 @@ test('extracts slash-delimited options from message content', () => {
 
   expect(output.content).toBe('Need a choice');
   expect(output.options).toEqual(['Approve', 'Reject']);
+});
+
+describe('delimitBareUrls', () => {
+  test('cuts a bare URL at CJK punctuation and at a bold closer', () => {
+    expect(delimitBareUrls('PR 已开：**https://github.com/vicoa-ai/vicoa/pull/54**（rebase 到最新 main）。')).toBe(
+      'PR 已开：**<https://github.com/vicoa-ai/vicoa/pull/54>**（rebase 到最新 main）。',
+    );
+    // What the agent actually emitted: ASCII punctuation glued on, which GFM
+    // would otherwise keep as part of the URL.
+    expect(delimitBareUrls('PR 已开:**https://github.com/vicoa-ai/vicoa/pull/54**(rebase 到最新 main,5 个文件)。')).toBe(
+      'PR 已开:**<https://github.com/vicoa-ai/vicoa/pull/54>**(rebase 到最新 main,5 个文件)。',
+    );
+    expect(delimitBareUrls('见 https://x.com/a，https://x.com/b。')).toBe('见 <https://x.com/a>，<https://x.com/b>。');
+    expect(delimitBareUrls('（https://x.com/a）')).toBe('（<https://x.com/a>）');
+  });
+
+  test('ends a URL opened by an emphasis run at the matching run', () => {
+    expect(delimitBareUrls('*https://x.com/a*, ***https://x.com/b***; ~~https://x.com/c~~(old)')).toBe(
+      '*<https://x.com/a>*, ***<https://x.com/b>***; ~~<https://x.com/c>~~(old)',
+    );
+    // A shorter run inside the URL is part of it.
+    expect(delimitBareUrls('**https://x.com/*/a**(b)')).toBe('**<https://x.com/*/a>**(b)');
+    // Not opened by emphasis: `*` stays in the URL, as in GFM.
+    expect(delimitBareUrls('see https://x.com/a**b')).toBe('see <https://x.com/a**b>');
+    // `_` and a lone `~` are URL characters, not delimiters.
+    expect(delimitBareUrls('_https://x.com/a_b_ ~https://x.com/~u~')).toBe('_<https://x.com/a_b>_ ~<https://x.com/~u>~');
+  });
+
+  test('never keeps an unclosed paren', () => {
+    expect(delimitBareUrls('https://x.com/pull/54(rebase to main)。')).toBe('<https://x.com/pull/54>(rebase to main)。');
+    expect(delimitBareUrls('https://x.com/a_(b)(c ok')).toBe('<https://x.com/a_(b)>(c ok');
+    expect(delimitBareUrls('https://x.com/((a)')).toBe('<https://x.com/>((a)');
+  });
+
+  test('keeps non-ASCII letters in a URL', () => {
+    expect(delimitBareUrls('https://ja.wikipedia.org/wiki/佐々木 和 https://zh.wikipedia.org/wiki/中文。')).toBe(
+      '<https://ja.wikipedia.org/wiki/佐々木> 和 <https://zh.wikipedia.org/wiki/中文>。',
+    );
+  });
+
+  test('trims trailing marks the way GFM does', () => {
+    expect(delimitBareUrls('see https://x.com/a.')).toBe('see <https://x.com/a>.');
+    expect(delimitBareUrls('see https://x.com/a).')).toBe('see <https://x.com/a>).');
+    expect(delimitBareUrls('see https://x.com/a_(b) ok')).toBe('see <https://x.com/a_(b)> ok');
+    expect(delimitBareUrls('see https://x.com/(a)) ok')).toBe('see <https://x.com/(a)>) ok');
+    expect(delimitBareUrls('see https://x.com/?a=1&amp; ok')).toBe('see <https://x.com/?a=1>&amp; ok');
+    expect(delimitBareUrls('see https://x.com/?a=1&b=2; ok')).toBe('see <https://x.com/?a=1&b=2>; ok');
+    expect(delimitBareUrls('_https://x.com/a_ ~https://x.com/b~ "https://x.com/c"')).toBe(
+      '_<https://x.com/a>_ ~<https://x.com/b>~ "<https://x.com/c>"',
+    );
+  });
+
+  test('stops at markdown delimiters and table pipes', () => {
+    expect(delimitBareUrls('|https://x.com/a|b|')).toBe('|<https://x.com/a>|b|');
+    expect(delimitBareUrls('https://x.com/a<b>')).toBe('<https://x.com/a><b>');
+    expect(delimitBareUrls('https://x.com/a`b')).toBe('<https://x.com/a>`b');
+  });
+
+  test('leaves code spans alone', () => {
+    expect(delimitBareUrls('a `https://x.com**（y` b https://x.com/c（d）')).toBe(
+      'a `https://x.com**（y` b <https://x.com/c>（d）',
+    );
+    expect(delimitBareUrls('`` a ` https://x.com `` https://y.com')).toBe('`` a ` https://x.com `` <https://y.com>');
+    // An unclosed backtick run is just text.
+    expect(delimitBareUrls('` https://x.com/a')).toBe('` <https://x.com/a>');
+  });
+
+  test('leaves URLs that already have a delimiter alone', () => {
+    expect(delimitBareUrls('<https://x.com/a> and [t](https://x.com/b) and [u](https://x.com/c "t")')).toBe(
+      '<https://x.com/a> and [t](https://x.com/b) and [u](https://x.com/c "t")',
+    );
+    expect(delimitBareUrls('<a href="https://x.com/a">x</a>')).toBe('<a href="https://x.com/a">x</a>');
+  });
+
+  test('leaves what GFM would not link alone', () => {
+    expect(delimitBareUrls('[see https://x.com/a](https://x.com/b) https://x.com/c')).toBe(
+      '[see https://x.com/a](https://x.com/b) <https://x.com/c>',
+    );
+    expect(delimitBareUrls('\\[not a label https://x.com/a')).toBe('\\[not a label <https://x.com/a>');
+    expect(delimitBareUrls('xhttps://x.com/a')).toBe('xhttps://x.com/a');
+    expect(delimitBareUrls('https:// and https://. and https://[::1]/')).toBe('https:// and https://. and https://[::1]/');
+    expect(delimitBareUrls('no links here')).toBe('no links here');
+  });
+
+  test('renders the reported message as a bold link followed by prose', () => {
+    const render = (md: string) =>
+      renderToStaticMarkup(React.createElement(ReactMarkdown, { remarkPlugins: [remarkGfm] }, delimitBareUrls(md)));
+    const link = '<strong><a href="https://github.com/vicoa-ai/vicoa/pull/54">https://github.com/vicoa-ai/vicoa/pull/54</a></strong>';
+    expect(render('PR 已开：**https://github.com/vicoa-ai/vicoa/pull/54**（rebase 到最新 main，5 个文件，lint/tsc/vitest 都过）。')).toBe(
+      `<p>PR 已开：${link}（rebase 到最新 main，5 个文件，lint/tsc/vitest 都过）。</p>`,
+    );
+    expect(render('PR 已开:**https://github.com/vicoa-ai/vicoa/pull/54**(rebase 到最新 main,5 个文件,lint/tsc/vitest 都过)。')).toBe(
+      `<p>PR 已开:${link}(rebase 到最新 main,5 个文件,lint/tsc/vitest 都过)。</p>`,
+    );
+  });
 });

--- a/apps/web/components/ui/message-markdown-utils.ts
+++ b/apps/web/components/ui/message-markdown-utils.ts
@@ -225,3 +225,195 @@ export function extractMessageOptions(content: string): ParsedMessageOptions {
 
   return { content, options: [] };
 }
+
+const URL_SCHEME = /https?:\/\//gi;
+/** Ends a bare URL: whitespace, markdown's own `<`/`>`/backtick, a table `|`,
+ *  or any non-ASCII punctuation or symbol (`（），。：`, `…`, `—`, emoji…). */
+const URL_END = /[\s<>|`]|(?![\x00-\x7f])[\p{P}\p{S}]/u;
+/** GFM's trailing marks: never part of a URL when nothing but marks follow. */
+const URL_TRAIL_MARKS = '!"\'*,.:;?_~]';
+
+/** Split a line into code spans and the prose between them. A backtick run
+ *  with no closing run of the same length is prose, as in CommonMark. */
+function splitCodeSpans(line: string): { text: string; code: boolean }[] {
+  const parts: { text: string; code: boolean }[] = [];
+  let i = 0;
+  let proseStart = 0;
+  while (i < line.length) {
+    if (line[i] !== '`') {
+      i += 1;
+      continue;
+    }
+    let runEnd = i;
+    while (runEnd < line.length && line[runEnd] === '`') runEnd += 1;
+    const size = runEnd - i;
+    let close = -1;
+    for (let j = runEnd; j < line.length; ) {
+      if (line[j] !== '`') {
+        j += 1;
+        continue;
+      }
+      let k = j;
+      while (k < line.length && line[k] === '`') k += 1;
+      if (k - j === size) {
+        close = j;
+        break;
+      }
+      j = k;
+    }
+    if (close === -1) {
+      i = runEnd;
+      continue;
+    }
+    if (i > proseStart) parts.push({ text: line.slice(proseStart, i), code: false });
+    parts.push({ text: line.slice(i, close + size), code: true });
+    i = proseStart = close + size;
+  }
+  if (proseStart < line.length) parts.push({ text: line.slice(proseStart), code: false });
+  return parts;
+}
+
+/** Drop the trailing marks GFM would not count as part of the URL: the
+ *  {@link URL_TRAIL_MARKS}, a `)` with no `(` to balance it, and an `&name;`
+ *  that reads as a character reference. */
+function trimUrlTrail(url: string): string {
+  let end = url.length;
+  while (end > 0) {
+    const ch = url[end - 1];
+    if (ch === ';') {
+      const ref = /&[a-z]+;$/i.exec(url.slice(0, end));
+      end -= ref ? ref[0].length : 1;
+    } else if (URL_TRAIL_MARKS.includes(ch)) {
+      end -= 1;
+    } else if (ch === ')') {
+      const head = url.slice(0, end);
+      const opens = head.split('(').length;
+      const closes = head.split(')').length;
+      if (closes <= opens) break;
+      end -= 1;
+    } else {
+      break;
+    }
+  }
+  return url.slice(0, end);
+}
+
+/** The `*`/`~` run an emphasis or strikethrough would have opened with right
+ *  before `at`, or `''`. A lone `~` is left alone: it's common in URLs
+ *  (`/~user`) and rare as a delimiter. `_` is never treated as one — it is far
+ *  more often part of the URL (`__init__.py`) than emphasis around it. */
+function emphasisOpener(text: string, at: number): string {
+  const ch = text[at - 1];
+  if (ch !== '*' && ch !== '~') return '';
+  let from = at - 1;
+  while (from > 0 && text[from - 1] === ch) from -= 1;
+  const run = text.slice(from, at);
+  return ch === '~' && run.length < 2 ? '' : run;
+}
+
+/** Index of the last `(` with no `)` after it, or `body.length` if every
+ *  paren is closed. */
+function unclosedParen(body: string): number {
+  let cut = body.length;
+  let depth = 0;
+  for (let i = body.length - 1; i >= 0; i -= 1) {
+    if (body[i] === ')') depth += 1;
+    else if (body[i] === '(') {
+      if (depth === 0) cut = i;
+      else depth -= 1;
+    }
+  }
+  return cut;
+}
+
+/** Net unclosed `[` in a run of prose (escaped brackets don't count). */
+function countOpenLabels(prose: string, depth: number): number {
+  let open = depth;
+  for (let i = 0; i < prose.length; i += 1) {
+    if (prose[i] === '\\') {
+      i += 1;
+    } else if (prose[i] === '[') {
+      open += 1;
+    } else if (prose[i] === ']' && open > 0) {
+      open -= 1;
+    }
+  }
+  return open;
+}
+
+/**
+ * Rewrite every bare `http(s)://` URL on one line of markdown as an explicit
+ * `<url>` autolink.
+ *
+ * GFM's autolink literal runs a bare URL up to the next ASCII whitespace or
+ * `<`, only ever forgiving a few *trailing* ASCII marks. CJK prose puts
+ * full-width punctuation straight after a URL, and a bold URL glues its
+ * closing `**` on as well, so `**https://x/pull/54**（rebase …` links the text
+ * `https://x/pull/54**（rebase` and leaves the opening `**` dangling. An
+ * angle-bracketed autolink ends exactly where we say it ends, so the same
+ * source renders as a bold link followed by plain text.
+ *
+ * The URL is cut at {@link URL_END} and trimmed like GFM trims it, plus two
+ * rules GFM lacks, for prose that glues ASCII punctuation on too
+ * (`**https://x/pull/54**(rebase …)`): a URL opened by an emphasis run
+ * (`**`, `*`, `~~`) ends at the matching run, and an unclosed `(` is never part
+ * of it (a closed one still is: `wiki/Foo_(bar)`). Untouched: code spans;
+ * anything GFM wouldn't link either (a URL glued to a preceding letter, inside
+ * an unclosed `[…` label, or with no domain); and URLs that already have a
+ * delimiter — `<…>`, an inline-link destination `](…)`, an HTML attribute
+ * value. Fenced code is the caller's job; indented code blocks are not
+ * detected. `www.` and e-mail literals are left to GFM.
+ */
+export function delimitBareUrls(line: string): string {
+  if (!/https?:\/\//i.test(line)) return line;
+  let out = '';
+  // Unclosed `[` seen so far: links can't nest, and GFM won't autolink inside
+  // a label either, so leave those alone.
+  let openLabels = 0;
+  for (const { text, code } of splitCodeSpans(line)) {
+    if (code) {
+      out += text;
+      continue;
+    }
+    let from = 0;
+    URL_SCHEME.lastIndex = 0;
+    for (let m = URL_SCHEME.exec(text); m; m = URL_SCHEME.exec(text)) {
+      const start = m.index;
+      openLabels = countOpenLabels(text.slice(from, start), openLabels);
+      out += text.slice(from, start);
+      from = start;
+      const before = text.slice(Math.max(0, start - 2), start);
+      const prev = before.slice(-1);
+      const skip =
+        openLabels > 0 ||
+        /[a-z<]/i.test(prev) ||
+        before === '](' ||
+        ((prev === '"' || prev === "'") && before[0] === '=');
+      if (skip) continue;
+
+      let end = start + m[0].length;
+      while (end < text.length) {
+        const ch = String.fromCodePoint(text.codePointAt(end) as number);
+        if (URL_END.test(ch)) break;
+        end += ch.length;
+      }
+      let body = text.slice(start + m[0].length, end);
+      const opener = emphasisOpener(text, start);
+      if (opener) {
+        const close = body.indexOf(opener);
+        if (close !== -1) body = body.slice(0, close);
+      }
+      body = body.slice(0, unclosedParen(body));
+      const url = trimUrlTrail(m[0] + body);
+      // Something GFM would call a domain has to follow the scheme.
+      if (!/^[\p{L}\p{N}]/u.test(url.slice(m[0].length))) continue;
+
+      out += `<${url}>`;
+      from = start + url.length;
+      URL_SCHEME.lastIndex = from;
+    }
+    openLabels = countOpenLabels(text.slice(from), openLabels);
+    out += text.slice(from);
+  }
+  return out;
+}

--- a/apps/web/components/ui/message-markdown.tsx
+++ b/apps/web/components/ui/message-markdown.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
 import 'highlight.js/styles/atom-one-dark.css';
-import { diffLineBackgroundClass, formatDiffLines, formatTaskNotifications, normalizeCommandOutput } from '@/components/ui/message-markdown-utils';
+import { delimitBareUrls, diffLineBackgroundClass, formatDiffLines, formatTaskNotifications, normalizeCommandOutput } from '@/components/ui/message-markdown-utils';
 import { makeFindHighlightPlugin } from '@/lib/find-highlight';
 import { messageUrlTransform, parseMessageLink } from '@/lib/message-links';
 import { useFileLinks } from '@/components/dashboard/file-link-context';
@@ -97,7 +97,9 @@ function MessageMarkdownImpl({ children, agentType, highlightQuery }: MessageMar
           continue;
         }
 
-        output.push(transformTodoLine(line));
+        // Bare URLs get an explicit `<…>` delimiter so CJK punctuation (or a
+        // bold URL's closing `**`) glued to the end isn't linked along with it.
+        output.push(transformTodoLine(delimitBareUrls(line)));
         continue;
       }
 


### PR DESCRIPTION
## Problem

An agent message like

```
PR 已开:**https://github.com/vicoa-ai/vicoa/pull/54**(rebase 到最新 main,5 个文件,lint/tsc/vitest 都过)。
```

rendered with `…/pull/54**(rebase` as the link and a literal `**` left dangling in front of it. Full-width punctuation (`**…**（rebase`) hit the same thing.

GFM's *autolink literal* runs a bare URL up to the next ASCII whitespace or `<`, forgiving only a few *trailing* ASCII marks. CJK prose glues punctuation straight onto the URL, and a bold URL glues its closing `**` on as well — both end up inside the link. Emphasis can't "win" here: links bind more tightly than emphasis in CommonMark, and `**` swallowed into a link token never becomes a delimiter run at all. The only fix is to end the URL token in the right place.

## Fix

`preprocessContent` (the existing per-line pass, prose branch only) now rewrites every bare `http(s)://` URL as an explicit `<url>` autolink, whose end is unambiguous — `**<https://…/54>**(rebase …` renders as a bold link followed by plain text. New `delimitBareUrls` in `message-markdown-utils.ts`:

- cuts the URL at whitespace, `<`/`>`, `|`, backtick, or any non-ASCII punctuation/symbol (`（），。：`, `…`, `—`, emoji); non-ASCII *letters* stay in (`…/wiki/佐々木`)
- trims trailing marks the way GFM does (`!"'*,.:;?_~]`, an unbalanced `)`, an `&amp;`-style tail)
- two rules GFM lacks: a URL opened by an emphasis run (`**`, `*`, `~~`) ends at the matching run; an unclosed `(` is never part of a URL (a closed pair still is: `wiki/Foo_(bar)`). `_` and a lone `~` are deliberately *not* treated as delimiters — they're common inside URLs (`__init__.py`, `/~user`).
- leaves alone: code spans, fenced code (caller), URLs already delimited (`<…>`, `](…)`, HTML attribute values), and anything GFM wouldn't link either (glued to a preceding letter, inside an unclosed `[` label, no domain)

The rendered text is byte-identical to before apart from the `**` now being consumed as bold; punctuation is never altered.

## Tests

- 8 new unit tests on `delimitBareUrls`, plus an end-to-end render through react-markdown + remark-gfm of both the ASCII and full-width variants of the reported message asserting `<strong><a href="…/pull/54">…</a></strong>(rebase …`.
- `pnpm test` 871/871, `pnpm lint` green.

## Known limits (pre-existing behaviour, unchanged)

- `www.example.com（…）` literals (no scheme, so no `<…>` form) still go through GFM's rule.
- Indented (non-fenced) code blocks aren't detected; a URL inside one would show the `<>`.
- CommonMark itself can't close `**` when a link is followed *directly* by a CJK letter (`**<url>**到…`) — the closer sits between punctuation and a letter, which fails the right-flanking rule. Same for `**[t](url)**到` in every CommonMark renderer.
