### PR TITLE
Desktop: open the window ~3s sooner, quit instantly, stop paying 3s per terminal tab

### DIFF
--- a/apps/desktop/src/check.ts
+++ b/apps/desktop/src/check.ts
@@ -3,6 +3,9 @@
  * No test framework — plain assertions; exits non-zero on failure.
  */
 import * as assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   backoffDelayMs,
   buildDaemonArgs,
@@ -10,7 +13,7 @@ import {
   parseCloudStatus,
   resolveDaemonCommand,
 } from './daemon-manager';
-import { mergePathEntries } from './resolve-path';
+import { mergeDaemonPath, mergePathEntries, readLoginShellPath } from './resolve-path';
 
 // --- resolveDaemonCommand ---------------------------------------------------
 assert.deepEqual(resolveDaemonCommand({}), ['vicoa'], 'default command is vicoa on PATH');
@@ -181,4 +184,67 @@ assert.equal(
   }
 }
 
-console.log('vicoa-desktop check: all assertions passed');
+// --- mergeDaemonPath ----------------------------------------------------------
+{
+  const env = { PATH: '/usr/bin:/bin', HOME: '/nonexistent-home' };
+  const merged = mergeDaemonPath('/opt/tools/bin:/usr/bin', env);
+  assert.ok(merged.path !== null, 'a shell dir the inherited PATH lacks -> override');
+  assert.ok(
+    merged.path?.startsWith('/opt/tools/bin:/usr/bin:/bin'),
+    'shell PATH first, then inherited, then fallbacks',
+  );
+  const noShell = mergeDaemonPath(null, {
+    PATH: '/opt/homebrew/bin:/usr/local/bin:/nonexistent-home/.local/bin:/nonexistent-home/.npm-global/bin:/usr/bin:/bin',
+    HOME: '/nonexistent-home',
+  });
+  assert.equal(noShell.path, null, 'nothing new over the inherited PATH -> leave PATH alone');
+}
+
+// --- readLoginShellPath (async; the probe must never block or reject) ------------
+async function checkLoginShellProbe(): Promise<void> {
+  if (process.platform === 'win32') {
+    return; // POSIX shells only
+  }
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vicoa-check-'));
+  try {
+    // A stand-in "shell" that ignores its -lic flags and prints a PATH: the
+    // probe must hand it back verbatim, trimmed.
+    const fakeShell = path.join(tmp, 'fake-shell');
+    fs.writeFileSync(fakeShell, '#!/bin/sh\nprintf "%s\\n" "/fake/one:/fake/two"\n', { mode: 0o755 });
+    assert.equal(
+      await readLoginShellPath({ SHELL: fakeShell, PATH: '/usr/bin:/bin' }),
+      '/fake/one:/fake/two',
+      'probe returns the shell-printed PATH',
+    );
+
+    // A shell that never answers must resolve null at the 2s deadline, not hang
+    // the boot (this used to be a synchronous spawn on the main thread).
+    const hungShell = path.join(tmp, 'hung-shell');
+    fs.writeFileSync(hungShell, '#!/bin/sh\nsleep 10\n', { mode: 0o755 });
+    const started = Date.now();
+    assert.equal(
+      await readLoginShellPath({ SHELL: hungShell, PATH: '/usr/bin:/bin' }),
+      null,
+      'hung shell -> null',
+    );
+    const elapsed = Date.now() - started;
+    assert.ok(elapsed >= 1_500 && elapsed < 4_000, `hung shell cut off at the deadline (${elapsed}ms)`);
+
+    // A missing shell binary resolves null (spawn ENOENT), never throws.
+    assert.equal(
+      await readLoginShellPath({ SHELL: path.join(tmp, 'nonexistent'), PATH: '/usr/bin:/bin' }),
+      null,
+      'missing shell -> null',
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+void checkLoginShellProbe().then(
+  () => console.log('vicoa-desktop check: all assertions passed'),
+  (err: unknown) => {
+    console.error(err);
+    process.exitCode = 1;
+  },
+);

--- a/apps/desktop/src/cli-link.ts
+++ b/apps/desktop/src/cli-link.ts
@@ -224,8 +224,8 @@ async function registerUnixRuntime(daemonDir: string, version: string): Promise<
 }
 
 /** Is `dir` on the user's *login shell* PATH (not the app's launchd PATH)? */
-function binDirOnPath(dir: string): boolean {
-  const shellPath = readLoginShellPath() ?? process.env.PATH ?? '';
+async function binDirOnPath(dir: string): Promise<boolean> {
+  const shellPath = (await readLoginShellPath()) ?? process.env.PATH ?? '';
   return shellPath.split(path.delimiter).includes(dir);
 }
 
@@ -300,7 +300,7 @@ export async function installCliLink(): Promise<CliLinkResult> {
     await fsp.writeFile(linkPath, unixLauncher(), { mode: 0o755 });
     await fsp.chmod(linkPath, 0o755);
 
-    const onPath = binDirOnPath(binDir());
+    const onPath = await binDirOnPath(binDir());
     return {
       ok: true,
       path: linkPath,

--- a/apps/desktop/src/daemon-manager.ts
+++ b/apps/desktop/src/daemon-manager.ts
@@ -14,7 +14,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import { resolveDaemonPath } from './resolve-path';
+import { resolveDaemonPath, type ResolvedDaemonPath } from './resolve-path';
 
 export type DaemonStatus =
   | 'idle' // never started
@@ -56,6 +56,13 @@ export interface DaemonManagerOptions {
    * a VICOA_DAEMON_CMD override and a bundled binary both still win over it.
    */
   managedDaemonPath?: string | null;
+  /**
+   * An already-started login-shell PATH resolution (resolve-path.ts). The shell
+   * probe takes ~1s+ on a real profile, so the boot path kicks it off first thing
+   * and lets it overlap the renderer-server start; the first spawn awaits it.
+   * Absent → resolved lazily on the first spawn.
+   */
+  pathResolution?: Promise<ResolvedDaemonPath>;
   env?: NodeJS.ProcessEnv;
   log?: (line: string) => void;
 }
@@ -247,9 +254,10 @@ export class DaemonManager {
   private child: ChildProcess | null = null;
   private status: DaemonStatus = 'idle';
   private localOnly = true;
-  /** Login-shell PATH for the daemon child; resolved once, lazily, then cached. */
+  /** Login-shell PATH for the daemon child; resolved once (async), then cached. */
   private daemonPath: string | null = null;
   private daemonPathResolved = false;
+  private pathResolution: Promise<ResolvedDaemonPath> | null;
   private cloudStatus: CloudStatus | undefined;
   private cloudPollTimer: NodeJS.Timeout | null = null;
   private lastError: string | undefined;
@@ -269,6 +277,7 @@ export class DaemonManager {
     this.origin = options.origin;
     this.bundledDaemonPath = options.bundledDaemonPath ?? null;
     this.managedDaemonPath = options.managedDaemonPath ?? null;
+    this.pathResolution = options.pathResolution ?? null;
     this.baseEnv = options.env ?? process.env;
     this.log = options.log ?? ((line) => console.log(`[daemon] ${line}`));
   }
@@ -290,15 +299,19 @@ export class DaemonManager {
   /**
    * Resolve (once) the login-shell PATH to hand the daemon child so it can find
    * user-installed `claude` / `codex` even when launched from Finder with a
-   * minimal launchd PATH. Cached; safe across restarts. Never throws.
+   * minimal launchd PATH. Cached; safe across restarts. Never throws. Awaits
+   * the boot-time probe when one was handed in, so the main thread never
+   * blocks on the shell.
    */
-  private ensureDaemonPath(): void {
+  private async ensureDaemonPath(): Promise<void> {
     if (this.daemonPathResolved) {
       return;
     }
-    this.daemonPathResolved = true;
+    if (this.pathResolution === null) {
+      this.pathResolution = resolveDaemonPath(this.baseEnv);
+    }
     try {
-      const resolved = resolveDaemonPath(this.baseEnv);
+      const resolved = await this.pathResolution;
       this.daemonPath = resolved.path;
       this.log(
         `resolved PATH (${resolved.entryCount} entries; ` +
@@ -308,6 +321,7 @@ export class DaemonManager {
       this.daemonPath = null;
       this.log(`PATH resolution failed, using inherited PATH: ${errorMessage(err)}`);
     }
+    this.daemonPathResolved = true;
   }
 
   get isLocalOnly(): boolean {
@@ -362,7 +376,13 @@ export class DaemonManager {
     const generation = this.generation;
     this.clearCloudPoll();
     this.cloudStatus = undefined;
-    this.ensureDaemonPath();
+    // 'starting' before the (possibly still running) PATH probe so the tray
+    // reflects the boot as soon as it is requested, not once the shell answers.
+    this.setState('starting');
+    await this.ensureDaemonPath();
+    if (generation !== this.generation) {
+      return false; // stopped/restarted while the PATH probe was still running
+    }
 
     const [cmd, ...leadingArgs] = this.resolvedCommand();
     if (cmd === undefined) {
@@ -382,7 +402,6 @@ export class DaemonManager {
       }),
     ];
     this.log(`spawning: ${cmd} ${args.join(' ')} (local-only=${this.localOnly})`);
-    this.setState('starting');
 
     let child: ChildProcess;
     try {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -44,6 +44,7 @@ import {
   type DesktopConfig,
 } from './config';
 import { DaemonManager, daemonCommandAvailable, type DaemonState } from './daemon-manager';
+import { resolveDaemonPath } from './resolve-path';
 import { startRendererServer, type RendererServer } from './renderer-server';
 import { createMainWindow } from './window';
 import { createTray, destroyTray, updateTrayDaemonState } from './tray';
@@ -223,6 +224,9 @@ function desktopConfig(): DesktopConfig {
 }
 
 function focusOrCreateWindow(): void {
+  if (isQuitting) {
+    return; // windows are hidden for teardown; a dock/tray click must not resurface them
+  }
   if (mainWindow !== null && !mainWindow.isDestroyed()) {
     if (mainWindow.isMinimized()) {
       mainWindow.restore();
@@ -641,8 +645,9 @@ function warmManagedDaemon(): void {
 function onDaemonState(state: DaemonState): void {
   updateTrayDaemonState(state);
   if (state.status === 'running') {
-    // Window creation is gated on the first healthy daemon; also covers
-    // supervisor recoveries when the window was never created.
+    // The window normally opens before the daemon is healthy (bootstrap); this
+    // covers the paths that don't — a tray "Restart daemon" or supervisor
+    // recovery when the window was never created. Idempotent.
     ensureMainWindow();
   }
   if (state.status === 'failed') {
@@ -1046,6 +1051,12 @@ function setDockIcon(): void {
 // Bootstrap
 // ---------------------------------------------------------------------------
 async function bootstrap(): Promise<void> {
+  // Probe the login shell for the daemon's PATH right away. Sourcing a real
+  // zsh/bash profile takes ~1-1.5s; started here it overlaps Electron's own
+  // init and the renderer-server boot instead of sitting between "renderer
+  // ready" and "daemon spawned" (it used to be a synchronous spawn there,
+  // stalling the main thread for that long). DaemonManager awaits it on spawn.
+  const daemonPathResolution = resolveDaemonPath(process.env);
   await app.whenReady();
   applySelfHostEnv();
   setDockIcon();
@@ -1129,6 +1140,7 @@ async function bootstrap(): Promise<void> {
     origin: new URL(effectiveRendererUrl).origin,
     bundledDaemonPath: isBundled() ? bundledDaemonPath() : null,
     managedDaemonPath: managedDaemonPathForManager(),
+    pathResolution: daemonPathResolution,
   });
   daemonManager.onState(onDaemonState);
 
@@ -1180,14 +1192,16 @@ async function bootstrap(): Promise<void> {
     return;
   }
 
-  const healthy = await daemonManager.start(false);
-  if (healthy) {
-    ensureMainWindow(); // also triggered by onDaemonState('running'); idempotent
-  } else if (isBundled()) {
-    // Packaged app: never leave the user with only a tray icon — show the
-    // window in a degraded state alongside the failure dialog.
-    ensureMainWindow();
-  }
+  // Open the window NOW, before the daemon is up. In cloud mode the dashboard
+  // is entirely cloud-backed (REST + WS go to the backend; see the renderer's
+  // runtime-config.ts) — the local daemon only serves this machine's RPC/pty
+  // side channel, and every consumer of it already tolerates "daemon still
+  // booting" (fetchLocalHealth → null, WsClient reconnect backoff). So the
+  // page load (~1s) overlaps the daemon's cold start (~2s PyInstaller import)
+  // instead of following it, and the first frame lands ~3s earlier. Also
+  // gives a failure dialog a parent window instead of a bare tray icon.
+  ensureMainWindow();
+  await daemonManager.start(false);
   // On failure onDaemonState('failed') has already surfaced the tray status +
   // dialog; the user can retry from either.
 }
@@ -1206,27 +1220,55 @@ app.on('window-all-closed', () => {
 });
 
 /**
+ * Upper bound on quit cleanup. The daemon stop escalates to SIGKILL at 5s and
+ * the renderer server dies on kill(), so a healthy teardown is well inside
+ * this; the deadline only matters when a child ignores its exit and would
+ * otherwise leave a window-less, un-quittable process behind.
+ */
+const QUIT_CLEANUP_DEADLINE_MS = 8_000;
+
+/**
  * Stop the daemon (SIGTERM -> SIGKILL after 5s) and the bundled renderer
  * server, and tear down the tray. Idempotent. Does NOT exit the process —
  * callers decide what happens next: a normal quit exits after this, while an
  * update install hands off to Squirrel via autoUpdater.quitAndInstall so the
  * bundle swap can proceed (see updater.ts onBeforeInstall).
+ *
+ * Perceived quit speed: the windows are hidden FIRST, so the app disappears
+ * the instant the user quits while the children (daemon graceful shutdown:
+ * cloud WS CLOSE round-trip, pty teardown; Next standalone server) wind down
+ * behind it. The two stops are independent, so they run in parallel.
  */
 async function runQuitCleanup(): Promise<void> {
   if (quitCleanupDone) {
     return;
   }
   quitCleanupDone = true;
-  try {
-    await daemonManager?.stop();
-  } catch (err) {
-    console.warn('[main] daemon stop during quit failed:', err);
+  isQuitting = true; // also reached via the updater's onBeforeInstall, ahead of before-quit
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.hide();
+    }
   }
-  try {
-    await rendererServer?.stop();
-  } catch (err) {
-    console.warn('[main] renderer server stop during quit failed:', err);
-  }
+  const stops = Promise.all([
+    daemonManager?.stop().catch((err: unknown) => {
+      console.warn('[main] daemon stop during quit failed:', err);
+    }),
+    rendererServer?.stop().catch((err: unknown) => {
+      console.warn('[main] renderer server stop during quit failed:', err);
+    }),
+  ]);
+  let deadline: NodeJS.Timeout | undefined;
+  await Promise.race([
+    stops,
+    new Promise<void>((resolve) => {
+      deadline = setTimeout(() => {
+        console.warn(`[main] quit cleanup exceeded ${QUIT_CLEANUP_DEADLINE_MS}ms; exiting anyway`);
+        resolve();
+      }, QUIT_CLEANUP_DEADLINE_MS);
+    }),
+  ]);
+  clearTimeout(deadline);
   destroyTray();
 }
 

--- a/apps/desktop/src/resolve-path.ts
+++ b/apps/desktop/src/resolve-path.ts
@@ -13,8 +13,13 @@
  *
  * The resolver is deliberately defensive: a 2s timeout, falls back to the
  * inherited PATH on any error, and never throws.
+ *
+ * It is ASYNC on purpose: sourcing a real zsh/bash profile (nvm, conda, oh-my-
+ * zsh, …) routinely takes 1-1.5s, and a synchronous spawn would block the
+ * Electron main thread for that long — nothing paints, the window can't open.
+ * Callers start it early (boot) so it overlaps the renderer-server start.
  */
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -82,34 +87,62 @@ export function findExecutableOnPath(name: string, pathStr: string): string | nu
 }
 
 /**
- * Probe the user's login shell for its interactive PATH. Returns null on any
- * failure (missing shell, timeout, non-zero exit, empty output). Never throws.
+ * Probe the user's login shell for its interactive PATH. Resolves null on any
+ * failure (missing shell, timeout, empty output). Never rejects.
  *
  * `-lic <cmd>` = login + interactive + run a command: this sources the same
  * rc/profile files the user's terminal does (nvm, asdf, homebrew shellenv, …),
  * which is exactly where user-installed CLIs get onto PATH.
  */
-export function readLoginShellPath(env: NodeJS.ProcessEnv = process.env): string | null {
+export function readLoginShellPath(env: NodeJS.ProcessEnv = process.env): Promise<string | null> {
   const shell = env.SHELL !== undefined && env.SHELL.length > 0 ? env.SHELL : '/bin/zsh';
-  try {
-    const result = spawnSync(
-      shell,
-      ['-lic', 'command -v claude >/dev/null 2>&1; printf "%s" "$PATH"'],
-      {
-        encoding: 'utf8',
-        timeout: SHELL_RESOLVE_TIMEOUT_MS,
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(shell, ['-lic', 'command -v claude >/dev/null 2>&1; printf "%s" "$PATH"'], {
         env,
         stdio: ['ignore', 'pipe', 'ignore'],
-      },
-    );
-    if (result.error !== undefined && result.error !== null) {
-      return null;
+        // Own process group, so the timeout can take out anything the profile
+        // itself spawned (an `nvm` init, a slow `brew shellenv`, …) — killing
+        // just the shell would leave those holding our stdout pipe open.
+        detached: true,
+      });
+    } catch {
+      resolve(null);
+      return;
     }
-    const out = typeof result.stdout === 'string' ? result.stdout.trim() : '';
-    return out.length > 0 ? out : null;
-  } catch {
-    return null;
-  }
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const finish = (value: string | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    // A profile that hangs (prompting, network) must not gate the daemon spawn.
+    const timer = setTimeout(() => {
+      try {
+        if (child.pid !== undefined) {
+          process.kill(-child.pid, 'SIGKILL'); // the whole group (see `detached`)
+        } else {
+          child.kill('SIGKILL');
+        }
+      } catch {
+        // already gone
+      }
+      finish(null);
+    }, SHELL_RESOLVE_TIMEOUT_MS);
+    child.stdout?.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.on('error', () => finish(null));
+    child.on('close', () => {
+      // Exit status is deliberately ignored: a noisy rc file can leave `$?`
+      // non-zero while the PATH it printed is perfectly good.
+      const out = Buffer.concat(chunks).toString('utf8').trim();
+      finish(out.length > 0 ? out : null);
+    });
+  });
 }
 
 export interface ResolvedDaemonPath {
@@ -130,17 +163,26 @@ export interface ResolvedDaemonPath {
  *
  * `path` is only non-null when the merge actually adds a dir the inherited PATH
  * lacked — we never override PATH just to reorder it, and never blank it out.
- * Defensive: never throws; falls back to leaving PATH alone on any error.
+ * Defensive: never rejects; falls back to leaving PATH alone on any error.
  */
-export function resolveDaemonPath(env: NodeJS.ProcessEnv = process.env): ResolvedDaemonPath {
-  const currentPath = env.PATH ?? '';
+export async function resolveDaemonPath(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ResolvedDaemonPath> {
   let shellPath: string | null = null;
   try {
-    shellPath = readLoginShellPath(env);
+    shellPath = await readLoginShellPath(env);
   } catch {
     shellPath = null;
   }
+  return mergeDaemonPath(shellPath, env);
+}
 
+/** The pure merge step of `resolveDaemonPath`, split out so it is unit-testable. */
+export function mergeDaemonPath(
+  shellPath: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedDaemonPath {
+  const currentPath = env.PATH ?? '';
   const merged = mergePathEntries([shellPath, currentPath, ...fallbackPathDirs(env)]);
   const claudePath = findExecutableOnPath('claude', merged.length > 0 ? merged : currentPath);
 

--- a/apps/web/components/plugins/plugin-catalog-sync.tsx
+++ b/apps/web/components/plugins/plugin-catalog-sync.tsx
@@ -10,6 +10,12 @@
  * on desktop, the cloud relay for a remote machine — so Tier 1 plugins light up
  * on plain web too, for any machine whose daemon is connected.
  *
+ * Desktop cold start: the window now opens before the local daemon has booted
+ * and registered, so the first tick usually cannot learn this machine's id yet.
+ * Rather than leaving the local plugins dark until the next 60s tick, a short
+ * backoff (1s → 16s) retries just the local lookup and syncs that one machine
+ * as soon as the daemon answers.
+ *
  * Renders nothing.
  */
 
@@ -23,6 +29,8 @@ import { pluginRegistry } from '@/lib/plugins/registry';
 import { mapCatalog, type CatalogWire } from '@/lib/plugins/catalog';
 
 const POLL_MS = 60_000;
+/** Local-daemon boot retry schedule (ms); cumulative reach ≈ 32s, past any sane cold start. */
+const LOCAL_BOOT_RETRY_MS = [1_000, 1_000, 2_000, 4_000, 8_000, 16_000];
 
 export function PluginCatalogSync() {
   const { api } = useAgentDashboard();
@@ -30,6 +38,38 @@ export function PluginCatalogSync() {
 
   useEffect(() => {
     let cancelled = false;
+    let localRetryTimer: number | null = null;
+
+    const syncMachine = async (machineId: string) => {
+      try {
+        const res = (await getRpcClient(machineId).callRpc(machineId, 'plugin-catalog', {
+          etag: etags.current[machineId],
+        })) as CatalogWire;
+        if (cancelled) return;
+        if (res.not_modified) return;
+        if (res.etag) etags.current[machineId] = res.etag;
+        pluginRegistry.setMachinePlugins(machineId, mapCatalog(machineId, res));
+      } catch {
+        // Machine unreachable or daemon too old to know the RPC; keep prior
+        // state rather than dropping the plugins mid-session.
+      }
+    };
+
+    // The local daemon wasn't up for the main tick: poll for its id on a short
+    // backoff and sync this machine alone the moment it appears.
+    const scheduleLocalRetry = (attempt: number) => {
+      if (cancelled || attempt >= LOCAL_BOOT_RETRY_MS.length) return;
+      localRetryTimer = window.setTimeout(async () => {
+        localRetryTimer = null;
+        const localId = await ensureLocalMachineId();
+        if (cancelled) return;
+        if (!localId) {
+          scheduleLocalRetry(attempt + 1);
+          return;
+        }
+        await syncMachine(localId);
+      }, LOCAL_BOOT_RETRY_MS[attempt]);
+    };
 
     const tick = async () => {
       // Target set = online cloud machines + this desktop's local machine. The
@@ -50,6 +90,7 @@ export function PluginCatalogSync() {
       if (getDesktopConfig()) {
         const localId = await ensureLocalMachineId();
         if (localId) targets.add(localId);
+        else if (localRetryTimer === null) scheduleLocalRetry(0);
       }
       if (cancelled) return;
 
@@ -61,22 +102,7 @@ export function PluginCatalogSync() {
         }
       }
 
-      await Promise.all(
-        [...targets].map(async (machineId) => {
-          try {
-            const res = (await getRpcClient(machineId).callRpc(machineId, 'plugin-catalog', {
-              etag: etags.current[machineId],
-            })) as CatalogWire;
-            if (cancelled) return;
-            if (res.not_modified) return;
-            if (res.etag) etags.current[machineId] = res.etag;
-            pluginRegistry.setMachinePlugins(machineId, mapCatalog(machineId, res));
-          } catch {
-            // Machine unreachable or daemon too old to know the RPC; keep prior
-            // state rather than dropping the plugins mid-session.
-          }
-        }),
-      );
+      await Promise.all([...targets].map(syncMachine));
     };
 
     void tick();
@@ -84,6 +110,7 @@ export function PluginCatalogSync() {
     return () => {
       cancelled = true;
       window.clearInterval(id);
+      if (localRetryTimer !== null) window.clearTimeout(localRetryTimer);
     };
   }, [api]);
 

--- a/backend/src/vicoa/terminal/pty_manager.py
+++ b/backend/src/vicoa/terminal/pty_manager.py
@@ -307,8 +307,22 @@ class PTYManager:
         # Terminate child process first
         if self.child_pid is not None:
             try:
+                if kill_group:
+                    # The desktop tab's child is an interactive login shell, and
+                    # interactive zsh/bash IGNORE SIGTERM — alone it would sit
+                    # out the whole grace period below before SIGKILL lands, per
+                    # tab, on every app quit. SIGHUP is what a terminal emulator
+                    # sends when its window closes: the shell exits at once and
+                    # re-sends HUP to its jobs. (Closing the master fd below
+                    # would HUP the foreground group anyway — this just does it
+                    # first.) SIGTERM still follows for a non-shell command that
+                    # only handles TERM.
+                    self._signal_child(signal.SIGHUP, kill_group)
                 self._signal_child(signal.SIGTERM, kill_group)
-                self.log_func(f"[INFO] Sent SIGTERM to child process {self.child_pid}")
+                self.log_func(
+                    f"[INFO] Sent {'SIGHUP+' if kill_group else ''}SIGTERM to "
+                    f"child process {self.child_pid}"
+                )
             except Exception as e:
                 self.log_func(f"[WARNING] Error terminating child: {e}")
 

--- a/backend/src/vicoa/terminal/service.py
+++ b/backend/src/vicoa/terminal/service.py
@@ -277,7 +277,24 @@ class TerminalService:
             sessions = list(self._sessions.values())
         for session in sessions:
             session.stop_requested.set()
-            self._close_session(session, context="shutdown")
+        # Close the tabs concurrently: each close() waits up to 3s for a
+        # stubborn foreground job before SIGKILL, and a quit with several tabs
+        # open must pay that once, not once per tab. _close_session is already
+        # serialized per session, so parallelism across sessions is safe.
+        closers = [
+            threading.Thread(
+                target=self._close_session,
+                args=(session,),
+                kwargs={"context": "shutdown"},
+                name=f"vicoa-pty-close-{session.pty_id[:8]}",
+                daemon=True,
+            )
+            for session in sessions
+        ]
+        for closer in closers:
+            closer.start()
+        for closer in closers:
+            closer.join(timeout=6.0)
         for session in sessions:
             if session.reader is not None:
                 session.reader.join(timeout=2.0)

--- a/backend/tests/test_terminal_service.py
+++ b/backend/tests/test_terminal_service.py
@@ -153,6 +153,66 @@ def test_kill_reaps_sighup_ignoring_child(
         pytest.fail(f"SIGHUP-ignoring child {child_pid} survived the terminal kill")
 
 
+def test_kill_interactive_shell_is_fast(
+    service: TerminalService, collector: _Collector, tmp_path: Path
+) -> None:
+    """The desktop tab runs an interactive login shell, and interactive zsh/bash
+    IGNORE SIGTERM — a TERM-only close sat out the full 3s grace before SIGKILL
+    on every tab at app quit. close(kill_group=True) now leads with SIGHUP (what
+    a terminal emulator sends when its window closes), so the shell exits at
+    once. Modelled with a child that ignores TERM but takes the default HUP."""
+    pty_id = service.spawn(
+        str(tmp_path),
+        80,
+        24,
+        command=[
+            "/bin/sh",
+            "-c",
+            "trap '' TERM; echo READY; while :; do sleep 1; done",
+        ],
+    )
+    assert collector.wait_for_output(b"READY")
+
+    started = time.monotonic()
+    service.kill(pty_id)
+    assert collector.exit_event.wait(timeout=10.0)
+    elapsed = time.monotonic() - started
+    assert elapsed < 2.0, (
+        f"TERM-ignoring shell took {elapsed:.1f}s to die (SIGHUP not sent first?)"
+    )
+
+
+def test_shutdown_closes_tabs_concurrently(
+    collector: _Collector, tmp_path: Path
+) -> None:
+    """Tabs whose job shrugs off HUP+TERM each need the 3s grace before SIGKILL;
+    shutdown() must overlap those waits, not stack them per tab."""
+    svc = TerminalService(on_output=collector.on_output, on_exit=collector.on_exit)
+    try:
+        for _ in range(3):
+            svc.spawn(
+                str(tmp_path),
+                80,
+                24,
+                command=[
+                    "/bin/sh",
+                    "-c",
+                    "trap '' HUP TERM; echo UP; while :; do sleep 1; done",
+                ],
+            )
+        assert collector.wait_for_output(b"UP")
+        started = time.monotonic()
+        svc.shutdown()
+        elapsed = time.monotonic() - started
+        # One grace period (3s) + slack, not three of them (9s+).
+        assert elapsed < 6.0, (
+            f"shutdown of 3 stubborn tabs took {elapsed:.1f}s (serial closes?)"
+        )
+        assert svc.live_session_ids() == []
+    finally:
+        svc.shutdown()
+
+
 def test_unleased_session_is_never_reaped(
     service: TerminalService, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What

Startup and shutdown of the desktop app were both bottlenecked by things that weren't obvious from the boot/quit code itself.

### Startup (~6.5s → ~3s to first frame)

- **`resolve-path.ts`** — the login-shell PATH probe (`$SHELL -lic …`) was a `spawnSync` on the Electron main thread, right before the daemon spawn. Measured 1.1–1.6s on a real zsh profile; that was the unexplained 1.2s gap in the boot timeline, and the main thread couldn't paint during it. Now async (own process group, whole group killed on the 2s timeout), started first thing in `bootstrap()` so it overlaps Electron init + the renderer-server start; `DaemonManager` awaits it on spawn (generation-guarded, so a stop/restart mid-probe bails cleanly).
- **`main.ts`** — `ensureMainWindow()` moves ahead of `daemonManager.start()`. The cloud-mode dashboard is entirely cloud-backed (`runtime-config.ts`: REST + WS go to the backend); the local daemon only serves this machine's RPC/pty side channel, and every consumer of it already handles "daemon still booting" (`fetchLocalHealth → null`, `WsClient` reconnect backoff, onboarding polls). The failure dialog also gets a parent window now.
- **`plugin-catalog-sync.tsx`** — the one consumer that did care: on a cold start it couldn't learn this machine's id on the first tick and waited for the 60s poll. Adds a 1/1/2/4/8/16s retry for just the local lookup.

### Shutdown

- **`runQuitCleanup`** hides every window *first*, runs the daemon + renderer-server stops in parallel (they're independent), and bounds the whole thing at 8s (SIGKILL escalation is 5s) so a wedged child can't leave a window-less process. `focusOrCreateWindow` ignores dock/tray clicks while quitting so the hidden window can't resurface mid-teardown. The updater's `onBeforeInstall` path shares all of this.
- **`pty_manager.py` / `service.py`** — the biggest hidden cost. The Terminal tab runs `$SHELL -l`, and **interactive zsh and bash ignore SIGTERM** (verified in a pty), so `close(kill_group=True)` sat out its full 3s grace before SIGKILL — per tab, serially, on every quit. Now leads with SIGHUP (what a terminal emulator sends when its window closes; shells exit immediately and re-HUP their jobs), then SIGTERM, 3s → SIGKILL unchanged. `TerminalService.shutdown` closes tabs concurrently. Only the `kill_group` branch changes; the Claude wrapper's default path is untouched.

### Deliberately not done

- Spawning the daemon in parallel with the renderer server: a renderer start retry can land on a different port while the daemon's allowed origin is fixed at construction → silent 403 on the local socket. ~0.7s isn't worth it.
- Reordering "renderer first, then daemon" on quit: uvicorn 0.46 `Server.shutdown()` closes WS connections itself (`fail_connection(1012)`), so it never waited on the renderer — the hypothesis was wrong.
- Keeping terminal tabs alive across a daemon restart: the PTY master dies with the daemon process (kernel SIGHUPs the shell); needs a separate PTY host. Separate feature.

## Tests

- desktop `pnpm run check`: new cases for `mergeDaemonPath` and the async probe (fake shell returns its PATH; hung shell → `null` at the 2s deadline with the process group killed; missing shell → `null`). `tsc` clean.
- backend `test_terminal_service.py`: `test_kill_interactive_shell_is_fast` and `test_shutdown_closes_tabs_concurrently` — run against the old code they fail at **3.2s** and **9.6s**; with the fix the suite passes (15). `make lint` (ruff + pyright + WS freeze) green.
- web `pnpm lint` green. No component-test harness exists for the retry; left untested.
- Packaged locally (`VICOA_DAEMON_VERSION=local`, daemon frozen from this branch) for a live dogfood run — the daemon side ships with the next CLI release, the shell/renderer side with the next desktop release.
